### PR TITLE
fix: Revert to YAML updater for galaxy.yml in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,11 @@
         {"type": "ci", "section": "CI", "hidden": true}
       ],
       "extra-files": [
-        "galaxy.yml"
+        {
+          "type": "yaml",
+          "path": "galaxy.yml",
+          "jsonpath": "$.version"
+        }
       ],
       "bootstrap-sha": "c92f6337c29fadaaae55866c1fd4c0d4a5ed259e"
     }


### PR DESCRIPTION
## Summary

- Revert `galaxy.yml` extra-files config back to `type: yaml` + `jsonpath`
- The generic updater did not fix the `---` stripping issue
- Common and rocky collections use the YAML updater successfully — match their config

## Test plan

- [ ] CI passes
- [ ] After merge, trigger release-please and verify galaxy.yml retains `---`

🤖 Generated with [Claude Code](https://claude.com/claude-code)