### PR TITLE
refactor!: Implement starship config; flip shell_user_config_mode default to 'initial'

### DIFF
--- a/roles/shell/README.md
+++ b/roles/shell/README.md
@@ -33,7 +33,7 @@ overrides if needed.
 |--------------------------|-------------|-----------------------------------------------------------|
 | `shell_default`          | `'bash'`    | Default shell for users: zsh, fish, bash                  |
 | `shell_users`            | `[]`        | Users to change shell (empty = all from users_list)       |
-| `shell_user_config_mode` | `'managed'` | User config mode: managed, initial (if absent), disabled  |
+| `shell_user_config_mode` | `'initial'` | User config mode: managed, initial (if absent), disabled  |
 
 ### Zsh
 
@@ -86,8 +86,22 @@ and adds Starship init automatically.
 |---------------------------------|-------------------|--------------------------------------------|
 | `shell_starship_enabled`        | `true`            | Enable Starship prompt installation        |
 | `shell_starship_config_enabled` | `false`           | Enable Starship config deployment          |
-| `shell_starship_preset`         | `''`              | Starship preset (see docs for options)     |
+| `shell_starship_preset`         | `''`              | Starship preset (empty = minimal default)  |
 | `shell_starship_shells`         | `['zsh', 'bash']` | Configure Starship for these shells        |
+
+When `shell_starship_config_enabled` is `true`, the role deploys
+`~/.config/starship.toml` per user (from `shell_users` or `users_list`).
+With a preset set, content is rendered via `starship preset <name>`. With
+an empty preset, a minimal placeholder is deployed. Deployment honours
+`shell_user_config_mode`: `'managed'` reconciles every run, `'initial'`
+only deploys if the file is absent, `'disabled'` skips entirely.
+
+Valid preset names (source: `starship preset --list`):
+`bracketed-segments`, `catppuccin-powerline`, `gruvbox-rainbow`,
+`jetpack`, `nerd-font-symbols`, `no-empty-icons`, `no-nerd-font`,
+`no-runtime-versions`, `pastel-powerline`, `plain-text-symbols`,
+`pure-preset`, `tokyo-night`. An invalid preset value fails the
+role at start with a clear assertion message.
 
 ### Additional Tools
 
@@ -103,12 +117,13 @@ and adds Starship init automatically.
 
 ## Tags
 
-| Tag              | Description                    |
-|------------------|--------------------------------|
-| `shell`          | All shell tasks                |
-| `shell:install`  | Package installation           |
-| `shell:ohmyzsh`  | Oh My Zsh setup and config     |
-| `shell:users`    | User shell configuration       |
+| Tag               | Description                    |
+|-------------------|--------------------------------|
+| `shell`           | All shell tasks                |
+| `shell:install`   | Package installation           |
+| `shell:ohmyzsh`   | Oh My Zsh setup and config     |
+| `shell:users`     | User shell configuration       |
+| `shell:starship`  | Starship per-user config       |
 
 ## Example Playbook
 

--- a/roles/shell/defaults/main.yml
+++ b/roles/shell/defaults/main.yml
@@ -17,7 +17,9 @@ shell_default: 'bash'
 shell_users: []
 
 # User configuration mode: managed (always deploy), initial (only if absent), disabled
-shell_user_config_mode: 'managed'
+# 'initial' preserves user customisations after first deploy.
+# Set to 'managed' for continuous reconciliation.
+shell_user_config_mode: 'initial'
 
 #
 # Zsh
@@ -85,7 +87,12 @@ shell_starship_enabled: true
 # Enable Starship config deployment
 shell_starship_config_enabled: false
 
-# Starship preset: plain-text, nerd-font, no-nerd-font, pastel-powerline, tokyo-night, gruvbox-rainbow
+# Starship preset (empty = minimal default config)
+# Options: bracketed-segments, catppuccin-powerline, gruvbox-rainbow,
+#          jetpack, nerd-font-symbols, no-empty-icons, no-nerd-font,
+#          no-runtime-versions, pastel-powerline, plain-text-symbols,
+#          pure-preset, tokyo-night
+# Source: `starship preset --list`
 shell_starship_preset: ''
 
 # Configure Starship for shells (adds init to shell config)

--- a/roles/shell/molecule/default/converge.yml
+++ b/roles/shell/molecule/default/converge.yml
@@ -49,3 +49,27 @@
     - name: Converge | Include shell role (ohmyzsh)  # noqa: role-name[path]
       ansible.builtin.include_role:
         name: '{{ playbook_dir }}/../..'
+
+- name: Converge — Starship config (Arch only — starship not in Debian/EL repos)
+  hosts: all
+  gather_facts: true
+
+  vars:
+    shell_enabled: true
+    shell_default: 'bash'
+    shell_zsh_enabled: false
+    shell_fish_enabled: false
+    shell_bash_completion_enabled: false
+    shell_starship_enabled: true
+    shell_starship_config_enabled: true
+    shell_starship_preset: 'plain-text-symbols'
+    shell_user_config_mode: 'managed'
+    shell_users:
+      - 'testuser'
+    shell_fzf_enabled: false
+
+  tasks:
+    - name: Converge | Include shell role (starship)  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+      when: ansible_facts['os_family'] == 'Archlinux'

--- a/roles/shell/molecule/default/verify.yml
+++ b/roles/shell/molecule/default/verify.yml
@@ -138,3 +138,22 @@
       register: _shell_ohmyzsh_theme
       changed_when: false
       failed_when: _shell_ohmyzsh_theme.rc != 0
+
+    #
+    # Starship config (Arch only)
+    #
+
+    - name: Verify | Check starship.toml deployed (Arch)
+      ansible.builtin.stat:
+        path: '/home/testuser/.config/starship.toml'
+      register: _shell_starship_toml
+      failed_when: not _shell_starship_toml.stat.exists
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | Check starship.toml contains plain-text-symbols content (Arch)
+      ansible.builtin.command:
+        cmd: 'grep -q "success_symbol" /home/testuser/.config/starship.toml'
+      register: _shell_starship_content
+      changed_when: false
+      failed_when: _shell_starship_content.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -17,6 +17,21 @@
     - shell
     - shell:vars
 
+- name: Main | Validate Starship preset
+  ansible.builtin.assert:
+    that:
+      - shell_starship_preset | length == 0
+        or shell_starship_preset in __shell_starship_valid_presets
+    fail_msg: >-
+      shell_starship_preset must be empty or one of
+      {{ __shell_starship_valid_presets }}, got: '{{ shell_starship_preset }}'
+  when:
+    - shell_enabled | bool
+    - shell_starship_enabled | bool
+    - shell_starship_config_enabled | bool
+  tags:
+    - shell
+
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml
   when: shell_enabled | bool
@@ -42,3 +57,13 @@
   tags:
     - shell
     - shell:users
+
+- name: Main | Import Starship config tasks
+  ansible.builtin.import_tasks: starship.yml
+  when:
+    - shell_enabled | bool
+    - shell_starship_enabled | bool
+    - shell_starship_config_enabled | bool
+  tags:
+    - shell
+    - shell:starship

--- a/roles/shell/tasks/starship.yml
+++ b/roles/shell/tasks/starship.yml
@@ -1,0 +1,55 @@
+---
+#
+# Starship Per-User Configuration
+#
+
+- name: Starship | Get users to configure
+  ansible.builtin.set_fact:
+    __shell_starship_users: >-
+      {{ shell_users if shell_users | length > 0
+         else (users_list | default([]) | map(attribute='name') | list) }}
+
+- name: Starship | Ensure ~/.config exists
+  ansible.builtin.file:
+    path: '/home/{{ item }}/.config'
+    state: directory
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0755'
+  loop: '{{ __shell_starship_users }}'
+  when: shell_user_config_mode != 'disabled'
+
+- name: Starship | Render preset content
+  ansible.builtin.command:
+    cmd: 'starship preset {{ shell_starship_preset }}'
+  register: __shell_starship_preset_content
+  changed_when: false
+  when:
+    - shell_user_config_mode != 'disabled'
+    - shell_starship_preset | length > 0
+
+- name: Starship | Deploy preset config
+  ansible.builtin.copy:
+    content: "{{ __shell_starship_preset_content.stdout }}\n"
+    dest: '/home/{{ item }}/.config/starship.toml'
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+    force: "{{ shell_user_config_mode == 'managed' }}"
+  loop: '{{ __shell_starship_users }}'
+  when:
+    - shell_user_config_mode != 'disabled'
+    - shell_starship_preset | length > 0
+
+- name: Starship | Deploy minimal default config (no preset)
+  ansible.builtin.template:
+    src: 'starship.toml.j2'
+    dest: '/home/{{ item }}/.config/starship.toml'
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+    force: "{{ shell_user_config_mode == 'managed' }}"
+  loop: '{{ __shell_starship_users }}'
+  when:
+    - shell_user_config_mode != 'disabled'
+    - shell_starship_preset | length == 0

--- a/roles/shell/templates/starship.toml.j2
+++ b/roles/shell/templates/starship.toml.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+# Starship config — minimal default (no preset selected).
+# See https://starship.rs/config/ for available options.

--- a/roles/shell/vars/main.yml
+++ b/roles/shell/vars/main.yml
@@ -13,3 +13,18 @@ __shell_paths:
   zsh: '/usr/bin/zsh'
   fish: '/usr/bin/fish'
   bash: '/bin/bash'
+
+# Valid Starship presets (source: `starship preset --list`)
+__shell_starship_valid_presets:
+  - 'bracketed-segments'
+  - 'catppuccin-powerline'
+  - 'gruvbox-rainbow'
+  - 'jetpack'
+  - 'nerd-font-symbols'
+  - 'no-empty-icons'
+  - 'no-nerd-font'
+  - 'no-runtime-versions'
+  - 'pastel-powerline'
+  - 'plain-text-symbols'
+  - 'pure-preset'
+  - 'tokyo-night'


### PR DESCRIPTION
## Summary

Two starship-related variables were defined in `defaults/main.yml`
(`shell_starship_config_enabled`, `shell_starship_preset`) but never
used in tasks or templates — pure no-ops. This PR wires them up so
they actually deploy a per-user `~/.config/starship.toml`.

This PR also flips `shell_user_config_mode` default from `'managed'`
to `'initial'`. The previous default silently overwrote user
customisations of `.zshrc` / Oh My Zsh / (now) starship.toml on every
Ansible run. `'initial'` deploys on first run and leaves user edits
alone afterwards. Users who want continuous reconciliation opt in
with `shell_user_config_mode: 'managed'`.

## Added

- `tasks/starship.yml`: per-user `~/.config/starship.toml` deployment
  gated by `shell_enabled and shell_starship_enabled and
  shell_starship_config_enabled`, honouring `shell_user_config_mode`
  (`'managed'` reconciles every run, `'initial'` deploys only when
  the file is absent, `'disabled'` skips entirely).
- `templates/starship.toml.j2`: minimal placeholder config used when
  `shell_starship_preset` is empty.
- `vars/main.yml`: `__shell_starship_valid_presets` list (12 presets
  from `starship preset --list`).
- Tag `shell:starship` for selective runs.

## Changes

- `defaults/main.yml`: change `shell_user_config_mode` default to
  `'initial'`; rewrite `shell_starship_preset` comment with the
  correct upstream preset list (the previous comment listed wrong
  names like `nerd-font` instead of `nerd-font-symbols`).
- `tasks/main.yml`: assert `shell_starship_preset` is empty or in
  `__shell_starship_valid_presets`; import the new starship tasks
  when starship config is enabled.
- `README.md`: update default in the table; add prose explaining
  starship deployment behaviour and listing valid preset names; add
  `shell:starship` tag row.
- `molecule/default/converge.yml`: add a third play exercising the
  starship config path (Arch only — starship is only packaged in
  Arch repos in the current vars).
- `molecule/default/verify.yml`: assert `~/.config/starship.toml`
  exists and contains preset content (`success_symbol` line from
  `plain-text-symbols`).

## Preset content via starship CLI

The role calls `starship preset <name>` at run time and writes the
output to `starship.toml`. This avoids bundling 12 preset files in
the role and keeps content authoritative against the installed
starship version. `changed_when: false` on the render task with
`copy.force` controlling deployment yields proper idempotence.

## Behaviour change — breaking

`shell_user_config_mode` default flip from `'managed'` to `'initial'`:
the same input now produces different observable behaviour. On hosts
where the role-deployed `.zshrc` / Oh My Zsh files were customised
locally, those customisations are now preserved across runs instead
of being overwritten.

To restore the previous behaviour:

```yaml
shell_user_config_mode: 'managed'
```

The starship-related changes are not breaking on their own:
`shell_starship_config_enabled` defaults to `false` (unchanged), so
inventories that never set it see no new file. Inventories that
explicitly set `shell_starship_config_enabled: true` were getting a
no-op before; they now get a `starship.toml` deployed. The semantic
matches the variable's documented intent.

## Test plan

- [x] Molecule passes on archlinux (native, ohmyzsh, and new starship
      scenario)
- [x] Starship preset content rendered into
      `~/.config/starship.toml` (verified `success_symbol` line from
      `plain-text-symbols`)
- [x] Idempotence: second run reports no changes (changed=0)
- [x] ansible-lint clean

Cases verified on the live workstation (not exercised by molecule):

- [ ] Disabled (default `shell_starship_config_enabled: false`): no
      `~/.config/starship.toml` created
- [ ] Empty preset: minimal placeholder deployed
- [ ] Invalid preset: assert fails fast with clear error
- [ ] `shell_user_config_mode: 'initial'`, file modified by user:
      file left untouched on next run
- [ ] `shell_user_config_mode: 'disabled'`: skipped entirely

Closes #51