### PR TITLE
docs(shell): Add deprecation notice for zsh defaults

### DIFF
--- a/roles/shell/defaults/main.yml
+++ b/roles/shell/defaults/main.yml
@@ -11,6 +11,7 @@ shell_enabled: true
 #
 
 # Default shell for users: zsh, fish, bash
+# DEPRECATED: Default will change to 'bash' in v2.0.0
 shell_default: 'zsh'
 
 # Users to change shell for (empty = all users from users_list)
@@ -24,6 +25,7 @@ shell_user_config_mode: 'managed'
 #
 
 # Enable Zsh installation
+# DEPRECATED: Default will change to 'false' in v2.0.0
 shell_zsh_enabled: true
 
 # Zsh framework: native (system packages) or ohmyzsh (Oh My Zsh per-user install)


### PR DESCRIPTION
## Summary

- Mark `shell_default` ('zsh') and `shell_zsh_enabled` (true) as deprecated in defaults
- Defaults will change to bash/false in v2.0.0

Refs: #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)