### PR TITLE
chore(ci): Add CI Gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,3 +272,30 @@ jobs:
           name: collection-tarball
           path: '*.tar.gz'
           retention-days: 30
+
+  # =============================================================================
+  # CI GATE (single required check for branch protection)
+  # =============================================================================
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [lint, markdown-lint, yaml-lint, build, molecule-compat, molecule-roles]
+    steps:
+      - name: Check required job results
+        run: |
+          results=(
+            "${{ needs.lint.result }}"
+            "${{ needs.markdown-lint.result }}"
+            "${{ needs.yaml-lint.result }}"
+            "${{ needs.build.result }}"
+            "${{ needs.molecule-compat.result }}"
+            "${{ needs.molecule-roles.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "::error::Required job failed or was cancelled: $r"
+              exit 1
+            fi
+          done
+          echo "All required jobs passed or were skipped"


### PR DESCRIPTION
## Summary

- Add `ci-gate` job that waits for all CI jobs (lint, build, compat, molecule) before reporting success
- Allows branch protection to use a single `CI Gate` required check instead of listing individual jobs
- Prevents merging before molecule tests complete (fixes the gap where only linters were required)

## Follow-up

After merge, update branch protection:
- Remove individual required checks (Ansible Lint, YAML Lint, Markdown Lint, Build Collection)
- Add `CI Gate` as the sole required check

🤖 Generated with [Claude Code](https://claude.com/claude-code)