### PR TITLE
fix: Rename gaming_wine to wine_enabled in example playbooks

### DIFF
--- a/playbooks/laptop_full.yml
+++ b/playbooks/laptop_full.yml
@@ -82,9 +82,11 @@
     downloads_transmission: true
     downloads_qbittorrent: false  # Alternative to Transmission
 
+    # Wine
+    wine_enabled: true
+
     # Gaming
     gaming_enabled: true
-    gaming_wine: true
     gaming_lutris: true
     gaming_retroarch: true
     gaming_playback: true

--- a/playbooks/workstation_full.yml
+++ b/playbooks/workstation_full.yml
@@ -77,9 +77,11 @@
     downloads_transmission: true
     downloads_qbittorrent: false  # Alternative to Transmission
 
+    # Wine
+    wine_enabled: true
+
     # Gaming
     gaming_enabled: true
-    gaming_wine: true
     gaming_lutris: true
     gaming_retroarch: true
     gaming_playback: true


### PR DESCRIPTION
## Summary

- Rename `gaming_wine` to `wine_enabled` in `workstation_full.yml` and `laptop_full.yml`
- Move wine config to its own section before gaming (wine is a standalone role since v1.0.0)

## Test plan

- [ ] CI passes (linting only — no runtime changes)
- [ ] Verify variable name matches `roles/wine/defaults/main.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)