### PR TITLE
fix: Use explicit generic updater for galaxy.yml in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,9 +17,8 @@
       ],
       "extra-files": [
         {
-          "type": "yaml",
-          "path": "galaxy.yml",
-          "jsonpath": "$.version"
+          "type": "generic",
+          "path": "galaxy.yml"
         }
       ],
       "bootstrap-sha": "c92f6337c29fadaaae55866c1fd4c0d4a5ed259e"


### PR DESCRIPTION
## Summary

- Switch `galaxy.yml` to `{"type": "generic", "path": "galaxy.yml"}` in release-please config
- The YAML updater (`js-yaml`) strips `---` and comments — known unfixed bug ([googleapis/release-please#1944](https://github.com/googleapis/release-please/issues/1944))
- The generic updater does line-by-line regex on `x-release-please-version` annotation, preserving all formatting
- A plain string `"galaxy.yml"` runs BOTH updaters (yaml first), which still breaks — must use explicit object

Same fix needs to be applied to common and rocky collections.

## Test plan

- [ ] CI passes
- [ ] After merge, release-please creates PR with `galaxy.yml` retaining `---`

🤖 Generated with [Claude Code](https://claude.com/claude-code)