### PR TITLE
feat(shell): Add Oh My Zsh framework support

### DIFF
--- a/roles/shell/README.md
+++ b/roles/shell/README.md
@@ -37,12 +37,36 @@ overrides if needed.
 
 ### Zsh
 
-| Variable                     | Default    | Description                                |
-|------------------------------|------------|--------------------------------------------|
-| `shell_zsh_enabled`          | `true`     | Enable Zsh installation                    |
-| `shell_zsh_plugins`          | `[...]`    | Zsh plugins (completions, autosuggestions) |
-| `shell_zsh_grml_enabled`     | `false`    | Enable grml-zsh-config (Arch ISO defaults) |
-| `shell_zsh_skeleton_enabled` | `false`    | Enable custom .zshrc skeleton deployment   |
+| Variable                 | Default    | Description                                          |
+|--------------------------|------------|------------------------------------------------------|
+| `shell_zsh_enabled`      | `true`     | Enable Zsh installation                              |
+| `shell_zsh_framework`    | `'native'` | Zsh framework: `native` (system packages) or `ohmyzsh` |
+| `shell_zsh_plugins`      | `[...]`    | Zsh plugins (native framework only)                  |
+| `shell_zsh_grml_enabled` | `false`    | Enable grml-zsh-config (native framework only)       |
+
+### Oh My Zsh
+
+Only used when `shell_zsh_framework: 'ohmyzsh'`. Installs Oh My Zsh per-user via git
+clone and deploys a managed `.zshrc`. Requires `git` to be installed.
+
+| Variable                        | Default          | Description                                    |
+|---------------------------------|------------------|------------------------------------------------|
+| `shell_ohmyzsh_theme`           | `'robbyrussell'` | Oh My Zsh theme (set to `''` for Starship)     |
+| `shell_ohmyzsh_plugins`         | `['git']`        | Built-in Oh My Zsh plugins to activate         |
+| `shell_ohmyzsh_custom_plugins`  | `[]`             | Third-party plugins (list of name/repo dicts)  |
+
+Custom plugins example:
+
+```yaml
+shell_ohmyzsh_custom_plugins:
+  - name: 'zsh-autosuggestions'
+    repo: 'https://github.com/zsh-users/zsh-autosuggestions.git'
+  - name: 'zsh-syntax-highlighting'
+    repo: 'https://github.com/zsh-users/zsh-syntax-highlighting.git'
+```
+
+When `shell_starship_enabled` is `true`, the deployed `.zshrc` sets `ZSH_THEME=""`
+and adds Starship init automatically.
 
 ### Fish
 
@@ -79,11 +103,12 @@ overrides if needed.
 
 ## Tags
 
-| Tag             | Description              |
-|-----------------|--------------------------|
-| `shell`         | All shell tasks          |
-| `shell:install` | Package installation     |
-| `shell:users`   | User shell configuration |
+| Tag              | Description                    |
+|------------------|--------------------------------|
+| `shell`          | All shell tasks                |
+| `shell:install`  | Package installation           |
+| `shell:ohmyzsh`  | Oh My Zsh setup and config     |
+| `shell:users`    | User shell configuration       |
 
 ## Example Playbook
 

--- a/roles/shell/defaults/main.yml
+++ b/roles/shell/defaults/main.yml
@@ -26,18 +26,39 @@ shell_user_config_mode: 'managed'
 # Enable Zsh installation
 shell_zsh_enabled: true
 
-# Zsh plugins to install
+# Zsh framework: native (system packages) or ohmyzsh (Oh My Zsh per-user install)
+shell_zsh_framework: 'native'
+
+# Zsh plugins to install (native framework only)
 # Options: autosuggestions, syntax-highlighting, completions, history-substring-search
 shell_zsh_plugins:
   - 'completions'
   - 'autosuggestions'
   - 'syntax-highlighting'
 
-# Enable grml-zsh-config (Arch ISO defaults)
+# Enable grml-zsh-config (native framework only, Arch ISO defaults)
 shell_zsh_grml_enabled: false
 
-# Enable custom .zshrc skeleton deployment
-shell_zsh_skeleton_enabled: false
+#
+# Oh My Zsh (only when shell_zsh_framework == 'ohmyzsh')
+#
+
+# Oh My Zsh theme (set to '' to disable, e.g. when using Starship)
+shell_ohmyzsh_theme: 'robbyrussell'
+
+# Built-in Oh My Zsh plugins to activate
+shell_ohmyzsh_plugins:
+  - 'git'
+
+# Third-party plugins to install via git clone into custom/plugins
+shell_ohmyzsh_custom_plugins: []
+# Example:
+#   - name: 'zsh-autosuggestions'
+#     repo: 'https://github.com/zsh-users/zsh-autosuggestions.git'
+#   - name: 'zsh-syntax-highlighting'
+#     repo: 'https://github.com/zsh-users/zsh-syntax-highlighting.git'
+#   - name: 'zsh-completions'
+#     repo: 'https://github.com/zsh-users/zsh-completions.git'
 
 #
 # Fish

--- a/roles/shell/defaults/main.yml
+++ b/roles/shell/defaults/main.yml
@@ -51,6 +51,7 @@ shell_ohmyzsh_plugins:
   - 'git'
 
 # Third-party plugins to install via git clone into custom/plugins
+# Each entry requires 'name' and 'repo'. Optional 'version' (default: master).
 shell_ohmyzsh_custom_plugins: []
 # Example:
 #   - name: 'zsh-autosuggestions'

--- a/roles/shell/molecule/default/converge.yml
+++ b/roles/shell/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Converge — Native framework
   hosts: all
   gather_facts: true
 
@@ -7,6 +7,7 @@
     shell_enabled: true
     shell_default: 'zsh'
     shell_zsh_enabled: true
+    shell_zsh_framework: 'native'
     shell_zsh_plugins:
       - 'completions'
     shell_fish_enabled: false
@@ -16,6 +17,35 @@
     shell_users: []
 
   tasks:
-    - name: Converge | Include shell role  # noqa: role-name[path]
+    - name: Converge | Include shell role (native)  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+- name: Converge — Oh My Zsh framework
+  hosts: all
+  gather_facts: true
+
+  vars:
+    shell_enabled: true
+    shell_default: 'zsh'
+    shell_zsh_enabled: true
+    shell_zsh_framework: 'ohmyzsh'
+    shell_ohmyzsh_theme: 'robbyrussell'
+    shell_ohmyzsh_plugins:
+      - 'git'
+    shell_ohmyzsh_custom_plugins:
+      - name: 'zsh-autosuggestions'
+        repo: 'https://github.com/zsh-users/zsh-autosuggestions.git'
+    shell_starship_enabled: false
+    shell_zoxide_enabled: false
+    shell_fzf_enabled: false
+    shell_fish_enabled: false
+    shell_bash_completion_enabled: false
+    shell_users:
+      - 'testuser'
+    shell_user_config_mode: 'managed'
+
+  tasks:
+    - name: Converge | Include shell role (ohmyzsh)  # noqa: role-name[path]
       ansible.builtin.include_role:
         name: '{{ playbook_dir }}/../..'

--- a/roles/shell/molecule/default/prepare.yml
+++ b/roles/shell/molecule/default/prepare.yml
@@ -80,3 +80,14 @@
         name: dbus-broker
         state: started
       when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Install git
+      ansible.builtin.package:
+        name: git
+        state: present
+
+    - name: Prepare | Create test user
+      ansible.builtin.user:
+        name: testuser
+        create_home: true
+        shell: /bin/bash

--- a/roles/shell/molecule/default/verify.yml
+++ b/roles/shell/molecule/default/verify.yml
@@ -96,3 +96,45 @@
       when:
         - ansible_facts['os_family'] == 'Archlinux'
         - __shell_starship_package | default('') | length > 0
+
+    #
+    # Oh My Zsh
+    #
+
+    - name: Verify | Check Oh My Zsh directory exists
+      ansible.builtin.stat:
+        path: '/home/testuser/.oh-my-zsh'
+      register: _shell_ohmyzsh_dir
+      failed_when: not _shell_ohmyzsh_dir.stat.exists
+
+    - name: Verify | Check Oh My Zsh oh-my-zsh.sh exists
+      ansible.builtin.stat:
+        path: '/home/testuser/.oh-my-zsh/oh-my-zsh.sh'
+      register: _shell_ohmyzsh_sh
+      failed_when: not _shell_ohmyzsh_sh.stat.exists
+
+    - name: Verify | Check custom plugin cloned
+      ansible.builtin.stat:
+        path: '/home/testuser/.oh-my-zsh/custom/plugins/zsh-autosuggestions'
+      register: _shell_ohmyzsh_custom_plugin
+      failed_when: not _shell_ohmyzsh_custom_plugin.stat.exists
+
+    - name: Verify | Check .zshrc deployed
+      ansible.builtin.stat:
+        path: '/home/testuser/.zshrc'
+      register: _shell_ohmyzsh_zshrc
+      failed_when: not _shell_ohmyzsh_zshrc.stat.exists
+
+    - name: Verify | Check .zshrc contains Oh My Zsh source
+      ansible.builtin.command:
+        cmd: 'grep -q "source.*oh-my-zsh.sh" /home/testuser/.zshrc'
+      register: _shell_ohmyzsh_source
+      changed_when: false
+      failed_when: _shell_ohmyzsh_source.rc != 0
+
+    - name: Verify | Check .zshrc contains theme
+      ansible.builtin.command:
+        cmd: 'grep -q "ZSH_THEME=\"robbyrussell\"" /home/testuser/.zshrc'
+      register: _shell_ohmyzsh_theme
+      changed_when: false
+      failed_when: _shell_ohmyzsh_theme.rc != 0

--- a/roles/shell/tasks/install.yml
+++ b/roles/shell/tasks/install.yml
@@ -8,9 +8,9 @@
     __shell_install_packages: >-
       {{
         (shell_zsh_enabled | bool | ternary([__shell_zsh_package], [])) +
-        (shell_zsh_enabled | bool | ternary(
+        ((shell_zsh_enabled | bool and shell_zsh_framework == 'native') | ternary(
           shell_zsh_plugins | map('extract', __shell_zsh_plugin_packages) | select('string') | list, [])) +
-        ((shell_zsh_grml_enabled | bool and __shell_zsh_grml_package | length > 0)
+        ((shell_zsh_grml_enabled | bool and shell_zsh_framework == 'native' and __shell_zsh_grml_package | length > 0)
           | ternary([__shell_zsh_grml_package], [])) +
         (shell_fish_enabled | bool | ternary([__shell_fish_package], [])) +
         (shell_bash_completion_enabled | bool | ternary([__shell_bash_completion_package], [])) +

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -24,6 +24,16 @@
     - shell
     - shell:install
 
+- name: Main | Import Oh My Zsh tasks
+  ansible.builtin.import_tasks: ohmyzsh.yml
+  when:
+    - shell_enabled | bool
+    - shell_zsh_enabled | bool
+    - shell_zsh_framework == 'ohmyzsh'
+  tags:
+    - shell
+    - shell:ohmyzsh
+
 - name: Main | Import user tasks
   ansible.builtin.import_tasks: users.yml
   when:

--- a/roles/shell/tasks/ohmyzsh.yml
+++ b/roles/shell/tasks/ohmyzsh.yml
@@ -1,0 +1,49 @@
+---
+#
+# Oh My Zsh Installation and Configuration
+#
+
+- name: OhMyZsh | Get users to configure
+  ansible.builtin.set_fact:
+    __shell_ohmyzsh_users: >-
+      {{ shell_users if shell_users | length > 0
+         else (users_list | default([]) | map(attribute='name') | list) }}
+
+- name: OhMyZsh | Clone Oh My Zsh
+  ansible.builtin.git:
+    repo: 'https://github.com/ohmyzsh/ohmyzsh.git'
+    dest: '/home/{{ item }}/.oh-my-zsh'
+    depth: 1
+    version: 'master'
+    update: "{{ shell_user_config_mode == 'managed' }}"
+  become: true
+  become_user: '{{ item }}'
+  loop: '{{ __shell_ohmyzsh_users }}'
+  when: shell_user_config_mode != 'disabled'
+
+- name: OhMyZsh | Clone custom plugins
+  ansible.builtin.git:
+    repo: '{{ item.1.repo }}'
+    dest: '/home/{{ item.0 }}/.oh-my-zsh/custom/plugins/{{ item.1.name }}'
+    depth: 1
+    version: 'HEAD'
+    update: "{{ shell_user_config_mode == 'managed' }}"
+  become: true
+  become_user: '{{ item.0 }}'
+  loop: '{{ __shell_ohmyzsh_users | product(shell_ohmyzsh_custom_plugins) | list }}'
+  loop_control:
+    label: '{{ item.0 }}: {{ item.1.name }}'
+  when:
+    - shell_user_config_mode != 'disabled'
+    - shell_ohmyzsh_custom_plugins | length > 0
+
+- name: OhMyZsh | Deploy .zshrc
+  ansible.builtin.template:
+    src: 'ohmyzsh.zshrc.j2'
+    dest: '/home/{{ item }}/.zshrc'
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+    force: "{{ shell_user_config_mode == 'managed' }}"
+  loop: '{{ __shell_ohmyzsh_users }}'
+  when: shell_user_config_mode != 'disabled'

--- a/roles/shell/tasks/ohmyzsh.yml
+++ b/roles/shell/tasks/ohmyzsh.yml
@@ -21,12 +21,12 @@
   loop: '{{ __shell_ohmyzsh_users }}'
   when: shell_user_config_mode != 'disabled'
 
-- name: OhMyZsh | Clone custom plugins
+- name: OhMyZsh | Clone custom plugins  # noqa: latest[git]
   ansible.builtin.git:
     repo: '{{ item.1.repo }}'
     dest: '/home/{{ item.0 }}/.oh-my-zsh/custom/plugins/{{ item.1.name }}'
     depth: 1
-    version: 'HEAD'
+    version: '{{ item.1.version | default("master") }}'
     update: "{{ shell_user_config_mode == 'managed' }}"
   become: true
   become_user: '{{ item.0 }}'

--- a/roles/shell/templates/ohmyzsh.zshrc.j2
+++ b/roles/shell/templates/ohmyzsh.zshrc.j2
@@ -1,0 +1,43 @@
+{{ ansible_managed | comment }}
+#
+# Oh My Zsh Configuration
+#
+
+# Path to Oh My Zsh installation
+export ZSH="$HOME/.oh-my-zsh"
+
+# Theme
+{% if shell_starship_enabled | default(false) | bool %}
+# Disabled — Starship handles the prompt
+ZSH_THEME=""
+{% else %}
+ZSH_THEME="{{ shell_ohmyzsh_theme }}"
+{% endif %}
+
+# Plugins
+plugins=(
+{% for plugin in shell_ohmyzsh_plugins %}
+  {{ plugin }}
+{% endfor %}
+{% for plugin in shell_ohmyzsh_custom_plugins %}
+  {{ plugin.name }}
+{% endfor %}
+)
+
+# Load Oh My Zsh
+source "$ZSH/oh-my-zsh.sh"
+
+#
+# Tool Initialization
+#
+
+{% if shell_starship_enabled | default(false) | bool %}
+# Starship prompt
+eval "$(starship init zsh)"
+
+{% endif %}
+{% if shell_zoxide_enabled | default(false) | bool %}
+# Zoxide (smarter cd)
+eval "$(zoxide init zsh)"
+
+{% endif %}


### PR DESCRIPTION
## Summary

- Add `shell_zsh_framework` toggle (`native`/`ohmyzsh`) to shell role
- Oh My Zsh mode: per-user git clone, managed `.zshrc` template, custom plugin support
- Starship integration: auto-disables OMZ theme when Starship is active
- Remove unused `shell_zsh_skeleton_enabled` placeholder
- Molecule tests cover both native and ohmyzsh modes on all 4 platforms

## Test plan

- [x] Molecule test Arch Linux
- [x] Molecule test Debian Trixie
- [x] Molecule test Rocky 9
- [x] Molecule test Rocky 10
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)