### PR TITLE
refactor!: Rename boolean toggles to follow naming convention

### DIFF
--- a/roles/bluetooth/README.md
+++ b/roles/bluetooth/README.md
@@ -42,12 +42,12 @@ overrides if needed.
 
 ### Packages
 
-| Variable                     | Default      | Description                                      |
-| ---------------------------- | ------------ | ------------------------------------------------ |
-| `bluetooth_deprecated_tools` | `false`      | Install deprecated tools (hcitool, rfcomm)       |
-| `bluetooth_obex`             | `true`       | Install OBEX file transfer support               |
-| `bluetooth_audio`            | `'pipewire'` | Audio backend: pipewire, pulseaudio, alsa, none  |
-| `bluetooth_gui`              | `'none'`     | GUI tool: blueman, gnome, kde, none              |
+| Variable                              | Default      | Description                                      |
+| ------------------------------------- | ------------ | ------------------------------------------------ |
+| `bluetooth_deprecated_tools_enabled`  | `false`      | Install deprecated tools (hcitool, rfcomm)       |
+| `bluetooth_obex_enabled`              | `true`       | Install OBEX file transfer support               |
+| `bluetooth_audio`                     | `'pipewire'` | Audio backend: pipewire, pulseaudio, alsa, none  |
+| `bluetooth_gui`                       | `'none'`     | GUI tool: blueman, gnome, kde, none              |
 
 ### General Settings
 

--- a/roles/bluetooth/defaults/main.yml
+++ b/roles/bluetooth/defaults/main.yml
@@ -14,10 +14,10 @@ bluetooth_service_enabled: true
 #
 
 # Install deprecated/legacy tools (hcitool, rfcomm, etc.)
-bluetooth_deprecated_tools: false
+bluetooth_deprecated_tools_enabled: false
 
 # Install OBEX support for file transfers
-bluetooth_obex: true
+bluetooth_obex_enabled: true
 
 #
 # Audio Integration

--- a/roles/bluetooth/molecule/default/converge.yml
+++ b/roles/bluetooth/molecule/default/converge.yml
@@ -6,8 +6,8 @@
   vars:
     bluetooth_enabled: true
     bluetooth_service_enabled: false
-    bluetooth_deprecated_tools: false
-    bluetooth_obex: true
+    bluetooth_deprecated_tools_enabled: false
+    bluetooth_obex_enabled: true
     bluetooth_audio: 'pipewire'
     bluetooth_gui: 'none'
     bluetooth_auto_enable: true

--- a/roles/bluetooth/tasks/install.yml
+++ b/roles/bluetooth/tasks/install.yml
@@ -4,9 +4,9 @@
     __bluetooth_install_packages: >-
       {{
         __bluetooth_packages +
-        ((bluetooth_deprecated_tools | bool and __bluetooth_deprecated_package | length > 0)
+        ((bluetooth_deprecated_tools_enabled | bool and __bluetooth_deprecated_package | length > 0)
           | ternary([__bluetooth_deprecated_package], [])) +
-        (bluetooth_obex | bool | ternary([__bluetooth_obex_package], [])) +
+        (bluetooth_obex_enabled | bool | ternary([__bluetooth_obex_package], [])) +
         (__bluetooth_audio_packages[bluetooth_audio] | default([])) +
         (__bluetooth_gui_packages[bluetooth_gui] | default([]))
       }}

--- a/roles/tuxedo/README.md
+++ b/roles/tuxedo/README.md
@@ -52,9 +52,9 @@ but are not actively tested. Use distro-specific vars overrides if needed.
 
 ### Warnings
 
-| Variable                | Default | Description                     |
-| ----------------------- | ------- | ------------------------------- |
-| `tuxedo_warn_conflicts` | `true`  | Check for auto-cpufreq conflict |
+| Variable                        | Default | Description                     |
+| ------------------------------- | ------- | ------------------------------- |
+| `tuxedo_warn_conflicts_enabled` | `true`  | Check for auto-cpufreq conflict |
 
 ## Tags
 

--- a/roles/tuxedo/defaults/main.yml
+++ b/roles/tuxedo/defaults/main.yml
@@ -34,4 +34,4 @@ tuxedo_tccd_sleep_enabled: true
 #
 
 # Warn about auto-cpufreq conflict with tccd power profiles
-tuxedo_warn_conflicts: true
+tuxedo_warn_conflicts_enabled: true

--- a/roles/tuxedo/molecule/default/converge.yml
+++ b/roles/tuxedo/molecule/default/converge.yml
@@ -10,7 +10,7 @@
     tuxedo_yt6801_ethernet_enabled: false
     tuxedo_tccd_enabled: false
     tuxedo_tccd_sleep_enabled: false
-    tuxedo_warn_conflicts: true
+    tuxedo_warn_conflicts_enabled: true
 
   tasks:
     - name: Converge | Include tuxedo role  # noqa: role-name[path]

--- a/roles/tuxedo/tasks/validate.yml
+++ b/roles/tuxedo/tasks/validate.yml
@@ -25,7 +25,7 @@
   changed_when: false
   # pacman -Qi exits 1 when package is not installed
   failed_when: false
-  when: tuxedo_warn_conflicts | bool
+  when: tuxedo_warn_conflicts_enabled | bool
 
 - name: Validate | Warn about auto-cpufreq conflict
   ansible.builtin.debug:
@@ -34,5 +34,5 @@
       Center power profiles. Consider removing auto-cpufreq or disabling its
       service to avoid unexpected behavior.
   when:
-    - tuxedo_warn_conflicts | bool
+    - tuxedo_warn_conflicts_enabled | bool
     - __tuxedo_auto_cpufreq_check.rc | default(1) == 0


### PR DESCRIPTION
## Summary

Bring three logic-gate booleans in line with the project's `_enabled`
suffix convention.

```
bluetooth (gate package installation in tasks/install.yml)
  bluetooth_deprecated_tools → bluetooth_deprecated_tools_enabled
  bluetooth_obex             → bluetooth_obex_enabled

tuxedo (gate validation tasks in tasks/validate.yml)
  tuxedo_warn_conflicts → tuxedo_warn_conflicts_enabled
```

The other bluetooth booleans (`auto_enable`, `always_pairable`,
`name_resolving`, `fast_connectable`) are direct config-file mirrors
that render verbatim into `bluetooth.conf` — they stay as-is per
convention.

## Changes

### bluetooth

- `roles/bluetooth/defaults/main.yml`: rename both toggles
- `roles/bluetooth/tasks/install.yml`: switch to new names in the
  package-list set_fact
- `roles/bluetooth/molecule/default/converge.yml`: update the test
  vars to the new names
- `roles/bluetooth/README.md`: update Variable column

### tuxedo

- `roles/tuxedo/defaults/main.yml`: rename
- `roles/tuxedo/tasks/validate.yml`: update both `when` conditions
- `roles/tuxedo/molecule/default/converge.yml`: update the test var
- `roles/tuxedo/README.md`: update Variable column

## Breaking change

Inventories that override any of the renamed variables need updates
to the new names. Hard rename, no fallback.

## Test plan

- [ ] CI molecule run passes for both bluetooth and tuxedo
- [ ] `grep -rn "bluetooth_deprecated_tools[^_]\|bluetooth_obex[^_]\|tuxedo_warn_conflicts[^_]" roles/`
      returns no matches
- [ ] CHANGELOG entry under "BREAKING" generated by release-please

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)