### PR TITLE
refactor(playbooks): Extract desktop_workstation tasks + align with common patterns

### DIFF
--- a/playbooks/desktop_workstation.yml
+++ b/playbooks/desktop_workstation.yml
@@ -3,12 +3,13 @@
 # Desktop Workstation Playbook
 # =============================================================================
 # Desktop collection roles only. For a full deployment including base system,
-# security, and other cross-collection dependencies, use:
-#   ansible-playbook playbooks/desktop.yml
+# security, and other cross-collection dependencies, use the infra playbooks.
 #
 # Usage:
 #   ansible-playbook marcstraube.desktop.desktop_workstation \
 #     -i inventories/homelab --limit enterprise
+#   ansible-playbook marcstraube.desktop.desktop_workstation \
+#     -i inventories/homelab --tags browser
 # =============================================================================
 
 - name: Deploy Desktop Workstation
@@ -27,175 +28,10 @@
           - 'Desktop:           {{ desktop_environment_list | default(["hyprland"]) | join(", ") }}'
           - 'Display manager:   {{ display_manager_name | default("greetd") }}'
           - '============================================================'
+      tags:
+        - always
 
   tasks:
-    # -----------------------------------------------------------------
-    # DESKTOP ENVIRONMENT
-    # -----------------------------------------------------------------
-    - name: Desktop | Include desktop_environment role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.desktop_environment
-      tags: [desktop]
-      when: desktop_environment_enabled | default(true) | bool
-
-    - name: Display Manager | Include display_manager role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.display_manager
-      tags: [display-manager]
-      when: display_manager_enabled | default(true) | bool
-
-    # -----------------------------------------------------------------
-    # CORE DESKTOP
-    # -----------------------------------------------------------------
-    - name: Terminal | Include terminal role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.terminal
-      tags: [terminal]
-      when: terminal_enabled | default(true) | bool
-
-    - name: Shell | Include shell role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.shell
-      tags: [shell]
-      when: shell_enabled | default(true) | bool
-
-    - name: PipeWire | Include pipewire role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.pipewire
-      tags: [pipewire]
-      when: pipewire_enabled | default(true) | bool
-
-    - name: Bluetooth | Include bluetooth role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.bluetooth
-      tags: [bluetooth]
-      when: bluetooth_enabled | default(true) | bool
-
-    - name: File Managers | Include filemanagers role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.filemanagers
-      tags: [filemanagers]
-      when: filemanagers_enabled | default(false) | bool
-
-    # -----------------------------------------------------------------
-    # PRODUCTIVITY
-    # -----------------------------------------------------------------
-    - name: Browser | Include browser role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.browser
-      tags: [browser]
-      when: browser_enabled | default(true) | bool
-
-    - name: KeePassXC | Include keepassxc role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.keepassxc
-      tags: [keepassxc]
-      when: keepassxc_enabled | default(true) | bool
-
-    - name: Office | Include office role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.office
-      tags: [office]
-      when: office_libreoffice_enabled | default(true) | bool
-
-    # -----------------------------------------------------------------
-    # DEVELOPMENT
-    # -----------------------------------------------------------------
-    - name: Development | Include development role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.development
-      tags: [development]
-      when: development_enabled | default(true) | bool
-
-    # -----------------------------------------------------------------
-    # AI TOOLS
-    # -----------------------------------------------------------------
-    - name: AI | Include ai role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.ai
-      tags: [ai]
-      when: ai_enabled | default(false) | bool
-
-    # -----------------------------------------------------------------
-    # APPLICATIONS
-    # -----------------------------------------------------------------
-    - name: Multimedia | Include multimedia role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.multimedia
-      tags: [multimedia]
-      when: multimedia_enabled | default(false) | bool
-
-    - name: Graphics Apps | Include graphics_apps role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.graphics_apps
-      tags: [graphics-apps]
-      when: graphics_apps_enabled | default(false) | bool
-
-    - name: CAD | Include cad role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.cad
-      tags: [cad]
-      when: cad_enabled | default(false) | bool
-
-    - name: Imaging | Include imaging role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.imaging
-      tags: [imaging]
-      when: imaging_enabled | default(false) | bool
-
-    - name: Downloads | Include downloads role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.downloads
-      tags: [downloads]
-      when: downloads_enabled | default(false) | bool
-
-    - name: Gaming | Include gaming role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.gaming
-      tags: [gaming]
-      when: gaming_enabled | default(false) | bool
-
-    - name: Communication | Include communication role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.communication
-      tags: [communication]
-      when: communication_enabled | default(false) | bool
-
-    - name: Remote Access | Include remote_access role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.remote_access
-      tags: [remote-access]
-      when: remote_access_enabled | default(false) | bool
-
-    - name: Security Apps | Include security_apps role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.security_apps
-      tags: [security-apps]
-      when: security_apps_enabled | default(false) | bool
-
-    - name: System Apps | Include system_apps role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.system_apps
-      tags: [system-apps]
-      when: system_apps_enabled | default(false) | bool
-
-    - name: Tabletop | Include tabletop role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.tabletop
-      tags: [tabletop]
-      when: tabletop_enabled | default(false) | bool
-
-    # -----------------------------------------------------------------
-    # PERIPHERALS
-    # -----------------------------------------------------------------
-    - name: Elgato | Include elgato role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.elgato
-      tags: [elgato]
-      when: elgato_enabled | default(false) | bool
-
-    - name: Tuxedo | Include tuxedo role
-      ansible.builtin.include_role:
-        name: marcstraube.desktop.tuxedo
-      tags: [tuxedo]
-      when: tuxedo_enabled | default(false) | bool
+    - name: Desktop | Import desktop workstation tasks
+      ansible.builtin.import_tasks:
+        file: tasks/desktop_workstation.yml

--- a/playbooks/desktop_workstation.yml
+++ b/playbooks/desktop_workstation.yml
@@ -17,20 +17,6 @@
   become: true
   gather_facts: true
 
-  pre_tasks:
-    - name: Pretasks | Display configuration
-      ansible.builtin.debug:
-        msg:
-          - '============================================================'
-          - 'DESKTOP WORKSTATION CONFIGURATION'
-          - '============================================================'
-          - 'Host:              {{ inventory_hostname }}'
-          - 'Desktop:           {{ desktop_environment_list | default(["hyprland"]) | join(", ") }}'
-          - 'Display manager:   {{ display_manager_name | default("greetd") }}'
-          - '============================================================'
-      tags:
-        - always
-
   tasks:
     - name: Desktop | Import desktop workstation tasks
       ansible.builtin.import_tasks:

--- a/playbooks/tasks/desktop_workstation.yml
+++ b/playbooks/tasks/desktop_workstation.yml
@@ -1,0 +1,331 @@
+---
+# =============================================================================
+# Desktop Workstation Tasks
+# =============================================================================
+# Task file for desktop workstation configuration — single source of truth.
+# Imported by playbooks/desktop_workstation.yml (standalone) and infra playbooks.
+#
+# Roles default to enabled or disabled as shown — override via inventory.
+# See each role's defaults/main.yml for available variables.
+# =============================================================================
+
+# -----------------------------------------------------------------
+# DESKTOP ENVIRONMENT
+# -----------------------------------------------------------------
+- name: Desktop | Include desktop_environment role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.desktop_environment
+    apply:
+      tags:
+        - desktop
+        - desktop-environment
+  tags:
+    - desktop
+    - desktop-environment
+  when: desktop_environment_enabled | default(true) | bool
+
+- name: Desktop | Include display_manager role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.display_manager
+    apply:
+      tags:
+        - desktop
+        - display-manager
+  tags:
+    - desktop
+    - display-manager
+  when: display_manager_enabled | default(true) | bool
+
+# -----------------------------------------------------------------
+# CORE DESKTOP
+# -----------------------------------------------------------------
+- name: Desktop | Include terminal role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.terminal
+    apply:
+      tags:
+        - desktop
+        - terminal
+  tags:
+    - desktop
+    - terminal
+  when: terminal_enabled | default(true) | bool
+
+- name: Desktop | Include shell role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.shell
+    apply:
+      tags:
+        - desktop
+        - shell
+  tags:
+    - desktop
+    - shell
+  when: shell_enabled | default(true) | bool
+
+- name: Desktop | Include pipewire role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.pipewire
+    apply:
+      tags:
+        - desktop
+        - pipewire
+  tags:
+    - desktop
+    - pipewire
+  when: pipewire_enabled | default(true) | bool
+
+- name: Desktop | Include bluetooth role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.bluetooth
+    apply:
+      tags:
+        - desktop
+        - bluetooth
+  tags:
+    - desktop
+    - bluetooth
+  when: bluetooth_enabled | default(true) | bool
+
+- name: Desktop | Include filemanagers role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.filemanagers
+    apply:
+      tags:
+        - desktop
+        - filemanagers
+  tags:
+    - desktop
+    - filemanagers
+  when: filemanagers_enabled | default(false) | bool
+
+# -----------------------------------------------------------------
+# PRODUCTIVITY
+# -----------------------------------------------------------------
+- name: Desktop | Include browser role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.browser
+    apply:
+      tags:
+        - desktop
+        - browser
+  tags:
+    - desktop
+    - browser
+  when: browser_enabled | default(true) | bool
+
+- name: Desktop | Include keepassxc role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.keepassxc
+    apply:
+      tags:
+        - desktop
+        - keepassxc
+  tags:
+    - desktop
+    - keepassxc
+  when: keepassxc_enabled | default(true) | bool
+
+- name: Desktop | Include office role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.office
+    apply:
+      tags:
+        - desktop
+        - office
+  tags:
+    - desktop
+    - office
+  when: office_libreoffice_enabled | default(true) | bool
+
+# -----------------------------------------------------------------
+# DEVELOPMENT
+# -----------------------------------------------------------------
+- name: Desktop | Include development role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.development
+    apply:
+      tags:
+        - desktop
+        - development
+  tags:
+    - desktop
+    - development
+  when: development_enabled | default(true) | bool
+
+# -----------------------------------------------------------------
+# AI TOOLS
+# -----------------------------------------------------------------
+- name: Desktop | Include ai role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.ai
+    apply:
+      tags:
+        - desktop
+        - ai
+  tags:
+    - desktop
+    - ai
+  when: ai_enabled | default(false) | bool
+
+# -----------------------------------------------------------------
+# APPLICATIONS
+# -----------------------------------------------------------------
+- name: Desktop | Include multimedia role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.multimedia
+    apply:
+      tags:
+        - desktop
+        - multimedia
+  tags:
+    - desktop
+    - multimedia
+  when: multimedia_enabled | default(false) | bool
+
+- name: Desktop | Include graphics_apps role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.graphics_apps
+    apply:
+      tags:
+        - desktop
+        - graphics-apps
+  tags:
+    - desktop
+    - graphics-apps
+  when: graphics_apps_enabled | default(false) | bool
+
+- name: Desktop | Include cad role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.cad
+    apply:
+      tags:
+        - desktop
+        - cad
+  tags:
+    - desktop
+    - cad
+  when: cad_enabled | default(false) | bool
+
+- name: Desktop | Include imaging role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.imaging
+    apply:
+      tags:
+        - desktop
+        - imaging
+  tags:
+    - desktop
+    - imaging
+  when: imaging_enabled | default(false) | bool
+
+- name: Desktop | Include downloads role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.downloads
+    apply:
+      tags:
+        - desktop
+        - downloads
+  tags:
+    - desktop
+    - downloads
+  when: downloads_enabled | default(false) | bool
+
+- name: Desktop | Include gaming role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.gaming
+    apply:
+      tags:
+        - desktop
+        - gaming
+  tags:
+    - desktop
+    - gaming
+  when: gaming_enabled | default(false) | bool
+
+- name: Desktop | Include communication role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.communication
+    apply:
+      tags:
+        - desktop
+        - communication
+  tags:
+    - desktop
+    - communication
+  when: communication_enabled | default(false) | bool
+
+- name: Desktop | Include remote_access role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.remote_access
+    apply:
+      tags:
+        - desktop
+        - remote-access
+  tags:
+    - desktop
+    - remote-access
+  when: remote_access_enabled | default(false) | bool
+
+- name: Desktop | Include security_apps role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.security_apps
+    apply:
+      tags:
+        - desktop
+        - security-apps
+  tags:
+    - desktop
+    - security-apps
+  when: security_apps_enabled | default(false) | bool
+
+- name: Desktop | Include system_apps role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.system_apps
+    apply:
+      tags:
+        - desktop
+        - system-apps
+  tags:
+    - desktop
+    - system-apps
+  when: system_apps_enabled | default(false) | bool
+
+- name: Desktop | Include tabletop role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.tabletop
+    apply:
+      tags:
+        - desktop
+        - tabletop
+  tags:
+    - desktop
+    - tabletop
+  when: tabletop_enabled | default(false) | bool
+
+# -----------------------------------------------------------------
+# PERIPHERALS
+# -----------------------------------------------------------------
+- name: Desktop | Include elgato role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.elgato
+    apply:
+      tags:
+        - desktop
+        - elgato
+  tags:
+    - desktop
+    - elgato
+  when: elgato_enabled | default(false) | bool
+
+- name: Desktop | Include tuxedo role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.tuxedo
+    apply:
+      tags:
+        - desktop
+        - tuxedo
+  tags:
+    - desktop
+    - tuxedo
+  when: tuxedo_enabled | default(false) | bool

--- a/playbooks/tasks/desktop_workstation.yml
+++ b/playbooks/tasks/desktop_workstation.yml
@@ -7,11 +7,15 @@
 #
 # Roles default to enabled or disabled as shown — override via inventory.
 # See each role's defaults/main.yml for available variables.
+#
+# Tag scheme:
+#   desktop       All roles in this file
+#   <role-name>   Individual role (e.g., browser, terminal)
 # =============================================================================
 
-# -----------------------------------------------------------------
-# DESKTOP ENVIRONMENT
-# -----------------------------------------------------------------
+#
+# Desktop Environment
+#
 - name: Desktop | Include desktop_environment role
   ansible.builtin.include_role:
     name: marcstraube.desktop.desktop_environment
@@ -36,9 +40,9 @@
     - display-manager
   when: display_manager_enabled | default(true) | bool
 
-# -----------------------------------------------------------------
-# CORE DESKTOP
-# -----------------------------------------------------------------
+#
+# Core Desktop
+#
 - name: Desktop | Include terminal role
   ansible.builtin.include_role:
     name: marcstraube.desktop.terminal
@@ -99,9 +103,9 @@
     - filemanagers
   when: filemanagers_enabled | default(false) | bool
 
-# -----------------------------------------------------------------
-# PRODUCTIVITY
-# -----------------------------------------------------------------
+#
+# Productivity
+#
 - name: Desktop | Include browser role
   ansible.builtin.include_role:
     name: marcstraube.desktop.browser
@@ -136,11 +140,11 @@
   tags:
     - desktop
     - office
-  when: office_libreoffice_enabled | default(true) | bool
+  when: office_enabled | default(true) | bool
 
-# -----------------------------------------------------------------
-# DEVELOPMENT
-# -----------------------------------------------------------------
+#
+# Development
+#
 - name: Desktop | Include development role
   ansible.builtin.include_role:
     name: marcstraube.desktop.development
@@ -153,9 +157,9 @@
     - development
   when: development_enabled | default(true) | bool
 
-# -----------------------------------------------------------------
-# AI TOOLS
-# -----------------------------------------------------------------
+#
+# AI Tools
+#
 - name: Desktop | Include ai role
   ansible.builtin.include_role:
     name: marcstraube.desktop.ai
@@ -168,9 +172,9 @@
     - ai
   when: ai_enabled | default(false) | bool
 
-# -----------------------------------------------------------------
-# APPLICATIONS
-# -----------------------------------------------------------------
+#
+# Applications
+#
 - name: Desktop | Include multimedia role
   ansible.builtin.include_role:
     name: marcstraube.desktop.multimedia
@@ -303,9 +307,9 @@
     - tabletop
   when: tabletop_enabled | default(false) | bool
 
-# -----------------------------------------------------------------
-# PERIPHERALS
-# -----------------------------------------------------------------
+#
+# Peripherals
+#
 - name: Desktop | Include elgato role
   ansible.builtin.include_role:
     name: marcstraube.desktop.elgato


### PR DESCRIPTION
## Summary

Move all role includes out of `playbooks/desktop_workstation.yml` into a new
`playbooks/tasks/desktop_workstation.yml` task file, mirroring the pattern
from `marcstraube.common` v2.0.0. The standalone playbook becomes a minimal
import wrapper, and the same task file is consumed by infra orchestrators.

Also fixes a pre-existing role gate bug for the office role and aligns
playbook conventions with common.

## Changes

### Refactoring (#30)
- New: `playbooks/tasks/desktop_workstation.yml` — single source of truth
  for the desktop role list, used by both standalone and infra playbooks.
- `playbooks/desktop_workstation.yml` reduced to a minimal wrapper that
  imports the task file.
- Every role include carries the `desktop` group tag in addition to its
  per-role tag, enabling group-level targeting (`--tags desktop`).

### Bug fix (carried 1:1 from v1.2.1, fixed during refactor)
- Office role gate was incorrectly using `office_libreoffice_enabled`
  (a package toggle) as the role-enable variable. Switched to the role's
  actual control variable `office_enabled`. Without this fix, disabling
  LibreOffice would skip the entire role even when OnlyOffice or WPS
  were enabled.

### Style alignment with common
- Added tag scheme docs to the task file header.
- Converted section comment style to common's `#\n# Title\n#` pattern.
- Dropped the standalone playbook's pre_tasks debug banner so the
  standalone wrapper stays minimal — environment-specific pretasks
  belong in the infra layer (matches common's pattern).

## Test plan

- [ ] `ansible-playbook marcstraube.desktop.desktop_workstation` runs
      successfully against a workstation host
- [ ] `--tags desktop` selects all desktop roles
- [ ] `--tags browser` selects the browser role only
- [ ] Office role runs when `office_enabled: true` and any package
      toggle (`office_libreoffice_enabled`, `office_onlyoffice_enabled`,
      etc.) is set
- [ ] Office role is skipped when `office_enabled: false`

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)