### PR TITLE
fix(multimedia): Disable abandoned packages by default

### DIFF
--- a/roles/multimedia/defaults/main.yml
+++ b/roles/multimedia/defaults/main.yml
@@ -41,7 +41,7 @@ multimedia_openshot_enabled: false
 #
 
 # Enable FFMultiConverter media file converter
-multimedia_ffmulticonverter_enabled: true
+multimedia_ffmulticonverter_enabled: false
 
 # Enable HandBrake video transcoder
 multimedia_handbrake_enabled: false
@@ -51,7 +51,7 @@ multimedia_handbrake_enabled: false
 #
 
 # Enable Peek animated GIF recorder
-multimedia_peek_enabled: true
+multimedia_peek_enabled: false
 
 # Enable OBS Studio streaming and recording
 multimedia_obs_enabled: false


### PR DESCRIPTION
## Summary

- Disable `multimedia_peek_enabled` — X11-only GIF recorder, last release 2022, no Wayland support
- Disable `multimedia_ffmulticonverter_enabled` — GUI ffmpeg wrapper, last release ~2016, Python 2, AUR broken

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)