### PR TITLE
fix(plymouth): Add --all argument to HSM sign script call

### DIFF
--- a/roles/plymouth/tasks/kernel.yml
+++ b/roles/plymouth/tasks/kernel.yml
@@ -50,7 +50,7 @@
 
 - name: Kernel | Re-sign boot files (HSM)
   ansible.builtin.command:
-    cmd: /usr/local/bin/secureboot-hsm-sign.sh
+    cmd: /usr/local/bin/secureboot-hsm-sign.sh --all
   changed_when: true
   when:
     - ansible_facts['os_family'] == 'Archlinux'


### PR DESCRIPTION
## Summary

The `secureboot-hsm-sign.sh` script requires an explicit mode argument. Calling it bare prints usage and exits non-zero, so the post-GRUB re-sign step fails on HSM-signed hosts.

Same bug as marcstraube/ansible-collection-common#70.

## Changes

- `roles/plymouth/tasks/kernel.yml`: invoke script with `--all`

## Test plan

- [ ] Plymouth GRUB regeneration triggers successful HSM re-signing on a host with `secureboot_method: hsm`

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)