### PR TITLE
chore: Schema compliance (README, prepare.yml, vars/main.yml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-Desktop workstation roles for Arch Linux, Debian Trixie, and Rocky Linux 9/10.
+Desktop workstation roles for Arch Linux, Debian Trixie, and EL 9/10.
 27 roles covering desktop environments, display managers, browsers,
 development tools, multimedia, office, and productivity applications.
 
@@ -14,8 +14,8 @@ development tools, multimedia, office, and productivity applications.
 
 - Arch Linux (primary)
 - Debian Trixie (13)
-- Rocky Linux 9 / EL 9 (Rocky, Alma, RHEL)
-- Rocky Linux 10 / EL 10 (Rocky, Alma, RHEL)
+- EL 9 (Rocky, Alma, RHEL)
+- EL 10 (Rocky, Alma, RHEL)
 
 ## Requirements
 

--- a/roles/ai/README.md
+++ b/roles/ai/README.md
@@ -24,12 +24,12 @@ API keys are managed by the user via environment variables (not by this role).
 
 ## Supported Platforms
 
-| Platform       | Notes                                      |
-| -------------- | ------------------------------------------ |
-| Arch Linux     | Native packages + AUR                      |
-| Debian Trixie  | npm/pipx/install scripts                   |
-| Rocky Linux 9  | npm/pipx/install scripts                   |
-| Rocky Linux 10 | npm/pipx/install scripts                   |
+| Platform                  | Notes                    |
+| ------------------------- | ------------------------ |
+| Arch Linux                | Native packages + AUR    |
+| Debian Trixie             | npm/pipx/install scripts |
+| EL 9 (Rocky, Alma, RHEL)  | npm/pipx/install scripts |
+| EL 10 (Rocky, Alma, RHEL) | npm/pipx/install scripts |
 
 ## Role Variables
 

--- a/roles/browser/README.md
+++ b/roles/browser/README.md
@@ -30,8 +30,8 @@ Chromium on Rocky Linux requires EPEL.
 | -------------- | ------- | ------------ | --------- | ----- | ------ | ---- |
 | Arch Linux     | yes     | yes          | AUR       | AUR   | AUR    | AUR  |
 | Debian Trixie  | ESR     | yes          | no        | no    | yes    | no   |
-| Rocky Linux 9  | yes     | EPEL         | no        | no    | no     | no   |
-| Rocky Linux 10 | yes     | EPEL         | no        | no    | no     | no   |
+| EL 9           | yes     | EPEL         | no        | no    | no     | no   |
+| EL 10          | yes     | EPEL         | no        | no    | no     | no   |
 
 ## Role Variables
 

--- a/roles/browser/molecule/default/prepare.yml
+++ b/roles/browser/molecule/default/prepare.yml
@@ -2,14 +2,71 @@
 - name: Prepare
   hosts: all
   gather_facts: true
+
+  vars:
+    __prepare_packages:
+      Debian:
+        - python3
+        - python3-apt
+        - systemd
+        - systemd-timesyncd
+        - locales
+        - dbus
+      RedHat:
+        - python3
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
+    #
+    # Package Cache
+    #
+
     - name: Prepare | Update package cache (Arch)
       community.general.pacman:
         update_cache: true
         upgrade: true
       when: ansible_facts['os_family'] == 'Archlinux'
 
-    - name: Prepare | Install base packages (Arch)
+    - name: Prepare | Update package cache (Debian)
+      ansible.builtin.apt:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Prepare | Update package cache (RedHat)
+      ansible.builtin.dnf:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # Container Dependencies
+    #
+
+    - name: Prepare | Replace curl-minimal with curl (RedHat)
+      ansible.builtin.dnf:
+        name:
+          - curl
+        state: present
+        allowerasing: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
+        state: present
+      when: ansible_facts['os_family'] in __prepare_packages
+
+    - name: Prepare | Start D-Bus (RedHat)
+      ansible.builtin.systemd_service:
+        name: dbus-broker
+        state: started
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # AUR Builder (Arch)
+    #
+
+    - name: Prepare | Install base-devel and sudo (Arch)
       community.general.pacman:
         name:
           - base-devel
@@ -32,43 +89,3 @@
         mode: '0440'
         validate: 'visudo -cf %s'
       when: ansible_facts['os_family'] == 'Archlinux'
-
-    - name: Prepare | Update package cache (Debian)
-      ansible.builtin.apt:
-        update_cache: true
-      when: ansible_facts['os_family'] == 'Debian'
-
-    - name: Prepare | Install prerequisites (Debian)
-      ansible.builtin.apt:
-        name:
-          - python3
-          - python3-apt
-          - systemd
-          - systemd-timesyncd
-          - locales
-          - dbus
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
-
-    - name: Prepare | Replace curl-minimal with curl (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - curl
-        state: present
-        allowerasing: true
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Install prerequisites (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - python3
-          - glibc-langpack-en
-          - glibc-locale-source
-        state: present
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Start D-Bus (RedHat)
-      ansible.builtin.systemd_service:
-        name: dbus-broker
-        state: started
-      when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/desktop_environment/molecule/default/prepare.yml
+++ b/roles/desktop_environment/molecule/default/prepare.yml
@@ -6,9 +6,21 @@
 - name: Prepare
   hosts: all
   gather_facts: true
+
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - systemd-timesyncd
+        - locales
+        - dbus
+      RedHat:
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
     #
-    # Package Cache Updates
+    # Package Cache
     #
 
     - name: Prepare | Update package cache (Arch)
@@ -31,16 +43,6 @@
     # Container Dependencies
     #
 
-    - name: Prepare | Install container dependencies (Debian)
-      ansible.builtin.apt:
-        name:
-          - systemd
-          - systemd-timesyncd
-          - locales
-          - dbus
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
-
     - name: Prepare | Replace curl-minimal with curl (RedHat)
       ansible.builtin.dnf:
         name:
@@ -49,13 +51,11 @@
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Prepare | Install container dependencies (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - glibc-langpack-en
-          - glibc-locale-source
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
-      when: ansible_facts['os_family'] == 'RedHat'
+      when: ansible_facts['os_family'] in __prepare_packages
 
     - name: Prepare | Start D-Bus (RedHat)
       ansible.builtin.systemd_service:
@@ -64,7 +64,7 @@
       when: ansible_facts['os_family'] == 'RedHat'
 
     #
-    # Arch Linux AUR Setup
+    # AUR Builder (Arch)
     #
 
     - name: Prepare | Install base-devel and sudo (Arch)

--- a/roles/display_manager/molecule/default/prepare.yml
+++ b/roles/display_manager/molecule/default/prepare.yml
@@ -1,12 +1,28 @@
 ---
 #
-# Prepare
+# Prepare containers for molecule testing
 #
 
 - name: Prepare
   hosts: all
   gather_facts: true
+
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - systemd-timesyncd
+        - locales
+        - dbus
+      RedHat:
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
+    #
+    # Package Cache
+    #
+
     - name: Prepare | Update package cache (Arch)
       community.general.pacman:
         update_cache: true
@@ -22,6 +38,34 @@
       ansible.builtin.dnf:
         update_cache: true
       when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # Container Dependencies
+    #
+
+    - name: Prepare | Replace curl-minimal with curl (RedHat)
+      ansible.builtin.dnf:
+        name:
+          - curl
+        state: present
+        allowerasing: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
+        state: present
+      when: ansible_facts['os_family'] in __prepare_packages
+
+    - name: Prepare | Start D-Bus (RedHat)
+      ansible.builtin.systemd_service:
+        name: dbus-broker
+        state: started
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # AUR Builder (Arch)
+    #
 
     - name: Prepare | Install base-devel and sudo (Arch)
       community.general.pacman:
@@ -46,35 +90,3 @@
         mode: '0440'
         validate: 'visudo -cf %s'
       when: ansible_facts['os_family'] == 'Archlinux'
-
-    - name: Prepare | Install container dependencies (Debian)
-      ansible.builtin.apt:
-        name:
-          - systemd
-          - systemd-timesyncd
-          - locales
-          - dbus
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
-
-    - name: Prepare | Replace curl-minimal with curl (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - curl
-        state: present
-        allowerasing: true
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Install container dependencies (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - glibc-langpack-en
-          - glibc-locale-source
-        state: present
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Start D-Bus (RedHat)
-      ansible.builtin.systemd_service:
-        name: dbus-broker
-        state: started
-      when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/gaming/README.md
+++ b/roles/gaming/README.md
@@ -5,7 +5,7 @@ Install gaming platforms and emulators.
 ## Description
 
 Installs Lutris, Steam, RetroArch, PCSX2, Dolphin, Moonlight, Heroic Games
-Launcher, and Playback across Arch Linux, Debian Trixie, and Rocky Linux 9/10.
+Launcher, and Playback across Arch Linux, Debian Trixie, and EL 9/10.
 Wine has been extracted into its own role (`marcstraube.desktop.wine`).
 
 Platform availability varies by OS — see the Role Variables table for details.
@@ -20,7 +20,7 @@ to exist on managed hosts.
 
 - ansible-core >= 2.17
 - `kewlfft.aur` collection (AUR packages on Arch Linux)
-- EPEL repository enabled (for Lutris on Rocky Linux 9/10)
+- EPEL repository enabled (for Lutris on EL 9/10)
 - `aur_builder` system user with passwordless sudo (Arch Linux only)
 
 ## Supported Platforms

--- a/roles/gaming/molecule/default/prepare.yml
+++ b/roles/gaming/molecule/default/prepare.yml
@@ -4,9 +4,20 @@
   become: true
   gather_facts: true
 
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - systemd-timesyncd
+        - locales
+        - dbus
+      RedHat:
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
     #
-    # Package Cache Updates
+    # Package Cache
     #
 
     - name: Prepare | Update package cache (Arch)
@@ -29,24 +40,6 @@
     # Container Dependencies
     #
 
-    - name: Prepare | Install base-devel and sudo (Arch)
-      community.general.pacman:
-        name:
-          - base-devel
-          - sudo
-        state: present
-      when: ansible_facts['os_family'] == 'Archlinux'
-
-    - name: Prepare | Install container dependencies (Debian)
-      ansible.builtin.apt:
-        name:
-          - systemd
-          - systemd-timesyncd
-          - locales
-          - dbus
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
-
     - name: Prepare | Replace curl-minimal with curl (RedHat)
       ansible.builtin.dnf:
         name:
@@ -55,13 +48,11 @@
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Prepare | Install container dependencies (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - glibc-langpack-en
-          - glibc-locale-source
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
-      when: ansible_facts['os_family'] == 'RedHat'
+      when: ansible_facts['os_family'] in __prepare_packages
 
     - name: Prepare | Start D-Bus (RedHat)
       ansible.builtin.systemd_service:
@@ -72,6 +63,14 @@
     #
     # AUR Builder (Arch)
     #
+
+    - name: Prepare | Install base-devel and sudo (Arch)
+      community.general.pacman:
+        name:
+          - base-devel
+          - sudo
+        state: present
+      when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Create aur_builder user (Arch)
       ansible.builtin.user:

--- a/roles/multimedia/molecule/default/prepare.yml
+++ b/roles/multimedia/molecule/default/prepare.yml
@@ -3,6 +3,16 @@
   hosts: all
   gather_facts: true
 
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - dbus
+        - locales
+      RedHat:
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
     #
     # Package Cache
@@ -34,7 +44,31 @@
       when: ansible_facts['os_family'] == 'RedHat'
 
     #
-    # Arch Linux
+    # Container Dependencies
+    #
+
+    - name: Prepare | Replace curl-minimal with curl (RedHat)
+      ansible.builtin.dnf:
+        name:
+          - curl
+        state: present
+        allowerasing: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
+        state: present
+      when: ansible_facts['os_family'] in __prepare_packages
+
+    - name: Prepare | Start D-Bus (RedHat)
+      ansible.builtin.systemd_service:
+        name: dbus-broker
+        state: started
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # AUR Builder (Arch)
     #
 
     - name: Prepare | Install base-devel and sudo (Arch)
@@ -60,38 +94,3 @@
         mode: '0440'
         validate: 'visudo -cf %s'
       when: ansible_facts['os_family'] == 'Archlinux'
-
-    #
-    # Container Dependencies
-    #
-
-    - name: Prepare | Install container dependencies (Debian)
-      ansible.builtin.apt:
-        name:
-          - systemd
-          - dbus
-          - locales
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
-
-    - name: Prepare | Replace curl-minimal with curl (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - curl
-        state: present
-        allowerasing: true
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Install locale packages (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - glibc-langpack-en
-          - glibc-locale-source
-        state: present
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Start D-Bus service (RedHat)
-      ansible.builtin.systemd_service:
-        name: dbus-broker
-        state: started
-      when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/office/molecule/default/prepare.yml
+++ b/roles/office/molecule/default/prepare.yml
@@ -4,12 +4,25 @@
   become: true
   gather_facts: true
 
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - dbus
+        - procps
+      RedHat:
+        - systemd
+        - dbus
+        - procps-ng
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
     #
     # Package Cache
     #
 
-    - name: Prepare | Full system update (Arch)
+    - name: Prepare | Update package cache (Arch)
       community.general.pacman:
         update_cache: true
         upgrade: true
@@ -29,15 +42,6 @@
     # Container Dependencies
     #
 
-    - name: Prepare | Install base packages (Debian)
-      ansible.builtin.apt:
-        name:
-          - systemd
-          - dbus
-          - procps
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
-
     - name: Prepare | Replace curl-minimal with curl (RedHat)
       ansible.builtin.dnf:
         name:
@@ -46,16 +50,11 @@
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Prepare | Install base packages (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - systemd
-          - dbus
-          - procps-ng
-          - glibc-langpack-en
-          - glibc-locale-source
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
-      when: ansible_facts['os_family'] == 'RedHat'
+      when: ansible_facts['os_family'] in __prepare_packages
 
     - name: Prepare | Start D-Bus (RedHat)
       ansible.builtin.systemd_service:

--- a/roles/plymouth/molecule/default/prepare.yml
+++ b/roles/plymouth/molecule/default/prepare.yml
@@ -3,12 +3,23 @@
   hosts: all
   gather_facts: true
 
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - systemd-timesyncd
+        - locales
+        - dbus
+      RedHat:
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
     #
-    # Package Cache Updates
+    # Package Cache
     #
 
-    - name: Prepare | Full system update (Arch)
+    - name: Prepare | Update package cache (Arch)
       community.general.pacman:
         update_cache: true
         upgrade: true
@@ -28,16 +39,6 @@
     # Container Dependencies
     #
 
-    - name: Prepare | Install base packages (Debian)
-      ansible.builtin.apt:
-        name:
-          - systemd
-          - systemd-timesyncd
-          - locales
-          - dbus
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
-
     - name: Prepare | Replace curl-minimal with curl (RedHat)
       ansible.builtin.dnf:
         name:
@@ -46,13 +47,11 @@
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Prepare | Install locale packages (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - glibc-langpack-en
-          - glibc-locale-source
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
-      when: ansible_facts['os_family'] == 'RedHat'
+      when: ansible_facts['os_family'] in __prepare_packages
 
     - name: Prepare | Start D-Bus (RedHat)
       ansible.builtin.systemd_service:

--- a/roles/security_apps/molecule/default/prepare.yml
+++ b/roles/security_apps/molecule/default/prepare.yml
@@ -3,6 +3,17 @@
   hosts: all
   gather_facts: true
 
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - systemd-timesyncd
+        - locales
+        - dbus
+      RedHat:
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
     #
     # Package Cache
@@ -28,16 +39,6 @@
     # Container Dependencies
     #
 
-    - name: Prepare | Install container dependencies (Debian)
-      ansible.builtin.apt:
-        name:
-          - systemd
-          - systemd-timesyncd
-          - locales
-          - dbus
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
-
     - name: Prepare | Replace curl-minimal with curl (RedHat)
       ansible.builtin.dnf:
         name:
@@ -46,13 +47,11 @@
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Prepare | Install locale packages (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - glibc-langpack-en
-          - glibc-locale-source
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
-      when: ansible_facts['os_family'] == 'RedHat'
+      when: ansible_facts['os_family'] in __prepare_packages
 
     - name: Prepare | Start D-Bus (RedHat)
       ansible.builtin.systemd_service:
@@ -61,7 +60,7 @@
       when: ansible_facts['os_family'] == 'RedHat'
 
     #
-    # AUR Builder
+    # AUR Builder (Arch)
     #
 
     - name: Prepare | Install base-devel and sudo (Arch)

--- a/roles/shell/molecule/default/prepare.yml
+++ b/roles/shell/molecule/default/prepare.yml
@@ -2,12 +2,72 @@
 - name: Prepare
   hosts: all
   gather_facts: true
+
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - systemd-timesyncd
+        - locales
+        - dbus
+      RedHat:
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
+    #
+    # Package Cache
+    #
+
     - name: Prepare | Update package cache (Arch)
       community.general.pacman:
         update_cache: true
         upgrade: true
       when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Prepare | Update package cache (Debian)
+      ansible.builtin.apt:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Prepare | Install EPEL release (RedHat)  # noqa: package-latest
+      ansible.builtin.package:
+        name: epel-release
+        state: latest
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Update package cache (RedHat)
+      ansible.builtin.dnf:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # Container Dependencies
+    #
+
+    - name: Prepare | Replace curl-minimal with curl (RedHat)
+      ansible.builtin.dnf:
+        name:
+          - curl
+        state: present
+        allowerasing: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
+        state: present
+      when: ansible_facts['os_family'] in __prepare_packages
+
+    - name: Prepare | Start D-Bus (RedHat)
+      ansible.builtin.systemd_service:
+        name: dbus-broker
+        state: started
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # AUR Builder (Arch)
+    #
 
     - name: Prepare | Install base-devel and sudo (Arch)
       community.general.pacman:
@@ -33,53 +93,9 @@
         validate: 'visudo -cf %s'
       when: ansible_facts['os_family'] == 'Archlinux'
 
-    - name: Prepare | Update package cache (Debian)
-      ansible.builtin.apt:
-        update_cache: true
-      when: ansible_facts['os_family'] == 'Debian'
-
-    - name: Prepare | Install container dependencies (Debian)
-      ansible.builtin.apt:
-        name:
-          - systemd
-          - systemd-timesyncd
-          - locales
-          - dbus
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
-
-    - name: Prepare | Install EPEL release (RedHat)  # noqa: package-latest
-      ansible.builtin.package:
-        name: epel-release
-        state: latest
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Update package cache (RedHat)
-      ansible.builtin.dnf:
-        update_cache: true
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Replace curl-minimal with curl (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - curl
-        state: present
-        allowerasing: true
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Install locale packages (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - glibc-langpack-en
-          - glibc-locale-source
-        state: present
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Start D-Bus (RedHat)
-      ansible.builtin.systemd_service:
-        name: dbus-broker
-        state: started
-      when: ansible_facts['os_family'] == 'RedHat'
+    #
+    # Test Dependencies
+    #
 
     - name: Prepare | Install git
       ansible.builtin.package:

--- a/roles/shell/vars/Archlinux.yml
+++ b/roles/shell/vars/Archlinux.yml
@@ -3,11 +3,6 @@
 # Arch Linux Variables
 #
 
-# Shell packages
-__shell_zsh_package: 'zsh'
-__shell_fish_package: 'fish'
-__shell_bash_completion_package: 'bash-completion'
-
 # Zsh plugins
 __shell_zsh_plugin_packages:
   completions: 'zsh-completions'
@@ -28,9 +23,3 @@ __shell_bat_package: 'bat'
 __shell_fd_package: 'fd'
 __shell_ripgrep_package: 'ripgrep'
 __shell_tldr_package: 'tldr'
-
-# Shell paths
-__shell_paths:
-  zsh: '/usr/bin/zsh'
-  fish: '/usr/bin/fish'
-  bash: '/bin/bash'

--- a/roles/shell/vars/Debian.yml
+++ b/roles/shell/vars/Debian.yml
@@ -3,11 +3,6 @@
 # Debian Variables
 #
 
-# Shell packages
-__shell_zsh_package: 'zsh'
-__shell_fish_package: 'fish'
-__shell_bash_completion_package: 'bash-completion'
-
 # Zsh plugins
 __shell_zsh_plugin_packages:
   completions: ''
@@ -28,9 +23,3 @@ __shell_bat_package: 'bat'
 __shell_fd_package: 'fd-find'
 __shell_ripgrep_package: 'ripgrep'
 __shell_tldr_package: 'tldr'
-
-# Shell paths
-__shell_paths:
-  zsh: '/usr/bin/zsh'
-  fish: '/usr/bin/fish'
-  bash: '/bin/bash'

--- a/roles/shell/vars/RedHat.yml
+++ b/roles/shell/vars/RedHat.yml
@@ -3,11 +3,6 @@
 # RedHat Variables
 #
 
-# Shell packages
-__shell_zsh_package: 'zsh'
-__shell_fish_package: 'fish'
-__shell_bash_completion_package: 'bash-completion'
-
 # Zsh plugins
 __shell_zsh_plugin_packages:
   completions: ''
@@ -28,9 +23,3 @@ __shell_bat_package: 'bat'
 __shell_fd_package: 'fd-find'
 __shell_ripgrep_package: 'ripgrep'
 __shell_tldr_package: 'tldr'
-
-# Shell paths
-__shell_paths:
-  zsh: '/usr/bin/zsh'
-  fish: '/usr/bin/fish'
-  bash: '/bin/bash'

--- a/roles/shell/vars/main.yml
+++ b/roles/shell/vars/main.yml
@@ -1,0 +1,15 @@
+---
+#
+# OS-independent Variables
+#
+
+# Shell packages
+__shell_zsh_package: 'zsh'
+__shell_fish_package: 'fish'
+__shell_bash_completion_package: 'bash-completion'
+
+# Shell paths
+__shell_paths:
+  zsh: '/usr/bin/zsh'
+  fish: '/usr/bin/fish'
+  bash: '/bin/bash'

--- a/roles/system_apps/molecule/default/prepare.yml
+++ b/roles/system_apps/molecule/default/prepare.yml
@@ -4,30 +4,41 @@
   become: true
   gather_facts: true
 
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - procps
+      RedHat:
+        - systemd
+        - procps-ng
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
-    - name: Prepare | Full system update (Arch)
+    #
+    # Package Cache
+    #
+
+    - name: Prepare | Update package cache (Arch)
       community.general.pacman:
         update_cache: true
         upgrade: true
       when: ansible_facts['os_family'] == 'Archlinux'
 
-    - name: Prepare | Install base packages (Debian)
+    - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
-        name:
-          - systemd
-          - procps
-        state: present
         update_cache: true
       when: ansible_facts['os_family'] == 'Debian'
 
-    - name: Prepare | Install base packages (RedHat)
+    - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
-        name:
-          - systemd
-          - procps-ng
-        state: present
         update_cache: true
       when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # Container Dependencies
+    #
 
     - name: Prepare | Replace curl-minimal with curl (RedHat)
       ansible.builtin.dnf:
@@ -37,13 +48,11 @@
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Prepare | Install locale packages (RedHat)
-      ansible.builtin.dnf:
-        name:
-          - glibc-langpack-en
-          - glibc-locale-source
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
-      when: ansible_facts['os_family'] == 'RedHat'
+      when: ansible_facts['os_family'] in __prepare_packages
 
     - name: Prepare | Start D-Bus (RedHat)
       ansible.builtin.systemd_service:


### PR DESCRIPTION
## Summary

- Standardize EL platform format in READMEs (browser, ai, gaming, collection root)
- Centralize OS-independent shell vars (`__shell_paths`, `__shell_zsh_package`, `__shell_fish_package`, `__shell_bash_completion_package`) into `vars/main.yml`
- Migrate 10 prepare.yml files to `__prepare_packages` dict pattern (browser, shell, display_manager, desktop_environment, multimedia, gaming, plymouth, security_apps, office, system_apps)

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)