### PR TITLE
refactor: Implement LXQt variant; drop unused desktop_environment_default and _cursor_size

### DIFF
--- a/roles/desktop_environment/README.md
+++ b/roles/desktop_environment/README.md
@@ -44,10 +44,9 @@ overrides if needed.
 
 ### Desktop Environments
 
-| Variable                      | Default        | Description                         |
-|-------------------------------|----------------|-------------------------------------|
-| `desktop_environment_list`    | `['hyprland']` | Desktop environments to install     |
-| `desktop_environment_default` | first in list  | Default session for display manager |
+| Variable                   | Default        | Description                     |
+|----------------------------|----------------|---------------------------------|
+| `desktop_environment_list` | `['hyprland']` | Desktop environments to install |
 
 ### Wayland Utilities
 
@@ -123,10 +122,10 @@ overrides if needed.
 
 ### LXQt Options
 
-| Variable                                | Default          | Description             |
-|-----------------------------------------|------------------|-------------------------|
-| `desktop_environment_lxqt_full_enabled` | `true`           | Install full lxqt group |
-| `desktop_environment_lxqt_icons`        | `'breeze-icons'` | Icon theme              |
+| Variable                           | Default          | Description              |
+|------------------------------------|------------------|--------------------------|
+| `desktop_environment_lxqt_variant` | `'full'`         | Variant: minimal or full |
+| `desktop_environment_lxqt_icons`   | `'breeze-icons'` | Icon theme               |
 
 ### Common Options
 
@@ -142,7 +141,6 @@ overrides if needed.
 | Variable                            | Default | Description              |
 |-------------------------------------|---------|--------------------------|
 | `desktop_environment_cursor_themes` | `[]`    | Cursor themes to install |
-| `desktop_environment_cursor_size`   | `24`    | Cursor size              |
 | `desktop_environment_icon_themes`   | `[]`    | Icon themes to install   |
 
 ## Tags

--- a/roles/desktop_environment/defaults/main.yml
+++ b/roles/desktop_environment/defaults/main.yml
@@ -24,9 +24,6 @@ desktop_environment_users: []
 desktop_environment_list:
   - 'hyprland'
 
-# Default session for display manager
-desktop_environment_default: '{{ desktop_environment_list | first }}'
-
 #
 # Wayland Utilities
 #
@@ -168,8 +165,8 @@ desktop_environment_lxde_full_enabled: true
 # LXQt Options
 #
 
-# Install full lxqt group instead of minimal
-desktop_environment_lxqt_full_enabled: true
+# LXQt variant: 'minimal' (core lxqt panel/session) or 'full' (lxqt + extras)
+desktop_environment_lxqt_variant: 'full'
 
 # Icon theme (breeze-icons, oxygen-icons)
 desktop_environment_lxqt_icons: 'breeze-icons'
@@ -199,9 +196,6 @@ desktop_environment_text_editor: 'none'
 # Cursor themes to install (list of theme keys, empty = none)
 # Options: adwaita, breeze, capitaine, bibata
 desktop_environment_cursor_themes: []
-
-# Cursor size (used by some DEs/WMs when themes are installed)
-desktop_environment_cursor_size: 24
 
 # Icon themes to install (list of theme keys, empty = none)
 # Options: adwaita, breeze, papirus, hicolor

--- a/roles/desktop_environment/tasks/lxqt.yml
+++ b/roles/desktop_environment/tasks/lxqt.yml
@@ -3,11 +3,20 @@
 # LXQt Installation
 #
 
+- name: LXQt | Pick variant package set
+  ansible.builtin.set_fact:
+    __desktop_environment_lxqt_variant_packages: >-
+      {{
+        __desktop_environment_lxqt_minimal_packages
+        if desktop_environment_lxqt_variant == 'minimal'
+        else __desktop_environment_lxqt_full_packages
+      }}
+
 - name: LXQt | Build package list
   ansible.builtin.set_fact:
     __desktop_environment_lxqt_install_packages: >-
       {{
-        __desktop_environment_lxqt_packages +
+        __desktop_environment_lxqt_variant_packages +
         [__desktop_environment_lxqt_icon_packages[desktop_environment_lxqt_icons] | default('')]
       }}
 

--- a/roles/desktop_environment/tasks/main.yml
+++ b/roles/desktop_environment/tasks/main.yml
@@ -16,6 +16,19 @@
   tags:
     - desktop-environment
 
+- name: Main | Validate LXQt variant
+  ansible.builtin.assert:
+    that:
+      - desktop_environment_lxqt_variant in ['minimal', 'full']
+    fail_msg: >-
+      desktop_environment_lxqt_variant must be 'minimal' or 'full',
+      got: '{{ desktop_environment_lxqt_variant }}'
+  when:
+    - desktop_environment_enabled | bool
+    - "'lxqt' in desktop_environment_list"
+  tags:
+    - desktop-environment
+
 - name: Main | Derive desktop users from users_list (exclude root and system users)
   ansible.builtin.set_fact:
     desktop_environment_users: >-

--- a/roles/desktop_environment/vars/Archlinux.yml
+++ b/roles/desktop_environment/vars/Archlinux.yml
@@ -127,7 +127,13 @@ __desktop_environment_lxde_full_packages:
 # LXQt
 #
 
-__desktop_environment_lxqt_packages:
+__desktop_environment_lxqt_minimal_packages:
+  - 'lxqt-session'
+  - 'lxqt-panel'
+  - 'lxqt-config'
+  - 'lxqt-policykit'
+
+__desktop_environment_lxqt_full_packages:
   - 'lxqt'
 
 __desktop_environment_lxqt_icon_packages:

--- a/roles/desktop_environment/vars/Debian.yml
+++ b/roles/desktop_environment/vars/Debian.yml
@@ -112,7 +112,10 @@ __desktop_environment_lxde_full_packages:
 # LXQt
 #
 
-__desktop_environment_lxqt_packages:
+__desktop_environment_lxqt_minimal_packages:
+  - 'lxqt-core'
+
+__desktop_environment_lxqt_full_packages:
   - 'lxqt'
 
 __desktop_environment_lxqt_icon_packages:

--- a/roles/desktop_environment/vars/RedHat.yml
+++ b/roles/desktop_environment/vars/RedHat.yml
@@ -118,7 +118,13 @@ __desktop_environment_lxde_full_packages:
 # LXQt
 #
 
-__desktop_environment_lxqt_packages:
+# LXQt is not packaged for EL 9/10 even with EPEL — the group reference
+# below is a placeholder; both variants will fail to install. Track in
+# a follow-up issue if LXQt-on-EL support is needed.
+__desktop_environment_lxqt_minimal_packages:
+  - '@lxqt-desktop-environment'
+
+__desktop_environment_lxqt_full_packages:
   - '@lxqt-desktop-environment'
 
 __desktop_environment_lxqt_icon_packages:


### PR DESCRIPTION
## Summary

Three variables in the `desktop_environment` role were either
unimplemented or used a pattern inconsistent with the rest of the
project. All three were no-ops, so removal does not change behaviour
for any existing inventory.

This PR also implements LXQt minimal/full variant selection via a
new enum variable that matches the project-wide `mode`/`scope`
pattern (`keepassxc_secret_service_scope`, `users` mode).

## Removed variables

```
desktop_environment_default        # never read; display_manager owns this slot
desktop_environment_lxqt_full_enabled  # boolean toggle, never wired to install
desktop_environment_cursor_size    # unused; cursor size is DE-specific
```

## Added

- `desktop_environment_lxqt_variant` (enum: `'minimal'` / `'full'`,
  default `'full'`) — picks which LXQt package set to install
- Assertion in `tasks/main.yml`: fails fast with a clear message if
  the variant value is invalid, only runs when `'lxqt'` is in
  `desktop_environment_list`
- Per-distro `__desktop_environment_lxqt_minimal_packages` and
  `__desktop_environment_lxqt_full_packages` in `vars/`

## Per-distro package sets

| Distro     | Minimal                                                       | Full                        |
|------------|---------------------------------------------------------------|-----------------------------|
| Arch Linux | `lxqt-session`, `lxqt-panel`, `lxqt-config`, `lxqt-policykit` | `lxqt` (group)              |
| Debian     | `lxqt-core`                                                   | `lxqt`                      |
| EL 9 / 10  | `@lxqt-desktop-environment` (placeholder — not in EPEL)       | `@lxqt-desktop-environment` |

LXQt is not packaged for EL 9/10 even with EPEL. The placeholder
preserves the prior (broken) behaviour rather than silently changing
it; a follow-up issue should track EL LXQt support if needed.

## Changes

- `defaults/main.yml`: drop the 3 listed variables; add
  `desktop_environment_lxqt_variant`
- `tasks/main.yml`: add LXQt variant validation assert (gated on
  `'lxqt' in desktop_environment_list`)
- `tasks/lxqt.yml`: pick variant package set, then build install list
- `vars/{Archlinux,Debian,RedHat}.yml`: split
  `__desktop_environment_lxqt_packages` into `_minimal` and `_full`
- `README.md`: drop dead variable rows; document
  `desktop_environment_lxqt_variant`

## Behaviour notes (not breaking)

- `desktop_environment_default`, `_lxqt_full_enabled`, `_cursor_size`
  were no-ops in any prior version, so removal does not change
  behaviour for any existing inventory.
- The new `desktop_environment_lxqt_variant` defaults to `'full'`,
  which installs the same package set the role installed before
  (`lxqt` group on Arch/Debian, `@lxqt-desktop-environment` on EL).
  Existing LXQt inventories see no change.
- New `'minimal'` option is opt-in via inventory.
- Existing inventories that set the removed variables continue to
  parse (the variables are simply ignored).

## Test plan

- [x] Molecule passes on archlinux (xfce scenario, no LXQt path
      exercised — same as before, sanity check no regression)
- [x] Idempotence: second run reports no changes (changed=0)
- [x] ansible-lint clean

LXQt-specific behavioural cases will be verified on the live
workstation:

- [ ] `_lxqt_variant: 'minimal'`: only the minimal set installed
- [ ] `_lxqt_variant: 'full'`: full set installed
- [ ] `_lxqt_variant: 'lite'` (invalid): assert fails fast
- [ ] Default `_lxqt_variant`: full set installed

Closes #49