### PR TITLE
fix!: Implement keepassxc 'initial' user_config_mode; flip default to 'initial'

### DIFF
--- a/roles/keepassxc/README.md
+++ b/roles/keepassxc/README.md
@@ -68,7 +68,7 @@ overrides if needed.
 | Variable                          | Default             | Description                                                |
 | --------------------------------- | ------------------- | ---------------------------------------------------------- |
 | `keepassxc_deploy_config_enabled` | `false`             | Deploy default configuration file                          |
-| `keepassxc_user_config_mode`      | `managed`           | Default config mode: `managed`, `initial`, or `disabled`   |
+| `keepassxc_user_config_mode`      | `initial`           | Default config mode: `managed`, `initial`, or `disabled`   |
 | `keepassxc_config_dir`            | `.config/keepassxc` | Configuration directory (relative to home)                 |
 | `keepassxc_config`                | *(see defaults)*    | Configuration settings dict                                |
 
@@ -77,6 +77,18 @@ overrides if needed.
 | Variable          | Default | Description                           |
 | ----------------- | ------- | ------------------------------------- |
 | `keepassxc_users` | `[]`    | Users list for per-user configuration |
+
+User config mode semantics:
+
+| Mode      | First run | Subsequent runs                          |
+|-----------|-----------|------------------------------------------|
+| `managed` | deploy    | overwrite (always reconcile to template) |
+| `initial` | deploy    | leave existing user customisations alone |
+| `disabled`| skip      | skip                                     |
+
+`'initial'` is the default: deploys when `~/.config/keepassxc/keepassxc.ini`
+is absent for the user, otherwise leaves the file untouched. Per-user
+override via `item.mode` takes precedence over the role-level default.
 
 Each user entry supports:
 

--- a/roles/keepassxc/defaults/main.yml
+++ b/roles/keepassxc/defaults/main.yml
@@ -61,9 +61,11 @@ keepassxc_deploy_config_enabled: false
 
 # Default mode when user entry has no 'mode' key
 # managed = always deploy/overwrite config
-# initial = deploy only when user is newly created
+# initial = deploy only if keepassxc.ini does not yet exist for the user
 # disabled = skip config deployment for this user
-keepassxc_user_config_mode: 'managed'
+# 'initial' preserves user customisations after first deploy.
+# Set to 'managed' for continuous reconciliation.
+keepassxc_user_config_mode: 'initial'
 
 #
 # Users

--- a/roles/keepassxc/molecule/default/converge.yml
+++ b/roles/keepassxc/molecule/default/converge.yml
@@ -8,6 +8,9 @@
     keepassxc_secret_service_enabled: true
     keepassxc_secret_service_scope: 'global'  # pragma: allowlist secret
     keepassxc_autostart_enabled: false
+    keepassxc_users:
+      - name: 'testuser'
+        mode: 'managed'
 
   tasks:
     - name: Converge | Include keepassxc role  # noqa: role-name[path]

--- a/roles/keepassxc/molecule/default/prepare.yml
+++ b/roles/keepassxc/molecule/default/prepare.yml
@@ -43,3 +43,9 @@
         mode: '0440'
         validate: 'visudo -cf %s'
       when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Prepare | Create test user
+      ansible.builtin.user:
+        name: testuser
+        create_home: true
+        shell: /bin/bash

--- a/roles/keepassxc/molecule/default/verify.yml
+++ b/roles/keepassxc/molecule/default/verify.yml
@@ -65,3 +65,33 @@
             '/usr/bin/keepassxc'
             in (_keepassxc_secret_content.content | b64decode)
         fail_msg: 'Secret Service configuration incorrect'
+
+    #
+    # Per-user Config Verification (testuser, mode: managed)
+    #
+
+    - name: Verify | Check testuser keepassxc.ini exists
+      ansible.builtin.stat:
+        path: '/home/testuser/.config/keepassxc/keepassxc.ini'
+      register: _keepassxc_user_ini
+
+    - name: Verify | Assert testuser keepassxc.ini deployed
+      ansible.builtin.assert:
+        that:
+          - _keepassxc_user_ini.stat.exists
+          - _keepassxc_user_ini.stat.pw_name == 'testuser'
+          - _keepassxc_user_ini.stat.mode == '0600'
+        fail_msg: 'testuser keepassxc.ini missing or wrong ownership/permissions'
+
+    - name: Verify | Read testuser keepassxc.ini
+      ansible.builtin.slurp:
+        src: '/home/testuser/.config/keepassxc/keepassxc.ini'
+      register: _keepassxc_user_ini_content
+
+    - name: Verify | Assert managed-mode template values present
+      ansible.builtin.assert:
+        that:
+          - "'[FdoSecrets]' in (_keepassxc_user_ini_content.content | b64decode)"
+          - "'[Security]' in (_keepassxc_user_ini_content.content | b64decode)"
+          - "'ConfigVersion=2' in (_keepassxc_user_ini_content.content | b64decode)"
+        fail_msg: 'testuser keepassxc.ini missing expected sections/values'

--- a/roles/keepassxc/tasks/configure.yml
+++ b/roles/keepassxc/tasks/configure.yml
@@ -3,6 +3,33 @@
 # KeePassXC Configure Tasks
 #
 
+- name: Configure | Stat existing per-user keepassxc.ini
+  ansible.builtin.stat:
+    path: '/home/{{ item.name }}/{{ keepassxc_config_dir }}/keepassxc.ini'
+  loop: '{{ keepassxc_users }}'
+  loop_control:
+    label: '{{ item.name }}'
+  register: __keepassxc_config_stats
+  when:
+    - keepassxc_users | length > 0
+    - (item.mode | default(keepassxc_user_config_mode)) != 'disabled'
+
+- name: Configure | Build per-user deploy decision
+  ansible.builtin.set_fact:
+    __keepassxc_should_deploy: >-
+      {{
+        dict(__keepassxc_config_stats.results
+             | rejectattr('skipped', 'defined')
+             | map(attribute='item.name')
+             | zip(__keepassxc_config_stats.results
+                   | rejectattr('skipped', 'defined')
+                   | map(attribute='stat.exists')
+                   | map('ternary', false, true)))
+      }}
+  when:
+    - keepassxc_users | length > 0
+    - __keepassxc_config_stats is defined
+
 - name: Configure | Create config directories
   ansible.builtin.file:
     path: '/home/{{ item.name }}/{{ keepassxc_config_dir }}'
@@ -16,6 +43,8 @@
   when:
     - keepassxc_users | length > 0
     - (item.mode | default(keepassxc_user_config_mode)) != 'disabled'
+    - (item.mode | default(keepassxc_user_config_mode)) == 'managed'
+      or __keepassxc_should_deploy[item.name] | default(true)
 
 # General
 - name: Configure | General settings
@@ -34,6 +63,8 @@
   when:
     - keepassxc_users | length > 0
     - (item.mode | default(keepassxc_user_config_mode)) != 'disabled'
+    - (item.mode | default(keepassxc_user_config_mode)) == 'managed'
+      or __keepassxc_should_deploy[item.name] | default(true)
 
 # Browser
 - name: Configure | Browser integration
@@ -52,6 +83,8 @@
   when:
     - keepassxc_users | length > 0
     - (item.mode | default(keepassxc_user_config_mode)) != 'disabled'
+    - (item.mode | default(keepassxc_user_config_mode)) == 'managed'
+      or __keepassxc_should_deploy[item.name] | default(true)
 
 # FdoSecrets
 - name: Configure | Secret Service (FdoSecrets)
@@ -70,6 +103,8 @@
   when:
     - keepassxc_users | length > 0
     - (item.mode | default(keepassxc_user_config_mode)) != 'disabled'
+    - (item.mode | default(keepassxc_user_config_mode)) == 'managed'
+      or __keepassxc_should_deploy[item.name] | default(true)
 
 # GUI
 - name: Configure | GUI settings
@@ -95,6 +130,8 @@
   when:
     - keepassxc_users | length > 0
     - (item.0.mode | default(keepassxc_user_config_mode)) != 'disabled'
+    - (item.0.mode | default(keepassxc_user_config_mode)) == 'managed'
+      or __keepassxc_should_deploy[item.0.name] | default(true)
 
 # SSHAgent
 - name: Configure | SSH Agent
@@ -113,6 +150,8 @@
   when:
     - keepassxc_users | length > 0
     - (item.mode | default(keepassxc_user_config_mode)) != 'disabled'
+    - (item.mode | default(keepassxc_user_config_mode)) == 'managed'
+      or __keepassxc_should_deploy[item.name] | default(true)
 
 # Security
 - name: Configure | Security settings
@@ -151,3 +190,5 @@
   when:
     - keepassxc_users | length > 0
     - (item.0.mode | default(keepassxc_user_config_mode)) != 'disabled'
+    - (item.0.mode | default(keepassxc_user_config_mode)) == 'managed'
+      or __keepassxc_should_deploy[item.0.name] | default(true)


### PR DESCRIPTION
## Summary

`tasks/configure.yml` only guarded against `mode == 'disabled'`, so
`'initial'` behaved identically to `'managed'`: every run overwrote
the user's `keepassxc.ini`. The promised "deploy only on first
creation" semantics were never implemented.

This PR implements the missing differentiation: per-user `stat` of
`keepassxc.ini`, then skip all `ini_file` tasks for `'initial'`-mode
users when the file already exists. This PR also flips the default
from `'managed'` to `'initial'` so user customisations are preserved
by default — matching the safer pattern adopted in browser (#55) and
shell (#58) for the same reason.

## Implementation

- `tasks/configure.yml` now starts with two new tasks:
  1. `Configure | Stat existing per-user keepassxc.ini` — per-user
     stat of `~/.config/keepassxc/keepassxc.ini`, skipped for
     disabled users.
  2. `Configure | Build per-user deploy decision` — derives a
     `__keepassxc_should_deploy` dict (username → bool) where True
     means "file is absent, deploy".
- Each existing `ini_file` task gains a third `when` condition:
  `mode == 'managed' or __keepassxc_should_deploy[item.name] | default(true)`.
  managed always runs; initial runs only when the file is absent.

## Mode semantics

| Mode       | First run | Subsequent runs                          |
|------------|-----------|------------------------------------------|
| `managed`  | deploy    | overwrite (always reconcile to template) |
| `initial`  | deploy    | leave existing user customisations alone |
| `disabled` | skip      | skip                                     |

## Changes

- `defaults/main.yml`: change default to `'initial'`; clarify the
  comment ("deploy only if `keepassxc.ini` does not yet exist for the
  user")
- `tasks/configure.yml`: stat + deploy-decision + updated `when`
  clauses on all 7 ini_file/file tasks
- `README.md`: update default in the table; add a mode-semantics
  table and prose explaining `'initial'` behaviour
- `molecule/default/prepare.yml`: create `testuser` so the configure
  loop has work to do
- `molecule/default/converge.yml`: add `keepassxc_users` with
  `testuser` in `'managed'` mode
- `molecule/default/verify.yml`: assert
  `~/.config/keepassxc/keepassxc.ini` exists, owned by testuser, mode
  `0600`, contains `[FdoSecrets]`, `[Security]`, `ConfigVersion=2`

## Behaviour change — breaking

Default flip from `'managed'` to `'initial'`: same input now produces
different observable behaviour. On hosts where the role-deployed
`keepassxc.ini` was customised locally, those customisations are now
preserved across runs instead of being overwritten.

To restore the previous behaviour:

```yaml
keepassxc_user_config_mode: 'managed'
```

The implementation fix half is not breaking on its own — inventories
that explicitly set `'initial'` were getting `'managed'`-equivalent
behaviour (a bug). They will now get the documented `'initial'`
semantics.

## Test plan

- [x] Molecule passes on archlinux: managed-mode user config
      deployed, idempotent on re-run
- [x] testuser keepassxc.ini exists, owned by testuser, mode `0600`,
      contains expected sections
- [x] ansible-lint clean

Cases verified on the live workstation (not exercised by molecule):

- [ ] Mode `'initial'` (default), file absent on first run: deployed
- [ ] Mode `'initial'`, file modified by user: file left untouched
      on second run
- [ ] Mode `'disabled'`: never deployed
- [ ] Per-user `item.mode` overrides the role-level default in all
      three combinations

Closes #46