### PR TITLE
refactor: Remove unused SDDM and LightDM theme variables

### DIFF
--- a/roles/display_manager/README.md
+++ b/roles/display_manager/README.md
@@ -42,10 +42,9 @@ overrides if needed.
 
 ### SDDM Options
 
-| Variable                                | Default | Description                         |
-|-----------------------------------------|---------|-------------------------------------|
-| `display_manager_sddm_theme`            | `''`    | SDDM theme (empty = default breeze) |
-| `display_manager_sddm_virtual_keyboard` | `false` | Enable virtual keyboard             |
+| Variable                                | Default | Description             |
+|-----------------------------------------|---------|-------------------------|
+| `display_manager_sddm_virtual_keyboard` | `false` | Enable virtual keyboard |
 
 ### GDM Options
 
@@ -55,10 +54,9 @@ overrides if needed.
 
 ### LightDM Options
 
-| Variable                          | Default | Description                     |
-|-----------------------------------|---------|---------------------------------|
-| `display_manager_lightdm_greeter` | `gtk`   | Greeter: gtk, slick             |
-| `display_manager_lightdm_theme`   | `''`    | Greeter theme (empty = default) |
+| Variable                          | Default | Description         |
+|-----------------------------------|---------|---------------------|
+| `display_manager_lightdm_greeter` | `gtk`   | Greeter: gtk, slick |
 
 ### greetd Options
 

--- a/roles/display_manager/defaults/main.yml
+++ b/roles/display_manager/defaults/main.yml
@@ -20,9 +20,6 @@ display_manager_name: 'sddm'
 # SDDM Options
 #
 
-# SDDM theme (empty = default breeze)
-display_manager_sddm_theme: ''
-
 # Enable virtual keyboard
 display_manager_sddm_virtual_keyboard: false
 
@@ -39,9 +36,6 @@ display_manager_gdm_wayland: true
 
 # Greeter: gtk, slick
 display_manager_lightdm_greeter: 'gtk'
-
-# Greeter theme (empty = default)
-display_manager_lightdm_theme: ''
 
 #
 # greetd Options


### PR DESCRIPTION
## Summary

`display_manager_sddm_theme` and `display_manager_lightdm_theme` were
defined in `defaults/main.yml` and documented in the README but never
referenced in any task or template. Setting them was a no-op in any
prior version, so removal does not change behaviour for any existing
inventory — variables that are set without a default are simply
ignored.

Theme deployment for SDDM/LightDM is non-trivial (config edits, theme
package installation, asset paths) and out of scope for this role in
its current form. If theme support becomes a requirement, a separate
issue should cover proper deployment.

## Removed variables

```
display_manager_sddm_theme
display_manager_lightdm_theme
```

## Removed sections

- `defaults/main.yml`: both variables and their comments
- `README.md`: corresponding rows in SDDM Options and LightDM Options
  tables, table widths re-fitted

## Test plan

- [x] grep returns no matches in `roles/display_manager/`
- [x] Molecule test passes on all 4 platforms (archlinux,
      debian-trixie, rocky-9, rocky-10)
- [x] Idempotence: second run reports no changes (changed=0)
- [x] ansible-lint clean

Closes #50