### PR TITLE
ci: Add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to release-please workflow
- Allows manual re-triggering when push trigger misses or stale release PRs need regeneration
- Release-please is trigger-agnostic — works identically with push and workflow_dispatch

## Test plan

- [ ] CI passes
- [ ] After merge, manually trigger release-please via Actions tab to regenerate v1.1.0 release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)