### PR TITLE
fix!: Implement wine 'initial' user_config_mode; flip default to 'initial'

### DIFF
--- a/roles/wine/README.md
+++ b/roles/wine/README.md
@@ -73,8 +73,20 @@ Debian handles 32-bit automatically via multiarch. EL 9 uses WoW64 mode.
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| `wine_user_config_mode` | `'managed'` | Default mode (`managed`/`initial`/`disabled`) |
+| `wine_user_config_mode` | `'initial'` | Default mode (`managed`/`initial`/`disabled`) |
 | `wine_users` | `[]` | Users for Wine prefix initialization |
+
+User config mode semantics:
+
+| Mode       | First run | Subsequent runs                          |
+|------------|-----------|------------------------------------------|
+| `managed`  | deploy    | overwrite (always reconcile to template) |
+| `initial`  | deploy    | leave existing user customisations alone |
+| `disabled` | skip      | skip                                     |
+
+`'initial'` is the default: runs `wineboot --init` only when the user's
+`{prefix}/system.reg` is absent. Per-user override via `item.mode`
+takes precedence over the role-level default.
 
 User entry format:
 

--- a/roles/wine/defaults/main.yml
+++ b/roles/wine/defaults/main.yml
@@ -79,7 +79,9 @@ wine_env: {}
 # managed = always ensure prefix exists and is initialized
 # initial = create prefix only if it does not exist
 # disabled = skip prefix creation
-wine_user_config_mode: 'managed'
+# 'initial' preserves user customisations after first deploy.
+# Set to 'managed' for continuous reconciliation.
+wine_user_config_mode: 'initial'
 
 # Users for Wine prefix initialization
 wine_users: []

--- a/roles/wine/tasks/configure.yml
+++ b/roles/wine/tasks/configure.yml
@@ -22,6 +22,39 @@
 # User Prefix Initialization
 #
 
+- name: Configure | Stat existing wine prefix per user
+  ansible.builtin.stat:
+    path: "{{ item.prefix | default('/home/' + item.username + '/.wine') }}/system.reg"
+  loop: '{{ wine_users }}'
+  loop_control:
+    label: '{{ item.username }}'
+  register: __wine_prefix_stats
+  when:
+    - wine_users | length > 0
+    - (item.mode | default(wine_user_config_mode)) != 'disabled'
+  tags:
+    - wine
+    - wine:configure
+
+- name: Configure | Build per-user deploy decision
+  ansible.builtin.set_fact:
+    __wine_should_deploy: >-
+      {{
+        dict(__wine_prefix_stats.results
+             | rejectattr('skipped', 'defined')
+             | map(attribute='item.username')
+             | zip(__wine_prefix_stats.results
+                   | rejectattr('skipped', 'defined')
+                   | map(attribute='stat.exists')
+                   | map('ternary', false, true)))
+      }}
+  when:
+    - wine_users | length > 0
+    - __wine_prefix_stats is defined
+  tags:
+    - wine
+    - wine:configure
+
 - name: Configure | Include user configuration tasks
   ansible.builtin.include_tasks:
     file: users.yml
@@ -36,6 +69,8 @@
   when:
     - wine_users | length > 0
     - (__wine_user.mode | default(wine_user_config_mode)) != 'disabled'
+    - (__wine_user.mode | default(wine_user_config_mode)) == 'managed'
+      or __wine_should_deploy[__wine_user.username] | default(true)
   tags:
     - wine
     - wine:configure


### PR DESCRIPTION
## Summary

`tasks/configure.yml` only guarded the user-config include against
`mode == 'disabled'`, so `'initial'` behaved identically to `'managed'`:
the include fired every run regardless. The promised "deploy only when
absent" semantics were never implemented at the role level.

(In practice the included `users.yml` task uses `creates:` on
`wineboot --init`, so the heavy work was already first-run-only. But
the gating contract was still wrong, and any future deploy task added
without `creates:` would surface the bug.)

This PR implements the missing differentiation: per-user `stat` of
`{prefix}/system.reg`, then skip the user include for `'initial'`-mode
users when the prefix already exists. This PR also flips the default
from `'managed'` to `'initial'` so user customisations are preserved
by default — matching the safer pattern adopted in browser (#55),
shell (#58), and keepassxc (#59).

## Implementation

- `tasks/configure.yml` adds two new tasks before the user include:
  1. `Configure | Stat existing wine prefix per user` — per-user
     stat of `{prefix}/system.reg`, skipped for disabled users.
  2. `Configure | Build per-user deploy decision` — derives a
     `__wine_should_deploy` dict (username → bool) where True means
     "prefix is absent, deploy".
- The user include gains a third `when` condition:
  `mode == 'managed' or __wine_should_deploy[__wine_user.username] | default(true)`.

## Mode semantics

| Mode       | First run | Subsequent runs                          |
|------------|-----------|------------------------------------------|
| `managed`  | deploy    | overwrite (always reconcile to template) |
| `initial`  | deploy    | leave existing user customisations alone |
| `disabled` | skip      | skip                                     |

## Changes

- `defaults/main.yml`: change default to `'initial'`; clarify the
  comment with the standard managed/initial/disabled blurb
- `tasks/configure.yml`: stat + deploy-decision + updated `when` on
  the user include
- `README.md`: update default in the table; add a mode-semantics
  table and prose explaining `'initial'` behaviour

## Behaviour change — breaking

Default flip from `'managed'` to `'initial'`: same input now produces
different observable behaviour at the gating layer. Inventories that
never override `wine_user_config_mode` will now skip the wine user
configure include entirely on subsequent runs once
`{prefix}/system.reg` exists.

To restore the previous behaviour:

```yaml
wine_user_config_mode: 'managed'
```

In practice the heavy work (`wineboot --init`) was already first-run-only
via `creates:`, so most existing inventories see no observable change.
The behavioural gap surfaces only for any deploy task added in the
future without its own `creates:` guard, or for explicit
`wine_user_config_mode: 'managed'` users who relied on the per-run
include firing.

## Test plan

- [x] Molecule passes on archlinux (wine_users empty in molecule, the
      new gate code is exercised only when wine_users is non-empty —
      same as before)
- [x] Idempotence: second run reports no changes (changed=0)
- [x] ansible-lint clean

Cases verified on the live workstation (not exercised by molecule):

- [ ] Mode `'initial'` (default), prefix absent: deploy fires, prefix
      created
- [ ] Mode `'initial'`, prefix present: include skipped entirely
- [ ] Mode `'managed'`: include fires every run
- [ ] Mode `'disabled'`: include never fires
- [ ] Per-user `item.mode` overrides the role-level default

Closes #53