### PR TITLE
feat: Add network retry logic to transient tasks

### DIFF
--- a/roles/ai/tasks/cli.yml
+++ b/roles/ai/tasks/cli.yml
@@ -14,6 +14,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_claude_code_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: CLI | Install Claude Code via npm (non-Arch)
   become: true
@@ -24,6 +26,8 @@
   when:
     - ansible_facts['os_family'] != 'Archlinux'
     - ai_claude_code_enabled | bool
+  retries: 3
+  delay: 5
 
 # Gemini CLI
 
@@ -36,6 +40,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_gemini_cli_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: CLI | Install Gemini CLI via npm (non-Arch)
   become: true
@@ -46,6 +52,8 @@
   when:
     - ansible_facts['os_family'] != 'Archlinux'
     - ai_gemini_cli_enabled | bool
+  retries: 3
+  delay: 5
 
 # OpenAI Codex
 
@@ -58,6 +66,8 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_codex_enabled | bool
     - __ai_codex_package | length > 0
+  retries: 3
+  delay: 5
 
 - name: CLI | Install OpenAI Codex via npm (non-Arch)
   become: true
@@ -68,6 +78,8 @@
   when:
     - ansible_facts['os_family'] != 'Archlinux'
     - ai_codex_enabled | bool
+  retries: 3
+  delay: 5
 
 # OpenCode
 
@@ -80,6 +92,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_opencode_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: CLI | Install OpenCode via npm (non-Arch)
   become: true
@@ -90,6 +104,8 @@
   when:
     - ansible_facts['os_family'] != 'Archlinux'
     - ai_opencode_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: CLI | Install OpenCode Claude auth from AUR (Arch)
   become: true
@@ -101,6 +117,8 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_opencode_enabled | bool
     - ai_opencode_claude_auth_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: CLI | Install OpenCode Claude auth via npm (non-Arch)
   become: true
@@ -112,6 +130,8 @@
     - ansible_facts['os_family'] != 'Archlinux'
     - ai_opencode_enabled | bool
     - ai_opencode_claude_auth_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: CLI | Install OpenCode Gemini auth from AUR (Arch)
   become: true
@@ -123,6 +143,8 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_opencode_enabled | bool
     - ai_opencode_gemini_auth_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: CLI | Install OpenCode Gemini auth via npm (non-Arch)
   become: true
@@ -134,6 +156,8 @@
     - ansible_facts['os_family'] != 'Archlinux'
     - ai_opencode_enabled | bool
     - ai_opencode_gemini_auth_enabled | bool
+  retries: 3
+  delay: 5
 
 # Aider
 
@@ -146,6 +170,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_aider_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: CLI | Install Aider via pipx (non-Arch)
   become: true
@@ -155,3 +181,5 @@
   when:
     - ansible_facts['os_family'] != 'Archlinux'
     - ai_aider_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/ai/tasks/comfyui.yml
+++ b/roles/ai/tasks/comfyui.yml
@@ -9,6 +9,8 @@
   ansible.builtin.package:
     name: '{{ __ai_comfyui_venv_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: ComfyUI | Create ComfyUI service user
   become: true
@@ -37,6 +39,8 @@
     dest: '{{ ai_comfyui_install_dir }}'
     version: '{{ ai_comfyui_version }}'
     update: true
+  retries: 5
+  delay: 10
 
 - name: ComfyUI | Create ComfyUI Python virtual environment
   become: true
@@ -57,6 +61,8 @@
     extra_args: '--index-url https://download.pytorch.org/whl/cu126'
     virtualenv: '{{ ai_comfyui_install_dir }}/venv'
   when: ai_comfyui_gpu == 'nvidia'
+  retries: 3
+  delay: 5
 
 - name: ComfyUI | Install PyTorch (AMD ROCm)
   become: true
@@ -69,6 +75,8 @@
     extra_args: '--index-url https://download.pytorch.org/whl/rocm6.2.4'
     virtualenv: '{{ ai_comfyui_install_dir }}/venv'
   when: ai_comfyui_gpu == 'amd'
+  retries: 3
+  delay: 5
 
 - name: ComfyUI | Install ComfyUI requirements
   become: true
@@ -76,6 +84,8 @@
   ansible.builtin.pip:
     requirements: '{{ ai_comfyui_install_dir }}/requirements.txt'
     virtualenv: '{{ ai_comfyui_install_dir }}/venv'
+  retries: 3
+  delay: 5
 
 - name: ComfyUI | Clone ComfyUI-Manager
   become: true
@@ -86,6 +96,8 @@
     version: 'main'
     update: true
   when: ai_comfyui_manager_enabled | bool
+  retries: 5
+  delay: 10
 
 - name: ComfyUI | Deploy ComfyUI systemd service
   become: true

--- a/roles/ai/tasks/desktop.yml
+++ b/roles/ai/tasks/desktop.yml
@@ -14,6 +14,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_claude_desktop_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Desktop | Claude Desktop not available (non-Arch)
   ansible.builtin.debug:
@@ -36,6 +38,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_opencode_desktop_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Desktop | Download OpenCode Desktop (Debian)
   become: true
@@ -46,6 +50,8 @@
     - ansible_facts['os_family'] == 'Debian'
     - ai_opencode_desktop_enabled | bool
     - __ai_opencode_desktop_url is defined
+  retries: 3
+  delay: 5
 
 - name: Desktop | Download OpenCode Desktop (RedHat)
   become: true
@@ -57,3 +63,5 @@
     - ansible_facts['os_family'] == 'RedHat'
     - ai_opencode_desktop_enabled | bool
     - __ai_opencode_desktop_url is defined
+  retries: 3
+  delay: 5

--- a/roles/ai/tasks/local.yml
+++ b/roles/ai/tasks/local.yml
@@ -14,6 +14,8 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_ollama_enabled | bool
     - __ai_ollama_package | length > 0
+  retries: 3
+  delay: 5
 
 - name: Local | Download Ollama install script (non-Arch)
   become: true
@@ -26,6 +28,8 @@
   when:
     - ansible_facts['os_family'] != 'Archlinux'
     - ai_ollama_enabled | bool
+  retries: 5
+  delay: 10
 
 - name: Local | Run Ollama install script (non-Arch)
   become: true
@@ -74,6 +78,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - ai_lmstudio_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Local | LM Studio not available (non-Arch)
   ansible.builtin.debug:

--- a/roles/bluetooth/tasks/install.yml
+++ b/roles/bluetooth/tasks/install.yml
@@ -21,6 +21,8 @@
     name: '{{ __bluetooth_install_packages }}'
     state: present
   when: __bluetooth_install_packages | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Install AUR audio packages
   become: true
@@ -31,3 +33,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - bluetooth_audio == 'alsa'
+  retries: 3
+  delay: 5

--- a/roles/browser/tasks/install.yml
+++ b/roles/browser/tasks/install.yml
@@ -8,6 +8,8 @@
     name: '{{ __browser_firefox_package }}'
     state: present
   when: browser_firefox_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Firefox language pack
   ansible.builtin.package:
@@ -16,6 +18,8 @@
   when:
     - browser_firefox_enabled | bool
     - browser_firefox_i18n | length > 0
+  retries: 3
+  delay: 5
 
 #
 # LibreWolf (AUR on Arch, not available elsewhere)
@@ -30,6 +34,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - browser_librewolf_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | LibreWolf not available notice
   ansible.builtin.debug:
@@ -49,6 +55,8 @@
     name: '{{ __browser_chromium_package }}'
     state: present
   when: browser_chromium_enabled | bool
+  retries: 3
+  delay: 5
 
 #
 # Brave (AUR on Arch, not available elsewhere)
@@ -63,6 +71,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - browser_brave_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Brave not available notice
   ansible.builtin.debug:
@@ -102,6 +112,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - browser_tor_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Tor Browser packages
   ansible.builtin.package:
@@ -111,6 +123,8 @@
     - ansible_facts['os_family'] != 'Archlinux'
     - browser_tor_enabled | bool
     - __browser_tor_package | length > 0
+  retries: 3
+  delay: 5
 
 #
 # Zen Browser (AUR on Arch only)
@@ -125,6 +139,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - browser_zen_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Zen Browser not available notice
   ansible.builtin.debug:

--- a/roles/cad/tasks/install.yml
+++ b/roles/cad/tasks/install.yml
@@ -6,6 +6,8 @@
   when:
     - cad_openscad_enabled | bool
     - __cad_openscad_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | FreeCAD
   ansible.builtin.package:
@@ -14,6 +16,8 @@
   when:
     - cad_freecad_enabled | bool
     - __cad_freecad_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | LibreCAD
   ansible.builtin.package:
@@ -22,6 +26,8 @@
   when:
     - cad_librecad_enabled | bool
     - __cad_librecad_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | QCAD
   ansible.builtin.package:
@@ -30,6 +36,8 @@
   when:
     - cad_qcad_enabled | bool
     - __cad_qcad_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Blender
   ansible.builtin.package:
@@ -38,6 +46,8 @@
   when:
     - cad_blender_enabled | bool
     - __cad_blender_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | KiCad
   ansible.builtin.package:
@@ -46,3 +56,5 @@
   when:
     - cad_kicad_enabled | bool
     - __cad_kicad_package | default('') | length > 0
+  retries: 3
+  delay: 5

--- a/roles/communication/tasks/install.yml
+++ b/roles/communication/tasks/install.yml
@@ -10,6 +10,8 @@
   when:
     - communication_telegram_enabled | bool
     - __communication_telegram_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Signal
   ansible.builtin.package:
@@ -18,6 +20,8 @@
   when:
     - communication_signal_enabled | bool
     - __communication_signal_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Discord
   ansible.builtin.package:
@@ -26,6 +30,8 @@
   when:
     - communication_discord_enabled | bool
     - __communication_discord_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Element
   ansible.builtin.package:
@@ -34,6 +40,8 @@
   when:
     - communication_element_enabled | bool
     - __communication_element_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Sieve
   ansible.builtin.package:
@@ -42,6 +50,8 @@
   when:
     - communication_sieve_enabled | bool
     - __communication_sieve_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | KDE Connect
   ansible.builtin.package:
@@ -50,6 +60,8 @@
   when:
     - communication_kdeconnect_enabled | bool
     - __communication_kdeconnect_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 #
 # AUR Packages (Arch)
@@ -65,6 +77,8 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - communication_slack_enabled | bool
     - not (communication_slack_wayland_enabled | bool)
+  retries: 3
+  delay: 5
 
 - name: Install | Slack Wayland from AUR (Arch)
   become: true
@@ -76,6 +90,8 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - communication_slack_enabled | bool
     - communication_slack_wayland_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Threema from AUR (Arch)
   become: true
@@ -86,6 +102,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - communication_threema_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Zoom from AUR (Arch)
   become: true
@@ -96,6 +114,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - communication_zoom_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Teams from AUR (Arch)
   become: true
@@ -106,6 +126,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - communication_teams_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Jitsi Meet from AUR (Arch)
   become: true
@@ -116,3 +138,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - communication_jitsi_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/desktop_environment/tasks/common.yml
+++ b/roles/desktop_environment/tasks/common.yml
@@ -28,3 +28,5 @@
     state: present
   when:
     - __desktop_environment_common_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/desktop_environment/tasks/gnome.yml
+++ b/roles/desktop_environment/tasks/gnome.yml
@@ -28,3 +28,5 @@
     state: present
   when:
     - __desktop_environment_gnome_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/desktop_environment/tasks/hyprland.yml
+++ b/roles/desktop_environment/tasks/hyprland.yml
@@ -57,6 +57,8 @@
     state: present
   when:
     - __desktop_environment_hyprland_install_packages | length > 0
+  retries: 3
+  delay: 5
 
 - name: Hyprland | Build AUR package list
   ansible.builtin.set_fact:
@@ -83,6 +85,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __desktop_environment_hyprland_install_aur_packages | default([]) | length > 0
+  retries: 3
+  delay: 5
 
 # uwsm Desktop Entry
 - name: Hyprland | Create wayland-sessions directory

--- a/roles/desktop_environment/tasks/i3.yml
+++ b/roles/desktop_environment/tasks/i3.yml
@@ -24,3 +24,5 @@
     state: present
   when:
     - __desktop_environment_i3_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/desktop_environment/tasks/kde.yml
+++ b/roles/desktop_environment/tasks/kde.yml
@@ -26,3 +26,5 @@
     state: present
   when:
     - __desktop_environment_kde_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/desktop_environment/tasks/lxde.yml
+++ b/roles/desktop_environment/tasks/lxde.yml
@@ -16,3 +16,5 @@
     state: present
   when:
     - __desktop_environment_lxde_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/desktop_environment/tasks/lxqt.yml
+++ b/roles/desktop_environment/tasks/lxqt.yml
@@ -22,3 +22,5 @@
     state: present
   when:
     - __desktop_environment_lxqt_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/desktop_environment/tasks/sway.yml
+++ b/roles/desktop_environment/tasks/sway.yml
@@ -24,3 +24,5 @@
     state: present
   when:
     - __desktop_environment_sway_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/desktop_environment/tasks/themes.yml
+++ b/roles/desktop_environment/tasks/themes.yml
@@ -40,6 +40,8 @@
     state: present
   when:
     - __desktop_environment_themes_packages | length > 0
+  retries: 3
+  delay: 5
 
 - name: Themes | Install AUR packages (Arch)
   become: true
@@ -50,3 +52,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __desktop_environment_themes_aur_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/desktop_environment/tasks/xfce.yml
+++ b/roles/desktop_environment/tasks/xfce.yml
@@ -25,3 +25,5 @@
     state: present
   when:
     - __desktop_environment_xfce_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/development/tasks/build.yml
+++ b/roles/development/tasks/build.yml
@@ -8,15 +8,21 @@
     name: '{{ __development_build_packages }}'
     state: "{{ 'present' if development_make_enabled | bool else 'absent' }}"
   when: ansible_facts['os_family'] == 'Archlinux'
+  retries: 3
+  delay: 5
 
 - name: Build | Manage build tools (Debian)
   ansible.builtin.apt:
     name: '{{ __development_build_packages }}'
     state: "{{ 'present' if development_make_enabled | bool else 'absent' }}"
   when: ansible_facts['os_family'] == 'Debian'
+  retries: 3
+  delay: 5
 
 - name: Build | Manage build tools (RedHat)
   ansible.builtin.dnf:
     name: '{{ __development_build_packages }}'
     state: "{{ 'present' if development_make_enabled | bool else 'absent' }}"
   when: ansible_facts['os_family'] == 'RedHat'
+  retries: 3
+  delay: 5

--- a/roles/development/tasks/git.yml
+++ b/roles/development/tasks/git.yml
@@ -7,15 +7,21 @@
   ansible.builtin.package:
     name: '{{ __development_git_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Git | Manage GitHub CLI
   ansible.builtin.package:
     name: '{{ __development_github_cli_package }}'
     state: "{{ 'present' if development_github_cli_enabled | bool else 'absent' }}"
   when: __development_github_cli_package | length > 0
+  retries: 3
+  delay: 5
 
 - name: Git | Manage GitLab CLI
   ansible.builtin.package:
     name: '{{ __development_gitlab_cli_package }}'
     state: "{{ 'present' if development_gitlab_cli_enabled | bool else 'absent' }}"
   when: __development_gitlab_cli_package | length > 0
+  retries: 3
+  delay: 5

--- a/roles/development/tasks/ides.yml
+++ b/roles/development/tasks/ides.yml
@@ -14,6 +14,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __development_aur_packages.ides_vscodium | default([]) | length > 0
+  retries: 3
+  delay: 5
 
 - name: IDEs | VSCodium not available notice (non-Arch)
   ansible.builtin.debug:
@@ -33,6 +35,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __development_aur_packages.ides_vscode | default([]) | length > 0
+  retries: 3
+  delay: 5
 
 # PHPStorm (Arch AUR)
 
@@ -45,6 +49,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __development_aur_packages.ides_phpstorm | default([]) | length > 0
+  retries: 3
+  delay: 5
 
 # Zed (Arch AUR)
 
@@ -57,6 +63,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __development_aur_packages.ides_zed | default([]) | length > 0
+  retries: 3
+  delay: 5
 
 # JetBrains Toolbox (Arch AUR)
 
@@ -69,6 +77,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __development_aur_packages.ides_jetbrains | default([]) | length > 0
+  retries: 3
+  delay: 5
 
 # Postman (Arch AUR)
 
@@ -81,6 +91,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __development_aur_packages.api_tools_postman | default([]) | length > 0
+  retries: 3
+  delay: 5
 
 # Insomnia (Arch AUR)
 
@@ -93,6 +105,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __development_aur_packages.api_tools_insomnia | default([]) | length > 0
+  retries: 3
+  delay: 5
 
 # Bruno (Arch AUR)
 
@@ -105,3 +119,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __development_aur_packages.api_tools_bruno | default([]) | length > 0
+  retries: 3
+  delay: 5

--- a/roles/development/tasks/languages.yml
+++ b/roles/development/tasks/languages.yml
@@ -15,6 +15,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - development_python_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Languages | Install Python (Debian)
   ansible.builtin.apt:
@@ -23,6 +25,8 @@
   when:
     - ansible_facts['os_family'] == 'Debian'
     - development_python_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Languages | Install Python (RedHat)
   ansible.builtin.dnf:
@@ -31,6 +35,8 @@
   when:
     - ansible_facts['os_family'] == 'RedHat'
     - development_python_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Languages | Install Python tools via pipx (non-Arch)
   community.general.pipx:
@@ -41,6 +47,8 @@
     - ansible_facts['os_family'] != 'Archlinux'
     - development_python_enabled | bool
     - development_python_tools | length > 0
+  retries: 3
+  delay: 5
 
 # Node.js
 
@@ -58,6 +66,8 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - development_rust_enabled | bool
     - __development_rust_packages | length > 0
+  retries: 3
+  delay: 5
 
 - name: Languages | Install Rust components via rustup (non-Arch)
   ansible.builtin.command:
@@ -79,6 +89,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - development_go_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Languages | Install Go (Debian)
   ansible.builtin.apt:
@@ -87,6 +99,8 @@
   when:
     - ansible_facts['os_family'] == 'Debian'
     - development_go_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Languages | Install Go (RedHat)
   ansible.builtin.dnf:
@@ -95,6 +109,8 @@
   when:
     - ansible_facts['os_family'] == 'RedHat'
     - development_go_enabled | bool
+  retries: 3
+  delay: 5
 
 # Java
 
@@ -105,6 +121,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - development_java_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Languages | Install Java (Debian)
   ansible.builtin.apt:
@@ -113,6 +131,8 @@
   when:
     - ansible_facts['os_family'] == 'Debian'
     - development_java_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Languages | Install Java (RedHat)
   ansible.builtin.dnf:
@@ -121,3 +141,5 @@
   when:
     - ansible_facts['os_family'] == 'RedHat'
     - development_java_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/development/tasks/tools.yml
+++ b/roles/development/tasks/tools.yml
@@ -8,33 +8,45 @@
     name: '{{ __development_misc_packages }}'
     state: present
   when: ansible_facts['os_family'] == 'Archlinux'
+  retries: 3
+  delay: 5
 
 - name: Tools | Install misc tools (Debian)
   ansible.builtin.apt:
     name: '{{ __development_misc_packages }}'
     state: present
   when: ansible_facts['os_family'] == 'Debian'
+  retries: 3
+  delay: 5
 
 - name: Tools | Install misc tools (RedHat)
   ansible.builtin.dnf:
     name: '{{ __development_misc_packages }}'
     state: present
   when: ansible_facts['os_family'] == 'RedHat'
+  retries: 3
+  delay: 5
 
 - name: Tools | Manage httpie (Arch)
   community.general.pacman:
     name: '{{ __development_httpie_package }}'
     state: "{{ 'present' if development_httpie_enabled | bool else 'absent' }}"
   when: ansible_facts['os_family'] == 'Archlinux'
+  retries: 3
+  delay: 5
 
 - name: Tools | Manage httpie (Debian)
   ansible.builtin.apt:
     name: '{{ __development_httpie_package }}'
     state: "{{ 'present' if development_httpie_enabled | bool else 'absent' }}"
   when: ansible_facts['os_family'] == 'Debian'
+  retries: 3
+  delay: 5
 
 - name: Tools | Manage httpie (RedHat)
   ansible.builtin.dnf:
     name: '{{ __development_httpie_package }}'
     state: "{{ 'present' if development_httpie_enabled | bool else 'absent' }}"
   when: ansible_facts['os_family'] == 'RedHat'
+  retries: 3
+  delay: 5

--- a/roles/display_manager/tasks/install.yml
+++ b/roles/display_manager/tasks/install.yml
@@ -38,3 +38,5 @@
     name: '{{ __display_manager_install_packages }}'
     state: present
   when: __display_manager_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/downloads/tasks/install.yml
+++ b/roles/downloads/tasks/install.yml
@@ -10,6 +10,8 @@
   when:
     - downloads_transmission_enabled | bool
     - __downloads_transmission_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | qBittorrent
   ansible.builtin.package:
@@ -18,6 +20,8 @@
   when:
     - downloads_qbittorrent_enabled | bool
     - __downloads_qbittorrent_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Deluge
   ansible.builtin.package:
@@ -26,6 +30,8 @@
   when:
     - downloads_deluge_enabled | bool
     - __downloads_deluge_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 #
 # Video Downloaders
@@ -38,6 +44,8 @@
   when:
     - downloads_ytdlp_enabled | bool
     - __downloads_ytdlp_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 #
 # Download Managers
@@ -50,6 +58,8 @@
   when:
     - downloads_aria2_enabled | bool
     - __downloads_aria2_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | uGet
   ansible.builtin.package:
@@ -58,6 +68,8 @@
   when:
     - downloads_uget_enabled | bool
     - __downloads_uget_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 #
 # AUR Packages
@@ -72,3 +84,5 @@
   when:
     - downloads_jdownloader_enabled | bool
     - ansible_facts['os_family'] == 'Archlinux'
+  retries: 3
+  delay: 5

--- a/roles/elgato/tasks/install.yml
+++ b/roles/elgato/tasks/install.yml
@@ -16,6 +16,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - elgato_streamdeck_enabled | bool
+  retries: 3
+  delay: 5
 
 #
 # Facecam
@@ -28,6 +30,8 @@
   when:
     - elgato_facecam_enabled | bool
     - __elgato_facecam_packages | default([]) | length > 0
+  retries: 3
+  delay: 5
 
 #
 # Key Light
@@ -42,3 +46,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - elgato_keylight_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/filemanagers/tasks/install.yml
+++ b/roles/filemanagers/tasks/install.yml
@@ -9,6 +9,8 @@
     state: present
   when:
     - filemanagers_vifm_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Midnight Commander
   ansible.builtin.package:
@@ -16,6 +18,8 @@
     state: present
   when:
     - filemanagers_mc_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | ranger
   ansible.builtin.package:
@@ -23,6 +27,8 @@
     state: present
   when:
     - filemanagers_ranger_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | nnn
   ansible.builtin.package:
@@ -30,6 +36,8 @@
     state: present
   when:
     - filemanagers_nnn_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | lf
   ansible.builtin.package:
@@ -38,6 +46,8 @@
   when:
     - filemanagers_lf_enabled | bool
     - __filemanagers_lf_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 #
 # GUI File Managers
@@ -49,6 +59,8 @@
     state: present
   when:
     - filemanagers_thunar_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Dolphin
   ansible.builtin.package:
@@ -56,6 +68,8 @@
     state: present
   when:
     - filemanagers_dolphin_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Nautilus
   ansible.builtin.package:
@@ -63,6 +77,8 @@
     state: present
   when:
     - filemanagers_nautilus_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | PCManFM
   ansible.builtin.package:
@@ -70,6 +86,8 @@
     state: present
   when:
     - filemanagers_pcmanfm_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Nemo
   ansible.builtin.package:
@@ -77,6 +95,8 @@
     state: present
   when:
     - filemanagers_nemo_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Double Commander
   ansible.builtin.package:
@@ -85,3 +105,5 @@
   when:
     - filemanagers_doublecmd_enabled | bool
     - __filemanagers_doublecmd_package | default('') | length > 0
+  retries: 3
+  delay: 5

--- a/roles/gaming/tasks/install.yml
+++ b/roles/gaming/tasks/install.yml
@@ -10,6 +10,8 @@
   when:
     - gaming_lutris_enabled | bool
     - __gaming_lutris_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Steam
   ansible.builtin.package:
@@ -18,6 +20,8 @@
   when:
     - gaming_steam_enabled | bool
     - __gaming_steam_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | RetroArch
   ansible.builtin.package:
@@ -26,6 +30,8 @@
   when:
     - gaming_retroarch_enabled | bool
     - __gaming_retroarch_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | PCSX2
   ansible.builtin.package:
@@ -35,6 +41,8 @@
     - gaming_pcsx2_enabled | bool
     - __gaming_pcsx2_package | default('') | length > 0
     - ansible_facts['os_family'] != 'Archlinux'
+  retries: 3
+  delay: 5
 
 - name: Install | Dolphin Emulator
   ansible.builtin.package:
@@ -43,6 +51,8 @@
   when:
     - gaming_dolphin_enabled | bool
     - __gaming_dolphin_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Moonlight
   ansible.builtin.package:
@@ -51,6 +61,8 @@
   when:
     - gaming_moonlight_enabled | bool
     - __gaming_moonlight_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 #
 # AUR Packages (Arch Linux)
@@ -65,6 +77,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - gaming_heroic_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Playback from AUR (Arch)
   become: true
@@ -75,6 +89,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - gaming_playback_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | PCSX2 from AUR (Arch)
   become: true
@@ -85,3 +101,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - gaming_pcsx2_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/graphics_apps/tasks/install.yml
+++ b/roles/graphics_apps/tasks/install.yml
@@ -5,6 +5,8 @@
     state: present
   when:
     - graphics_apps_gimp_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | GIMP plugins
   ansible.builtin.package:
@@ -13,6 +15,8 @@
   when:
     - graphics_apps_gimp_enabled | bool
     - graphics_apps_gimp_plugins | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Krita
   ansible.builtin.package:
@@ -21,6 +25,8 @@
   when:
     - graphics_apps_krita_enabled | bool
     - __graphics_apps_krita_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Inkscape
   ansible.builtin.package:
@@ -28,6 +34,8 @@
     state: present
   when:
     - graphics_apps_inkscape_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | XnConvert from AUR (Arch)
   become: true
@@ -38,6 +46,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - graphics_apps_xnconvert_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | XnView from AUR (Arch)
   become: true
@@ -48,3 +58,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - graphics_apps_xnview_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/imaging/tasks/install.yml
+++ b/roles/imaging/tasks/install.yml
@@ -13,6 +13,8 @@
   tags:
     - imaging
     - imaging:vuescan
+  retries: 3
+  delay: 5
 
 - name: Install | Warn if VueScan installation failed
   ansible.builtin.debug:
@@ -35,6 +37,8 @@
   tags:
     - imaging
     - imaging:sane
+  retries: 3
+  delay: 5
 
 - name: Install | XSane from AUR (Arch)
   become: true
@@ -48,6 +52,8 @@
   tags:
     - imaging
     - imaging:xsane
+  retries: 3
+  delay: 5
 
 - name: Install | XSane scanning frontend
   ansible.builtin.package:
@@ -59,6 +65,8 @@
   tags:
     - imaging
     - imaging:xsane
+  retries: 3
+  delay: 5
 
 - name: Install | Simple Scan
   ansible.builtin.package:
@@ -68,6 +76,8 @@
   tags:
     - imaging
     - imaging:simple-scan
+  retries: 3
+  delay: 5
 
 - name: Install | Skanlite scanning application
   ansible.builtin.package:
@@ -77,6 +87,8 @@
   tags:
     - imaging
     - imaging:skanlite
+  retries: 3
+  delay: 5
 
 - name: Install | ImageMagick
   ansible.builtin.package:
@@ -86,6 +98,8 @@
   tags:
     - imaging
     - imaging:imagemagick
+  retries: 3
+  delay: 5
 
 - name: Install | GraphicsMagick
   ansible.builtin.package:
@@ -95,3 +109,5 @@
   tags:
     - imaging
     - imaging:graphicsmagick
+  retries: 3
+  delay: 5

--- a/roles/keepassxc/tasks/install.yml
+++ b/roles/keepassxc/tasks/install.yml
@@ -8,6 +8,8 @@
     name: '{{ __keepassxc_package }}'
     state: present
   when: keepassxc_install_package_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Verify KeePassXC binary exists
   ansible.builtin.command:

--- a/roles/multimedia/tasks/install.yml
+++ b/roles/multimedia/tasks/install.yml
@@ -4,18 +4,24 @@
     name: '{{ __multimedia_vlc_package }}'
     state: present
   when: multimedia_vlc_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | MPV packages
   ansible.builtin.package:
     name: '{{ __multimedia_mpv_package }}'
     state: present
   when: multimedia_mpv_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Audacity packages
   ansible.builtin.package:
     name: '{{ __multimedia_audacity_package }}'
     state: present
   when: multimedia_audacity_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Ardour packages
   ansible.builtin.package:
@@ -24,18 +30,24 @@
   when:
     - multimedia_ardour_enabled | bool
     - __multimedia_ardour_package | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Kdenlive packages
   ansible.builtin.package:
     name: '{{ __multimedia_kdenlive_package }}'
     state: present
   when: multimedia_kdenlive_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | OpenShot packages
   ansible.builtin.package:
     name: '{{ __multimedia_openshot_package }}'
     state: present
   when: multimedia_openshot_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | FFMultiConverter from AUR (Arch)
   become: true
@@ -46,6 +58,8 @@
   when:
     - multimedia_ffmulticonverter_enabled | bool
     - ansible_facts['os_family'] == 'Archlinux'
+  retries: 3
+  delay: 5
 
 - name: Install | FFMultiConverter packages (Debian)
   ansible.builtin.package:
@@ -55,6 +69,8 @@
     - multimedia_ffmulticonverter_enabled | bool
     - ansible_facts['os_family'] != 'Archlinux'
     - __multimedia_ffmulticonverter_package | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | HandBrake packages
   ansible.builtin.package:
@@ -63,18 +79,24 @@
   when:
     - multimedia_handbrake_enabled | bool
     - __multimedia_handbrake_package | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Peek packages
   ansible.builtin.package:
     name: '{{ __multimedia_peek_package }}'
     state: present
   when: multimedia_peek_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | OBS Studio packages
   ansible.builtin.package:
     name: '{{ __multimedia_obs_package }}'
     state: present
   when: multimedia_obs_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | SimpleScreenRecorder packages
   ansible.builtin.package:
@@ -83,15 +105,21 @@
   when:
     - multimedia_simplescreenrecorder_enabled | bool
     - __multimedia_simplescreenrecorder_package | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Rhythmbox packages
   ansible.builtin.package:
     name: '{{ __multimedia_rhythmbox_package }}'
     state: present
   when: multimedia_rhythmbox_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Cava packages
   ansible.builtin.package:
     name: '{{ __multimedia_cava_package }}'
     state: present
   when: multimedia_cava_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/office/tasks/install.yml
+++ b/roles/office/tasks/install.yml
@@ -10,6 +10,8 @@
          ternary(__office_libreoffice_fresh_package, __office_libreoffice_still_package) }}
     state: present
   when: office_libreoffice_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | LibreOffice language pack
   ansible.builtin.package:
@@ -18,6 +20,8 @@
   when:
     - office_libreoffice_enabled | bool
     - office_libreoffice_i18n | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | OnlyOffice from AUR (Arch)
   become: true
@@ -28,6 +32,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - office_onlyoffice_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | WPS Office from AUR (Arch)
   become: true
@@ -38,6 +44,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - office_wps_enabled | bool
+  retries: 3
+  delay: 5
 
 #
 # PDF Tools
@@ -48,12 +56,16 @@
     name: '{{ __office_pdf_viewers[office_pdf_viewer] }}'
     state: present
   when: office_pdf_viewer | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | PDF command line tools
   ansible.builtin.package:
     name: '{{ __office_pdf_tools_packages }}'
     state: present
   when: office_pdf_tools_enabled | bool
+  retries: 3
+  delay: 5
 
 #
 # Email Clients
@@ -64,6 +76,8 @@
     name: '{{ __office_thunderbird_package }}'
     state: present
   when: office_thunderbird_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Thunderbird language pack
   ansible.builtin.package:
@@ -72,12 +86,16 @@
   when:
     - office_thunderbird_enabled | bool
     - office_thunderbird_i18n | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Evolution
   ansible.builtin.package:
     name: '{{ __office_evolution_package }}'
     state: present
   when: office_evolution_enabled | bool
+  retries: 3
+  delay: 5
 
 #
 # Calendar / PIM
@@ -90,6 +108,8 @@
   when:
     - office_gnome_calendar_enabled | bool
     - __office_gnome_calendar_package | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | GNOME Contacts
   ansible.builtin.package:
@@ -98,6 +118,8 @@
   when:
     - office_gnome_contacts_enabled | bool
     - __office_gnome_contacts_package | length > 0
+  retries: 3
+  delay: 5
 
 #
 # Note Taking
@@ -112,6 +134,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - office_obsidian_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Logseq from AUR (Arch)
   become: true
@@ -122,6 +146,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - office_logseq_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Joplin from AUR (Arch)
   become: true
@@ -132,6 +158,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - office_joplin_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Simplenote from AUR (Arch)
   become: true
@@ -142,6 +170,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - office_simplenote_enabled | bool
+  retries: 3
+  delay: 5
 
 #
 # Document Tools
@@ -156,12 +186,16 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - office_typora_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | TeXstudio
   ansible.builtin.package:
     name: '{{ __office_texstudio_package }}'
     state: present
   when: office_texstudio_enabled | bool
+  retries: 3
+  delay: 5
 
 #
 # OCR
@@ -172,6 +206,8 @@
     name: '{{ __office_tesseract_package }}'
     state: present
   when: office_ocr_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Tesseract language data
   ansible.builtin.package:
@@ -179,6 +215,8 @@
     state: present
   loop: '{{ office_ocr_languages }}'
   when: office_ocr_enabled | bool
+  retries: 3
+  delay: 5
 
 #
 # Scanning
@@ -189,6 +227,8 @@
     name: '{{ __office_simple_scan_package }}'
     state: present
   when: office_simple_scan_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | gscan2pdf
   ansible.builtin.package:
@@ -197,6 +237,8 @@
   when:
     - office_gscan2pdf_enabled | bool
     - __office_gscan2pdf_package | length > 0
+  retries: 3
+  delay: 5
 
 #
 # Ebook
@@ -207,6 +249,8 @@
     name: '{{ __office_calibre_package }}'
     state: present
   when: office_calibre_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Foliate
   ansible.builtin.package:
@@ -215,6 +259,8 @@
   when:
     - office_foliate_enabled | bool
     - __office_foliate_package | length > 0
+  retries: 3
+  delay: 5
 
 #
 # Spell Checking
@@ -225,6 +271,8 @@
     name: '{{ __office_hunspell_packages }}'
     state: present
   when: office_hunspell_enabled | bool
+  retries: 3
+  delay: 5
 
 #
 # Fonts
@@ -235,3 +283,5 @@
     name: '{{ __office_fonts_packages }}'
     state: present
   when: office_fonts_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/pipewire/tasks/cleanup.yml
+++ b/roles/pipewire/tasks/cleanup.yml
@@ -8,3 +8,5 @@
     name: '{{ __pipewire_pulseaudio_packages }}'
     state: absent
   notify: Restart PipeWire
+  retries: 3
+  delay: 5

--- a/roles/pipewire/tasks/install.yml
+++ b/roles/pipewire/tasks/install.yml
@@ -34,3 +34,5 @@
     state: present
   when: __pipewire_install_packages | length > 0
   notify: Restart PipeWire
+  retries: 3
+  delay: 5

--- a/roles/pipewire/tasks/realtime.yml
+++ b/roles/pipewire/tasks/realtime.yml
@@ -8,6 +8,8 @@
     name: '{{ __pipewire_realtime_package }}'
     state: present
   when: __pipewire_realtime_package | length > 0
+  retries: 3
+  delay: 5
 
 - name: Realtime | Ensure realtime group exists
   ansible.builtin.group:

--- a/roles/plymouth/tasks/install.yml
+++ b/roles/plymouth/tasks/install.yml
@@ -13,3 +13,5 @@
     name: '{{ __plymouth_install_packages }}'
     state: present
   when: __plymouth_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/remote_access/tasks/install.yml
+++ b/roles/remote_access/tasks/install.yml
@@ -10,6 +10,8 @@
   when:
     - remote_access_remmina_enabled | bool
     - __remote_access_remmina_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | TigerVNC packages
   ansible.builtin.package:
@@ -18,6 +20,8 @@
   when:
     - remote_access_tigervnc_enabled | bool
     - __remote_access_tigervnc_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | FreeRDP packages
   ansible.builtin.package:
@@ -26,6 +30,8 @@
   when:
     - remote_access_freerdp_enabled | bool
     - __remote_access_freerdp_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 #
 # AUR Packages (Arch Only)
@@ -40,6 +46,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - remote_access_rustdesk_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Asbru from AUR (Arch)
   become: true
@@ -50,6 +58,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - remote_access_asbru_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | RealVNC Viewer from AUR (Arch)
   become: true
@@ -60,6 +70,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - remote_access_realvnc_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | AnyDesk from AUR (Arch)
   become: true
@@ -70,6 +82,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - remote_access_anydesk_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | TeamViewer from AUR (Arch)
   become: true
@@ -80,3 +94,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - remote_access_teamviewer_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/security_apps/tasks/install.yml
+++ b/roles/security_apps/tasks/install.yml
@@ -6,6 +6,8 @@
   when:
     - security_apps_veracrypt_enabled | bool
     - __security_apps_packages.veracrypt is defined
+  retries: 3
+  delay: 5
 
 - name: Install | ClamTk packages
   ansible.builtin.package:
@@ -14,6 +16,8 @@
   when:
     - security_apps_clamtk_enabled | bool
     - __security_apps_packages.clamtk is defined
+  retries: 3
+  delay: 5
 
 - name: Install | Gufw packages
   ansible.builtin.package:
@@ -22,6 +26,8 @@
   when:
     - security_apps_gufw_enabled | bool
     - __security_apps_packages.gufw is defined
+  retries: 3
+  delay: 5
 
 - name: Install | Cypherock CySync from AUR (Arch)
   become: true
@@ -32,6 +38,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - security_apps_cypherock_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Ledger Live from AUR (Arch)
   become: true
@@ -42,6 +50,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - security_apps_ledger_enabled | bool
+  retries: 3
+  delay: 5
 
 - name: Install | Trezor Suite from AUR (Arch)
   become: true
@@ -52,3 +62,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - security_apps_trezor_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/shell/tasks/install.yml
+++ b/roles/shell/tasks/install.yml
@@ -34,3 +34,5 @@
     name: '{{ __shell_install_packages }}'
     state: present
   when: __shell_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/shell/tasks/ohmyzsh.yml
+++ b/roles/shell/tasks/ohmyzsh.yml
@@ -20,6 +20,8 @@
   become_user: '{{ item }}'
   loop: '{{ __shell_ohmyzsh_users }}'
   when: shell_user_config_mode != 'disabled'
+  retries: 5
+  delay: 10
 
 - name: OhMyZsh | Clone custom plugins  # noqa: latest[git]
   ansible.builtin.git:
@@ -36,6 +38,8 @@
   when:
     - shell_user_config_mode != 'disabled'
     - shell_ohmyzsh_custom_plugins | length > 0
+  retries: 5
+  delay: 10
 
 - name: OhMyZsh | Deploy .zshrc
   ansible.builtin.template:

--- a/roles/system_apps/tasks/install.yml
+++ b/roles/system_apps/tasks/install.yml
@@ -6,6 +6,8 @@
   when:
     - system_apps_gparted_enabled | bool
     - __system_apps_gparted_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Filelight
   ansible.builtin.package:
@@ -14,6 +16,8 @@
   when:
     - system_apps_filelight_enabled | bool
     - __system_apps_filelight_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Baobab
   ansible.builtin.package:
@@ -22,6 +26,8 @@
   when:
     - system_apps_baobab_enabled | bool
     - __system_apps_baobab_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Solaar
   ansible.builtin.package:
@@ -30,6 +36,8 @@
   when:
     - system_apps_solaar_enabled | bool
     - __system_apps_solaar_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | GNOME System Monitor
   ansible.builtin.package:
@@ -38,6 +46,8 @@
   when:
     - system_apps_gnome_system_monitor_enabled | bool
     - __system_apps_gnome_system_monitor_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Plasma System Monitor
   ansible.builtin.package:
@@ -46,6 +56,8 @@
   when:
     - system_apps_plasma_system_monitor_enabled | bool
     - __system_apps_plasma_system_monitor_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Timeshift
   ansible.builtin.package:
@@ -54,6 +66,8 @@
   when:
     - system_apps_timeshift_enabled | bool
     - __system_apps_timeshift_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: "Install | D\xE9j\xE0 Dup"
   ansible.builtin.package:
@@ -62,6 +76,8 @@
   when:
     - system_apps_deja_dup_enabled | bool
     - __system_apps_deja_dup_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Seahorse
   ansible.builtin.package:
@@ -70,6 +86,8 @@
   when:
     - system_apps_seahorse_enabled | bool
     - __system_apps_seahorse_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | dconf Editor
   ansible.builtin.package:
@@ -78,3 +96,5 @@
   when:
     - system_apps_dconf_editor_enabled | bool
     - __system_apps_dconf_editor_package | default('') | length > 0
+  retries: 3
+  delay: 5

--- a/roles/terminal/tasks/install.yml
+++ b/roles/terminal/tasks/install.yml
@@ -26,6 +26,8 @@
     name: '{{ __terminal_install_packages }}'
     state: present
   when: __terminal_install_packages | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Note about unavailable terminals
   ansible.builtin.debug:

--- a/roles/tuxedo/tasks/install.yml
+++ b/roles/tuxedo/tasks/install.yml
@@ -12,6 +12,8 @@
   when:
     - tuxedo_drivers_enabled | bool or tuxedo_yt6801_ethernet_enabled | bool
     - __tuxedo_dkms_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Detect running kernel package
   ansible.builtin.command:
@@ -27,6 +29,8 @@
   when:
     - tuxedo_drivers_enabled | bool or tuxedo_yt6801_ethernet_enabled | bool
     - __tuxedo_kernel_package is not skipped
+  retries: 3
+  delay: 5
 
 # Tuxedo drivers (DKMS)
 
@@ -39,6 +43,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - tuxedo_drivers_enabled | bool
+  retries: 3
+  delay: 5
 
 # Tuxedo Control Center
 
@@ -51,6 +57,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - tuxedo_control_center_enabled | bool
+  retries: 3
+  delay: 5
 
 # YT6801 Ethernet driver (optional, Gen9/Gen10)
 
@@ -63,3 +71,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - tuxedo_yt6801_ethernet_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/wayland_utils/tasks/install.yml
+++ b/roles/wayland_utils/tasks/install.yml
@@ -44,6 +44,8 @@
     name: '{{ __wayland_utils_packages }}'
     state: present
   when: __wayland_utils_packages | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Build AUR package list (Arch)
   ansible.builtin.set_fact:
@@ -63,3 +65,5 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __wayland_utils_aur_install_list | length > 0
+  retries: 3
+  delay: 5

--- a/roles/wine/tasks/install.yml
+++ b/roles/wine/tasks/install.yml
@@ -30,6 +30,8 @@
   ansible.builtin.package:
     name: '{{ __wine_package_variants[wine_variant] | default(__wine_package_variants["stable"]) }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Winetricks
   ansible.builtin.package:
@@ -38,6 +40,8 @@
   when:
     - wine_winetricks_enabled | bool
     - __wine_winetricks_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Wine Mono
   ansible.builtin.package:
@@ -46,6 +50,8 @@
   when:
     - wine_mono_enabled | bool
     - __wine_mono_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 - name: Install | Wine Gecko
   ansible.builtin.package:
@@ -54,6 +60,8 @@
   when:
     - wine_gecko_enabled | bool
     - __wine_gecko_package | default('') | length > 0
+  retries: 3
+  delay: 5
 
 #
 # 32-bit Support (Arch Linux)
@@ -66,6 +74,8 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - wine_lib32_packages | default([]) | length > 0
+  retries: 3
+  delay: 5
 
 #
 # GPU Vulkan Driver Detection (Arch Linux)
@@ -110,3 +120,5 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - __wine_gpu_vendor | default('none') != 'none'
     - __wine_gpu_vendor in (__wine_vulkan_drivers | default({}))
+  retries: 3
+  delay: 5


### PR DESCRIPTION
## Summary

- Add `retries`/`delay` to 232 network-dependent tasks across 27 roles
- Package installs (`package`, `apt`, `dnf`, `pacman`, `aur`, `pipx`, `npm`, `pip`): `retries: 3`, `delay: 5`
- Downloads/git clones (`get_url`, `git`): `retries: 5`, `delay: 10`

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)