### PR TITLE
feat(playbooks): Add system_update task file for Arch partial-upgrade safety

### DIFF
--- a/playbooks/desktop_workstation.yml
+++ b/playbooks/desktop_workstation.yml
@@ -17,6 +17,11 @@
   become: true
   gather_facts: true
 
+  pre_tasks:
+    - name: Desktop | Import system update tasks
+      ansible.builtin.import_tasks:
+        file: tasks/system_update.yml
+
   tasks:
     - name: Desktop | Import desktop workstation tasks
       ansible.builtin.import_tasks:

--- a/playbooks/security.yml
+++ b/playbooks/security.yml
@@ -202,6 +202,10 @@
       - 'solokey'
 
   pre_tasks:
+    - name: Security | Import system update tasks
+      ansible.builtin.import_tasks:
+        file: tasks/system_update.yml
+
     - name: Pretasks | Check for full disk encryption
       ansible.builtin.shell: |
         set -o pipefail

--- a/playbooks/tasks/system_update.yml
+++ b/playbooks/tasks/system_update.yml
@@ -1,0 +1,27 @@
+---
+# =============================================================================
+# System Update Tasks
+# =============================================================================
+# Pre-task file for full system upgrade before package operations.
+# Imported by collection standalone playbooks as pre_tasks.
+#
+# Scope: Arch Linux only.
+# Rolling release requires a full upgrade before any package install to
+# prevent partial-upgrade failures and missing packages on mirrors.
+#
+# EL/Debian are intentionally not handled here — those updates should be
+# performed deliberately, not as a side-effect of a configuration run.
+#
+# Tag scheme:
+#   system-update   This task file
+#   maintenance     Shared with other maintenance tasks
+# =============================================================================
+
+- name: System Update | Arch Linux full upgrade
+  community.general.pacman:
+    update_cache: true
+    upgrade: true
+  when: ansible_facts['os_family'] == 'Archlinux'
+  tags:
+    - system-update
+    - maintenance


### PR DESCRIPTION
## Summary

Add a self-contained `playbooks/tasks/system_update.yml` task file and
import it as `pre_tasks` in the standalone playbooks that install
packages directly. Standalone runs on stale Arch hosts are now safe.

## Scope

Arch only. Rolling release requires it. EL/Debian are typically server
systems where updates should be performed deliberately, not as a side
effect of a configuration run.

## Coverage

The pre_tasks import is added to:

- **`desktop_workstation.yml`** — covers `laptop.yml`, `laptop_full.yml`,
  and `workstation_full.yml` via the existing `import_playbook` chain
  (the imported play runs first with its pre_tasks).
- **`security.yml`** — standalone playbook, runs role-level package
  installs independently of the desktop chain.

## Design choices

- **Task file, not inlined.** Reusable across playbooks; future
  standalone playbooks adopt the same pattern.
- **No cross-collection dependency.** The task file lives inside this
  collection. Same pattern as marcstraube/ansible-collection-common#109.

## Changes

- New: `playbooks/tasks/system_update.yml`
- `playbooks/desktop_workstation.yml`: add `pre_tasks` block
- `playbooks/security.yml`: prepend system_update to existing `pre_tasks`

## Test plan

- [ ] `ansible-playbook marcstraube.desktop.desktop_workstation` on a
      stale Arch host runs the full upgrade before package operations
- [ ] `ansible-playbook marcstraube.desktop.laptop` likewise (via chain)
- [ ] `ansible-playbook marcstraube.desktop.security` likewise
- [ ] Run on a Debian host: pacman task is skipped (when condition)
- [ ] `--tags system-update` runs only the upgrade
- [ ] `--skip-tags system-update` skips the upgrade

## Related

Same pattern as marcstraube/ansible-collection-common#109 (PR #110).

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)