### PR TITLE
refactor!: Change browser_user_config_mode default to 'initial'

### DIFF
--- a/roles/browser/README.md
+++ b/roles/browser/README.md
@@ -115,7 +115,7 @@ Chromium on Rocky Linux requires EPEL.
 | Variable                   | Default     | Description                            |
 | -------------------------- | ----------- | -------------------------------------- |
 | `browser_users`            | `[]`        | Users for per-user profile settings    |
-| `browser_user_config_mode` | `'managed'` | Default mode: managed/initial/disabled |
+| `browser_user_config_mode` | `'initial'` | Default mode: managed/initial/disabled |
 
 ## Tags
 

--- a/roles/browser/defaults/main.yml
+++ b/roles/browser/defaults/main.yml
@@ -281,4 +281,6 @@ browser_users: []
 #     mode: 'managed'
 
 # Default mode when user entry has no 'mode' key
-browser_user_config_mode: 'managed'
+# 'initial' preserves user customisations after first deploy.
+# Set to 'managed' for continuous reconciliation.
+browser_user_config_mode: 'initial'


### PR DESCRIPTION
## Summary

Flip the default of `browser_user_config_mode` from `'managed'` to
`'initial'`. The implementation in `tasks/users.yml` already handles
all three modes (`managed`, `initial`, `disabled`) correctly — only
the default value changes.

`'initial'` is the safer default: deploy on first run, then preserve
user customisations on subsequent runs. Browser settings are typically
adjusted by the user, and the previous `'managed'` default silently
overwrote those adjustments on every Ansible run.

Inventories that want continuous reconciliation opt in explicitly via
`browser_user_config_mode: 'managed'`.

## Changes

- `defaults/main.yml`: flip default, add comment documenting the trade-off
- `README.md`: update Default column

## Breaking change

Inventories that relied on the implicit `'managed'` default for
continuous reconciliation will now see user customisations preserved
across runs. To restore the previous behaviour:

```yaml
browser_user_config_mode: 'managed'
```

## Test plan

- [x] Default value in `defaults/main.yml` is `'initial'`
- [x] Molecule on archlinux: ok=17, changed=0, failed=0 (idempotent)
- [x] ansible-lint clean

The behavioural cases below cannot be exercised by the current
molecule scenario because `browser_users: []` skips the user-config
code path. They will be verified on the live workstation:

- [ ] First run, file absent: deployed
- [ ] Second run, file modified by user: file left untouched
- [ ] Inventory override `'managed'`: file reconciled to template every run

Closes #52