### PR TITLE
refactor!: Use enum-style scope for keepassxc secret service

### DIFF
--- a/roles/keepassxc/README.md
+++ b/roles/keepassxc/README.md
@@ -49,7 +49,7 @@ overrides if needed.
 | Variable                             | Default | Description                                         |
 | ------------------------------------ | ------- | --------------------------------------------------- |
 | `keepassxc_secret_service_enabled`   | `false` | Enable Secret Service (freedesktop.org) integration |
-| `keepassxc_secret_service_global`    | `false` | Install Secret Service globally or per-user         |
+| `keepassxc_secret_service_scope`     | `'user'`| Secret Service scope: `'user'` or `'global'`        |
 
 ### SSH Agent Integration
 

--- a/roles/keepassxc/defaults/main.yml
+++ b/roles/keepassxc/defaults/main.yml
@@ -35,8 +35,8 @@ keepassxc_browser_integration_enabled: true
 # Enable Secret Service (freedesktop.org) integration
 keepassxc_secret_service_enabled: false
 
-# Install Secret Service globally (system-wide) or per-user
-keepassxc_secret_service_global: false
+# Secret Service installation scope: 'user' or 'global'
+keepassxc_secret_service_scope: 'user'  # pragma: allowlist secret
 
 #
 # SSH Agent Integration

--- a/roles/keepassxc/molecule/default/converge.yml
+++ b/roles/keepassxc/molecule/default/converge.yml
@@ -6,7 +6,7 @@
   vars:
     keepassxc_enabled: true
     keepassxc_secret_service_enabled: true
-    keepassxc_secret_service_global: true
+    keepassxc_secret_service_scope: 'global'  # pragma: allowlist secret
     keepassxc_autostart_enabled: false
 
   tasks:

--- a/roles/keepassxc/tasks/main.yml
+++ b/roles/keepassxc/tasks/main.yml
@@ -3,6 +3,17 @@
 # KeePassXC Main Tasks
 #
 
+- name: Main | Validate secret service scope
+  ansible.builtin.assert:
+    that:
+      - keepassxc_secret_service_scope in ['user', 'global']
+    fail_msg: >-
+      keepassxc_secret_service_scope must be 'user' or 'global',
+      got '{{ keepassxc_secret_service_scope }}'
+  when: keepassxc_enabled | bool
+  tags:
+    - keepassxc
+
 - name: Main | Derive users from users_list (exclude root and system users)
   ansible.builtin.set_fact:
     keepassxc_users: >-

--- a/roles/keepassxc/tasks/secret_service.yml
+++ b/roles/keepassxc/tasks/secret_service.yml
@@ -10,7 +10,7 @@
     owner: root
     group: root
     mode: '0755'
-  when: keepassxc_secret_service_global | bool
+  when: keepassxc_secret_service_scope == 'global'  # pragma: allowlist secret
 
 - name: Secret Service | Install globally
   ansible.builtin.copy:
@@ -19,7 +19,7 @@
     owner: root
     group: root
     mode: '0644'
-  when: keepassxc_secret_service_global | bool
+  when: keepassxc_secret_service_scope == 'global'  # pragma: allowlist secret
 
 - name: Secret Service | Create user-specific D-Bus services directories
   ansible.builtin.file:
@@ -29,7 +29,7 @@
     group: '{{ item.group | default(item.name) }}'
     mode: '0755'
   when:
-    - not keepassxc_secret_service_global | bool
+    - keepassxc_secret_service_scope == 'user'  # pragma: allowlist secret
     - item.secret_service | default(true)
   loop: '{{ keepassxc_users }}'
   loop_control:
@@ -43,7 +43,7 @@
     group: '{{ item.group | default(item.name) }}'
     mode: '0644'
   when:
-    - not keepassxc_secret_service_global | bool
+    - keepassxc_secret_service_scope == 'user'  # pragma: allowlist secret
     - item.secret_service | default(true)
   loop: '{{ keepassxc_users }}'
   loop_control:
@@ -54,7 +54,7 @@
     path: '/home/{{ item.name }}/.local/share/dbus-1/services/org.freedesktop.secrets.service'
     state: absent
   when:
-    - not keepassxc_secret_service_global | bool
+    - keepassxc_secret_service_scope == 'user'  # pragma: allowlist secret
     - not (item.secret_service | default(true))
   loop: '{{ keepassxc_users }}'
   loop_control:


### PR DESCRIPTION
## Summary

Replace `keepassxc_secret_service_global` (a boolean that inverted
the user-facing semantics) with an explicit enum
`keepassxc_secret_service_scope`. Values: `'user'` or `'global'`.

```
keepassxc_secret_service_global: false  →  keepassxc_secret_service_scope: 'user'
keepassxc_secret_service_global: true   →  keepassxc_secret_service_scope: 'global'
```

## Why

The boolean form had two issues:

1. The variable name implied "is this global?" while the truthy value
   was the unusual case, making `false` (= per-user) the default. New
   readers had to consult the description to interpret the value.
2. It was a logic gate but didn't fit the project's `_enabled` suffix
   convention cleanly — `_global_enabled: false` would read as
   "not-global is disabled", which is misleading.

The enum mirrors the established `mode: managed|initial|disabled`
pattern used in `users` and other roles. Self-documenting and
unambiguous.

## Changes

- `roles/keepassxc/defaults/main.yml`: rename the variable, default to `'user'`
- `roles/keepassxc/tasks/main.yml`: assert valid value at start, fail
  with clear error otherwise
- `roles/keepassxc/tasks/secret_service.yml`: switch all conditions
  from boolean to enum equality checks
- `roles/keepassxc/molecule/default/converge.yml`: update test var
- `roles/keepassxc/README.md`: update Variable column

The task and molecule files carry inline `pragma: allowlist secret`
comments because the detect-secrets pre-commit hook flags
quoted-value lines whose name contains the substring "secret" —
these are config values, not credentials.

## Breaking change

Inventories that set `keepassxc_secret_service_global: true` must
change to `keepassxc_secret_service_scope: 'global'`. `false` →
`'user'`. Missing/invalid values fail fast with an assertion
rather than silently falling back.

## Test plan

- [ ] CI molecule run passes (`scope: 'global'` exercised in converge.yml)
- [ ] Inventory with `keepassxc_secret_service_scope: 'user'`:
      D-Bus services placed in `~/.local/share/dbus-1/services/`
- [ ] Inventory with `keepassxc_secret_service_scope: 'global'`:
      D-Bus services placed in `/usr/local/share/dbus-1/services/`
- [ ] Invalid value (e.g. `'foo'`) fails with a clear assert message
- [ ] CHANGELOG entry under "BREAKING" generated by release-please

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)