### PR TITLE
feat(filemanagers): Deprecate CLI file managers

### DIFF
--- a/roles/filemanagers/README.md
+++ b/roles/filemanagers/README.md
@@ -4,8 +4,8 @@ Install terminal and GUI file managers.
 
 ## Description
 
-Installs optional file managers: terminal-based (vifm, Midnight Commander, ranger,
-nnn, lf) and graphical (Thunar, Dolphin, Nautilus, PCManFM, Nemo, Double Commander).
+Installs optional file managers: graphical (Thunar, Dolphin, Nautilus, PCManFM, Nemo,
+Double Commander) and terminal-based (deprecated -- moving to `marcstraube.common.utils`).
 Each application has its own boolean toggle and is independently installable. Package
 availability varies by platform -- applications not packaged for a given OS are
 silently skipped.
@@ -36,15 +36,19 @@ overrides if needed.
 | ---------------------- | ------- | ------------------- |
 | `filemanagers_enabled` | `true`  | Enable/disable role |
 
-### Terminal File Managers
+### Terminal File Managers (DEPRECATED)
 
-| Variable                      | Default | Description                           |
-| ----------------------------- | ------- | ------------------------------------- |
-| `filemanagers_vifm_enabled`   | `false` | Enable vifm (Vi-like file manager)    |
-| `filemanagers_mc_enabled`     | `false` | Enable Midnight Commander             |
-| `filemanagers_ranger_enabled` | `false` | Enable ranger                         |
-| `filemanagers_nnn_enabled`    | `false` | Enable nnn                            |
-| `filemanagers_lf_enabled`     | `false` | Enable lf (not available on EL/EPEL)  |
+> **Deprecation Notice:** Terminal file managers have moved to
+> `marcstraube.common.utils` (category: File Managers). The variables below still
+> work but will be removed in v2.0.0. Use `utils_filemgr_*_enabled` instead.
+
+| Variable                      | Default | Replacement                    |
+| ----------------------------- | ------- | ------------------------------ |
+| `filemanagers_vifm_enabled`   | `false` | `utils_filemgr_vifm_enabled`   |
+| `filemanagers_mc_enabled`     | `false` | `utils_filemgr_mc_enabled`     |
+| `filemanagers_ranger_enabled` | `false` | `utils_filemgr_ranger_enabled` |
+| `filemanagers_nnn_enabled`    | `false` | `utils_filemgr_nnn_enabled`    |
+| `filemanagers_lf_enabled`     | `false` | `utils_filemgr_lf_enabled`     |
 
 ### GUI File Managers
 

--- a/roles/filemanagers/defaults/main.yml
+++ b/roles/filemanagers/defaults/main.yml
@@ -8,21 +8,23 @@ filemanagers_enabled: true
 
 #
 # Terminal File Managers
+# DEPRECATED: Moving to marcstraube.common.utils (removed in v2.0.0)
+# Use utils_filemgr_*_enabled instead
 #
 
-# Enable vifm (Vi-like file manager)
+# DEPRECATED: Use utils_filemgr_vifm_enabled instead (removed in v2.0.0)
 filemanagers_vifm_enabled: false
 
-# Enable Midnight Commander (Norton Commander clone)
+# DEPRECATED: Use utils_filemgr_mc_enabled instead (removed in v2.0.0)
 filemanagers_mc_enabled: false
 
-# Enable ranger (Vi-like file manager with file previews)
+# DEPRECATED: Use utils_filemgr_ranger_enabled instead (removed in v2.0.0)
 filemanagers_ranger_enabled: false
 
-# Enable nnn (fast file manager)
+# DEPRECATED: Use utils_filemgr_nnn_enabled instead (removed in v2.0.0)
 filemanagers_nnn_enabled: false
 
-# Enable lf (terminal file manager inspired by ranger)
+# DEPRECATED: Use utils_filemgr_lf_enabled instead (removed in v2.0.0)
 filemanagers_lf_enabled: false
 
 #

--- a/roles/filemanagers/tasks/main.yml
+++ b/roles/filemanagers/tasks/main.yml
@@ -12,6 +12,32 @@
   tags:
     - filemanagers
 
+- name: Main | Warn about deprecated CLI file manager variables
+  ansible.builtin.debug:
+    msg: >-
+      DEPRECATION WARNING: '{{ item.old }}' is deprecated and will be removed in v2.0.0.
+      Terminal file managers have moved to marcstraube.common.utils.
+      Use '{{ item.new }}' instead.
+  when:
+    - filemanagers_enabled | bool
+    - lookup('vars', item.old, default='__undefined__') != '__undefined__'
+    - lookup('vars', item.old) | bool
+  loop:
+    - old: filemanagers_vifm_enabled
+      new: utils_filemgr_vifm_enabled
+    - old: filemanagers_mc_enabled
+      new: utils_filemgr_mc_enabled
+    - old: filemanagers_ranger_enabled
+      new: utils_filemgr_ranger_enabled
+    - old: filemanagers_nnn_enabled
+      new: utils_filemgr_nnn_enabled
+    - old: filemanagers_lf_enabled
+      new: utils_filemgr_lf_enabled
+  loop_control:
+    label: "{{ item.old }}"
+  tags:
+    - filemanagers
+
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml
   when: filemanagers_enabled | bool


### PR DESCRIPTION
## Summary

- Deprecate terminal file manager variables (`filemanagers_{vifm,mc,ranger,nnn,lf}_enabled`)
- CLI file managers have moved to `marcstraube.common.utils` (category: File Managers)
- Old variables still work but emit deprecation warnings at runtime
- Removal planned for v2.0.0

Companion PR: marcstraube/ansible-collection-common#35

## Test plan

- [ ] CI pipeline green
- [ ] Verify deprecation warning appears when using old variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)