### PR TITLE
fix(playbooks): Correct role gate conditions in desktop_workstation

### DIFF
--- a/playbooks/desktop_workstation.yml
+++ b/playbooks/desktop_workstation.yml
@@ -51,13 +51,13 @@
       ansible.builtin.include_role:
         name: marcstraube.desktop.terminal
       tags: [terminal]
-      when: terminal_ghostty_enabled | default(true) | bool
+      when: terminal_enabled | default(true) | bool
 
     - name: Shell | Include shell role
       ansible.builtin.include_role:
         name: marcstraube.desktop.shell
       tags: [shell]
-      when: shell_zsh_enabled | default(true) | bool
+      when: shell_enabled | default(true) | bool
 
     - name: PipeWire | Include pipewire role
       ansible.builtin.include_role:
@@ -84,7 +84,7 @@
       ansible.builtin.include_role:
         name: marcstraube.desktop.browser
       tags: [browser]
-      when: browser_firefox_enabled | default(true) | bool
+      when: browser_enabled | default(true) | bool
 
     - name: KeePassXC | Include keepassxc role
       ansible.builtin.include_role:


### PR DESCRIPTION
## Summary

- `terminal_ghostty_enabled` → `terminal_enabled`
- `shell_zsh_enabled` → `shell_enabled`
- `browser_firefox_enabled` → `browser_enabled`

These gates should match the role's top-level `_enabled` toggle, not a sub-feature toggle.

## Test plan

- [ ] `ansible-playbook marcstraube.desktop.desktop_workstation --check` with default vars
- [ ] Verify roles are still included when only top-level toggle is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)