### PR TITLE
fix: Switch galaxy.yml to generic updater in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,11 +16,7 @@
         {"type": "ci", "section": "CI", "hidden": true}
       ],
       "extra-files": [
-        {
-          "type": "yaml",
-          "path": "galaxy.yml",
-          "jsonpath": "$.version"
-        }
+        "galaxy.yml"
       ],
       "bootstrap-sha": "c92f6337c29fadaaae55866c1fd4c0d4a5ed259e"
     }


### PR DESCRIPTION
## Summary

- Switch `galaxy.yml` from `type: yaml` (jsonpath) to generic updater in release-please config
- The YAML updater strips `---` document start markers and inline comments, causing ansible-lint failures on the release PR
- The generic updater uses the `x-release-please-version` annotation already in `galaxy.yml` and preserves file structure

Fixes the failing CI on release-please PR #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)