### PR TITLE
refactor: Remove unused terminal config vars; implement terminal_default

### DIFF
--- a/roles/terminal/README.md
+++ b/roles/terminal/README.md
@@ -37,56 +37,33 @@ overrides if needed.
 
 ### Terminal Emulators
 
-| Variable             | Default                               | Description                              |
-|----------------------|---------------------------------------|------------------------------------------|
-| `terminal_emulators` | `['ghostty']`                         | List of terminal emulators to install    |
-| `terminal_default`   | `'{{ terminal_emulators \| first }}'` | Default terminal (for $TERMINAL env var) |
+| Variable             | Default                               | Description                                              |
+|----------------------|---------------------------------------|----------------------------------------------------------|
+| `terminal_emulators` | `['ghostty']`                         | List of terminal emulators to install                    |
+| `terminal_default`   | `'{{ terminal_emulators \| first }}'` | Default `$TERMINAL` (empty disables env file deployment) |
 
-### Ghostty Options
+When `terminal_default` is non-empty, the role writes
+`/etc/environment.d/terminal.conf` containing `TERMINAL=<value>`,
+exposing it as a system-wide environment variable for desktop sessions.
+Set `terminal_default: ''` to skip the env file (and remove it on
+existing systems).
 
-| Variable                          | Default | Description                  |
-|-----------------------------------|---------|------------------------------|
-| `terminal_ghostty_config_enabled` | `false` | Deploy custom Ghostty config |
-| `terminal_ghostty_font_family`    | `''`    | Ghostty font family          |
-| `terminal_ghostty_font_size`      | `12`    | Ghostty font size            |
-| `terminal_ghostty_theme`          | `''`    | Ghostty theme                |
-
-### Alacritty Options
-
-| Variable                            | Default       | Description                    |
-|-------------------------------------|---------------|--------------------------------|
-| `terminal_alacritty_config_enabled` | `false`       | Deploy custom Alacritty config |
-| `terminal_alacritty_font_family`    | `'monospace'` | Alacritty font family          |
-| `terminal_alacritty_font_size`      | `12.0`        | Alacritty font size            |
+Per-terminal configuration (fonts, themes, custom configs) is left to
+the user's dotfiles. Manage these via `~/.config/<terminal>/` directly.
 
 ### Kitty Options
 
-| Variable                        | Default       | Description                       |
-|---------------------------------|---------------|-----------------------------------|
-| `terminal_kitty_config_enabled` | `false`       | Deploy custom Kitty config        |
-| `terminal_kitty_font_family`    | `'monospace'` | Kitty font family                 |
-| `terminal_kitty_font_size`      | `12`          | Kitty font size                   |
-| `terminal_kitty_images_enabled` | `true`        | Enable Kitty image support (icat) |
-
-### Foot Options
-
-| Variable                       | Default               | Description               |
-|--------------------------------|-----------------------|---------------------------|
-| `terminal_foot_config_enabled` | `false`               | Deploy custom Foot config |
-| `terminal_foot_font`           | `'monospace:size=12'` | Foot font                 |
-
-### Wezterm Options
-
-| Variable                          | Default | Description                  |
-|-----------------------------------|---------|------------------------------|
-| `terminal_wezterm_config_enabled` | `false` | Deploy custom Wezterm config |
+| Variable                        | Default | Description                       |
+|---------------------------------|---------|-----------------------------------|
+| `terminal_kitty_images_enabled` | `true`  | Enable Kitty image support (icat) |
 
 ## Tags
 
-| Tag                | Scope                |
-|--------------------|----------------------|
-| `terminal`         | All role tasks       |
-| `terminal:install` | Package installation |
+| Tag                  | Scope                                    |
+|----------------------|------------------------------------------|
+| `terminal`           | All role tasks                           |
+| `terminal:install`   | Package installation                     |
+| `terminal:configure` | Default `$TERMINAL` env file in /etc/env |
 
 ## Example Playbook
 

--- a/roles/terminal/defaults/main.yml
+++ b/roles/terminal/defaults/main.yml
@@ -15,67 +15,13 @@ terminal_enabled: true
 terminal_emulators:
   - 'ghostty'
 
-# Default terminal (for $TERMINAL env var)
+# Default terminal exposed via $TERMINAL in /etc/environment.d/terminal.conf.
+# Set to '' to skip deploying the env file.
 terminal_default: '{{ terminal_emulators | first }}'
-
-#
-# Ghostty Options
-#
-
-# Deploy custom Ghostty config
-terminal_ghostty_config_enabled: false
-
-# Ghostty font family
-terminal_ghostty_font_family: ''
-
-# Ghostty font size
-terminal_ghostty_font_size: 12
-
-# Ghostty theme
-terminal_ghostty_theme: ''
-
-#
-# Alacritty Options
-#
-
-# Deploy custom Alacritty config
-terminal_alacritty_config_enabled: false
-
-# Alacritty font family
-terminal_alacritty_font_family: 'monospace'
-
-# Alacritty font size
-terminal_alacritty_font_size: 12.0
 
 #
 # Kitty Options
 #
 
-# Deploy custom Kitty config
-terminal_kitty_config_enabled: false
-
-# Kitty font family
-terminal_kitty_font_family: 'monospace'
-
-# Kitty font size
-terminal_kitty_font_size: 12
-
-# Enable Kitty image support (icat)
+# Enable Kitty image support (icat) — installs kitty-icat helper packages
 terminal_kitty_images_enabled: true
-
-#
-# Foot Options
-#
-
-# Deploy custom Foot config
-terminal_foot_config_enabled: false
-
-# Foot font
-terminal_foot_font: 'monospace:size=12'
-
-#
-# Wezterm Options
-#
-
-# Deploy custom Wezterm config
-terminal_wezterm_config_enabled: false

--- a/roles/terminal/molecule/default/converge.yml
+++ b/roles/terminal/molecule/default/converge.yml
@@ -6,8 +6,8 @@
   vars:
     terminal_enabled: true
     terminal_emulators:
-      - 'foot'
-    terminal_default: 'foot'
+      - 'kitty'
+    terminal_default: 'kitty'
 
   tasks:
     - name: Converge | Include terminal role  # noqa: role-name[path]

--- a/roles/terminal/molecule/default/prepare.yml
+++ b/roles/terminal/molecule/default/prepare.yml
@@ -20,6 +20,12 @@
         update_cache: true
       when: ansible_facts['os_family'] == 'Debian'
 
+    - name: Prepare | Install EPEL release (RedHat)  # noqa: package-latest
+      ansible.builtin.package:
+        name: epel-release
+        state: latest
+      when: ansible_facts['os_family'] == 'RedHat'
+
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true

--- a/roles/terminal/molecule/default/verify.yml
+++ b/roles/terminal/molecule/default/verify.yml
@@ -8,19 +8,19 @@
     # Package Verification
     #
 
-    - name: Verify | Check foot package is installed
+    - name: Verify | Check kitty package is installed
       ansible.builtin.package:
-        name: foot
+        name: kitty
         state: present
       check_mode: true
-      register: __terminal_foot_pkg_check
-      failed_when: __terminal_foot_pkg_check.changed
+      register: __terminal_kitty_pkg_check
+      failed_when: __terminal_kitty_pkg_check.changed
 
     #
     # Terminfo Verification
     #
 
-    - name: Verify | Check foot terminfo exists
+    - name: Verify | Check kitty terminfo exists
       ansible.builtin.command:
         cmd: toe -a
       register: __terminal_terminfo
@@ -28,9 +28,24 @@
       # toe may not be available on all platforms (minimal containers)
       failed_when: false
 
-    - name: Verify | Assert foot terminfo is available
+    - name: Verify | Assert kitty terminfo is available
       ansible.builtin.assert:
         that:
-          - "'foot' in __terminal_terminfo.stdout"
-        fail_msg: 'foot terminfo not found'
+          - "'xterm-kitty' in __terminal_terminfo.stdout"
+        fail_msg: 'kitty terminfo (xterm-kitty) not found'
       when: __terminal_terminfo.rc == 0
+
+    #
+    # Default Terminal Env Verification
+    #
+
+    - name: Verify | Read /etc/environment.d/terminal.conf
+      ansible.builtin.slurp:
+        src: /etc/environment.d/terminal.conf
+      register: __terminal_env_file
+
+    - name: Verify | Assert TERMINAL=kitty is set
+      ansible.builtin.assert:
+        that:
+          - "'TERMINAL=kitty' in (__terminal_env_file.content | b64decode)"
+        fail_msg: 'TERMINAL=kitty not found in /etc/environment.d/terminal.conf'

--- a/roles/terminal/tasks/configure.yml
+++ b/roles/terminal/tasks/configure.yml
@@ -1,0 +1,28 @@
+---
+#
+# Default Terminal — $TERMINAL via /etc/environment.d
+#
+
+- name: Configure | Ensure /etc/environment.d exists
+  ansible.builtin.file:
+    path: /etc/environment.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  when: terminal_default | default('') | length > 0
+
+- name: Configure | Deploy default terminal env file
+  ansible.builtin.template:
+    src: terminal.conf.j2
+    dest: /etc/environment.d/terminal.conf
+    owner: root
+    group: root
+    mode: '0644'
+  when: terminal_default | default('') | length > 0
+
+- name: Configure | Remove default terminal env file when unset
+  ansible.builtin.file:
+    path: /etc/environment.d/terminal.conf
+    state: absent
+  when: terminal_default | default('') | length == 0

--- a/roles/terminal/tasks/main.yml
+++ b/roles/terminal/tasks/main.yml
@@ -18,3 +18,10 @@
   tags:
     - terminal
     - terminal:install
+
+- name: Main | Import configure tasks
+  ansible.builtin.import_tasks: configure.yml
+  when: terminal_enabled | bool
+  tags:
+    - terminal
+    - terminal:configure

--- a/roles/terminal/templates/terminal.conf.j2
+++ b/roles/terminal/templates/terminal.conf.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+TERMINAL={{ terminal_default }}


### PR DESCRIPTION
## Summary

The terminal role declared 13 boolean/value variables for per-terminal
configuration deployment that were never referenced in any task,
template, or var file. Setting them in inventory was a no-op.

This PR drops the dead variables and implements `terminal_default`
as a system-wide `$TERMINAL` environment variable via
`/etc/environment.d/terminal.conf`.

Per-terminal configuration (fonts, themes, custom configs) is left
to the user's dotfiles. Maintaining config templates for 5 different
terminal emulators is high-cost for a feature most users handle via
dotfiles in their home directory.

## Removed variables

```
terminal_ghostty_config_enabled
terminal_ghostty_font_family
terminal_ghostty_font_size
terminal_ghostty_theme
terminal_alacritty_config_enabled
terminal_alacritty_font_family
terminal_alacritty_font_size
terminal_kitty_config_enabled
terminal_kitty_font_family
terminal_kitty_font_size
terminal_foot_config_enabled
terminal_foot_font
terminal_wezterm_config_enabled
```

`terminal_kitty_images_enabled` is kept (used in `install.yml` to add
image-support packages).

## Added

- `tasks/configure.yml` — deploys `/etc/environment.d/terminal.conf`
  with `TERMINAL=<value>` when `terminal_default` is non-empty;
  removes the file when `terminal_default: ''`
- `templates/terminal.conf.j2` — env file template with `ansible_managed`
  comment header
- Tag `terminal:configure` for selective runs

## Changes

- `defaults/main.yml`: drop 13 variables, document `terminal_default`
  semantics (empty = skip env file)
- `tasks/main.yml`: import `configure.yml` after `install.yml`
- `README.md`: drop the per-terminal Options sections; document
  `/etc/environment.d/terminal.conf` deployment; update Tags table
- `molecule/default/converge.yml`: switch test terminal from `foot`
  to `kitty` (only terminal in EPEL on Rocky 9/10 and present on
  Arch + Debian)
- `molecule/default/verify.yml`: assert `kitty` package, `xterm-kitty`
  terminfo, and `TERMINAL=kitty` in `/etc/environment.d/terminal.conf`
- `molecule/default/prepare.yml`: install `epel-release` on RedHat
  (matches `shell`/`wine`/`cad`/`filemanagers`/`downloads` convention)

## Behaviour notes (not breaking)

The 13 listed variables were no-ops in any prior version, so removing
them does not change behaviour for any existing inventory. Inventories
that set them will continue to parse (the variable is simply ignored).

`terminal_default` had a default of `'{{ terminal_emulators | first }}'`
that was never read. With this PR the variable does its documented
job: deploys `/etc/environment.d/terminal.conf` containing
`TERMINAL=<value>`. Inventories with the default config will get a
new env file on next run. To suppress deployment entirely, set
`terminal_default: ''`.

## Test plan

- [x] Molecule passes on archlinux, debian-trixie, rocky-9, rocky-10
- [x] Idempotence: second run reports no changes (changed=0)
- [x] `/etc/environment.d/terminal.conf` contains `TERMINAL=kitty`
      after converge (verified on all 4 platforms)
- [x] ansible-lint clean

The behavioural cases below will be verified on the live workstation:

- [ ] `terminal_default: ''`: no env file deployed (existing file removed)
- [ ] Login shell after deploy: `$TERMINAL` matches configured value

Closes #48