### PR TITLE
refactor!: Switch shell role default from zsh to bash

### DIFF
--- a/roles/shell/README.md
+++ b/roles/shell/README.md
@@ -31,7 +31,7 @@ overrides if needed.
 
 | Variable                 | Default     | Description                                               |
 |--------------------------|-------------|-----------------------------------------------------------|
-| `shell_default`          | `'zsh'`     | Default shell for users: zsh, fish, bash                  |
+| `shell_default`          | `'bash'`    | Default shell for users: zsh, fish, bash                  |
 | `shell_users`            | `[]`        | Users to change shell (empty = all from users_list)       |
 | `shell_user_config_mode` | `'managed'` | User config mode: managed, initial (if absent), disabled  |
 
@@ -39,8 +39,8 @@ overrides if needed.
 
 | Variable                 | Default    | Description                                          |
 |--------------------------|------------|------------------------------------------------------|
-| `shell_zsh_enabled`      | `true`     | Enable Zsh installation                              |
-| `shell_zsh_framework`    | `'native'` | Zsh framework: `native` (system packages) or `ohmyzsh` |
+| `shell_zsh_enabled`      | `false`    | Enable Zsh installation                              |
+| `shell_zsh_framework`    | `'native'` | Zsh framework: native or ohmyzsh                     |
 | `shell_zsh_plugins`      | `[...]`    | Zsh plugins (native framework only)                  |
 | `shell_zsh_grml_enabled` | `false`    | Enable grml-zsh-config (native framework only)       |
 

--- a/roles/shell/defaults/main.yml
+++ b/roles/shell/defaults/main.yml
@@ -11,8 +11,7 @@ shell_enabled: true
 #
 
 # Default shell for users: zsh, fish, bash
-# DEPRECATED: Default will change to 'bash' in v2.0.0
-shell_default: 'zsh'
+shell_default: 'bash'
 
 # Users to change shell for (empty = all users from users_list)
 shell_users: []
@@ -25,8 +24,7 @@ shell_user_config_mode: 'managed'
 #
 
 # Enable Zsh installation
-# DEPRECATED: Default will change to 'false' in v2.0.0
-shell_zsh_enabled: true
+shell_zsh_enabled: false
 
 # Zsh framework: native (system packages) or ohmyzsh (Oh My Zsh per-user install)
 shell_zsh_framework: 'native'


### PR DESCRIPTION
## Summary

Flip the shell role's defaults to bash for v2.0.0.

```
shell_default:     'zsh' → 'bash'
shell_zsh_enabled: true  → false
```

Both variables have carried `# DEPRECATED: Default will change … in v2.0.0`
notes since v1.x. This PR makes the change and drops the deprecation
comments.

## Why

bash is the POSIX-style shell shipped with every supported distribution
(Arch, Debian, Rocky 9/10) and works without additional packages or
per-user configuration. Defaulting to bash makes the role usable on a
fresh host with zero overrides; users who prefer zsh opt in via
inventory:

```yaml
shell_default: 'zsh'
shell_zsh_enabled: true
```

## Changes

- `roles/shell/defaults/main.yml`: flip the two defaults, drop
  DEPRECATED comments
- `roles/shell/README.md`: update the documented defaults

Molecule scenarios already set both variables explicitly, so test
coverage of the zsh path is unchanged.

## Breaking change

Hosts that relied on the old defaults to install zsh as the user shell
now need `shell_default: 'zsh'` and `shell_zsh_enabled: true` in
inventory. Otherwise bash is used and zsh is not installed.

## Test plan

- [ ] CI molecule run passes (zsh path still tested via converge.yml overrides)
- [ ] Inventory with no shell overrides: bash chosen, zsh package not pulled in
- [ ] Inventory with `shell_default: 'zsh'` + `shell_zsh_enabled: true`:
      previous behaviour preserved
- [ ] CHANGELOG entry under "BREAKING" generated by release-please

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)