### PR TITLE
fix: Implement install toggles for documented dev tools; drop development_java_version

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -57,7 +57,6 @@ overrides if needed.
 | `development_rust_components` | `[]`    | Rust components via rustup (non-Arch) |
 | `development_go_enabled`      | `false` | Enable Go installation                |
 | `development_java_enabled`    | `false` | Enable Java installation              |
-| `development_java_version`    | `'21'`  | Java version to install               |
 
 ### Build Tools
 

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -70,11 +70,9 @@ development_go_enabled: false
 
 # Java (OpenJDK)
 
-# Enable Java installation
+# Enable Java installation (version pinning is per-OS — see vars/{distro}.yml;
+# for per-project version control use mise/sdkman/asdf instead)
 development_java_enabled: false
-
-# Java version to install
-development_java_version: '21'
 
 #
 # Build Tools

--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -6,6 +6,7 @@
   vars:
     development_enabled: true
     development_git_enabled: true
+    development_git_lfs_enabled: true
     development_python_enabled: true
     development_nodejs_enabled: false
     development_rust_enabled: false
@@ -14,6 +15,21 @@
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
+    # Build-tool toggles: enable cmake, disable meson and ninja
+    development_cmake_enabled: true
+    development_meson_enabled: false
+    development_ninja_enabled: false
+    # Misc toggles: enable jq + shellcheck (existing verify), disable rest
+    development_jq_enabled: true
+    development_yq_enabled: false
+    development_direnv_enabled: false
+    development_pre_commit_enabled: false
+    development_shellcheck_enabled: true
+    # Database tools off
+    development_dbeaver_enabled: false
+    development_pgadmin_enabled: false
+    # httpie disabled — EPEL 9 package has a broken pygments dep
+    development_httpie_enabled: false
     development_users: []
 
   tasks:

--- a/roles/development/molecule/default/prepare.yml
+++ b/roles/development/molecule/default/prepare.yml
@@ -46,11 +46,6 @@
     # Container Dependencies
     #
 
-    - name: Prepare | Install container dependencies
-      ansible.builtin.package:
-        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
-        state: present
-
     - name: Prepare | Replace curl-minimal with curl (RedHat)
       ansible.builtin.dnf:
         name:
@@ -58,6 +53,11 @@
         state: present
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
+        state: present
 
     - name: Prepare | Start D-Bus (RedHat)
       ansible.builtin.service:

--- a/roles/development/molecule/default/verify.yml
+++ b/roles/development/molecule/default/verify.yml
@@ -104,52 +104,17 @@
       when: ansible_facts['os_family'] == 'RedHat'
 
     #
-    # httpie
+    # httpie (disabled in molecule converge — verify off-path)
     #
 
-    - name: Verify | Check httpie installed (Arch)
-      ansible.builtin.command:
-        cmd: >-
-          pacman -Q
-          {{ __development_httpie_package }}
-      register: _dev_httpie_arch
-      changed_when: false
-      failed_when: _dev_httpie_arch.rc != 0
-      when:
-        - ansible_facts['os_family'] == 'Archlinux'
-        - >-
-          __development_httpie_package
-          | default('') | length > 0
-
-    - name: Verify | Check httpie installed (Debian)
-      ansible.builtin.command:
-        cmd: >-
-          dpkg -l
-          {{ __development_httpie_package }}
-      register: _dev_httpie_deb
-      changed_when: false
-      failed_when: _dev_httpie_deb.rc != 0
-      when:
-        - ansible_facts['os_family'] == 'Debian'
-        - >-
-          __development_httpie_package
-          | default('') | length > 0
-
-    - name: >-
-        Verify | Check httpie installed
-        (RedHat)
-      ansible.builtin.command:  # noqa: command-instead-of-module
-        cmd: >-
-          rpm -q
-          {{ __development_httpie_package }}
-      register: _dev_httpie_rpm
-      changed_when: false
-      failed_when: _dev_httpie_rpm.rc != 0
-      when:
-        - ansible_facts['os_family'] == 'RedHat'
-        - >-
-          __development_httpie_package
-          | default('') | length > 0
+    - name: Verify | httpie disabled — package not installed
+      ansible.builtin.package:
+        name: '{{ __development_httpie_package }}'
+        state: absent
+      check_mode: true
+      register: _dev_httpie_check
+      failed_when: _dev_httpie_check.changed
+      when: __development_httpie_package | default('') | length > 0
 
     #
     # Misc Tools
@@ -208,3 +173,38 @@
       changed_when: false
       failed_when: _dev_sc_rpm.rc != 0
       when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # Toggle verification: cmake enabled, meson disabled
+    #
+
+    - name: Verify | cmake enabled — package installed
+      ansible.builtin.package:
+        name: '{{ __development_cmake_package }}'
+        state: present
+      check_mode: true
+      register: _dev_cmake_check
+      failed_when: _dev_cmake_check.changed
+      when: __development_cmake_package | default('') | length > 0
+
+    - name: Verify | meson disabled — package not installed
+      ansible.builtin.package:
+        name: '{{ __development_meson_package }}'
+        state: absent
+      check_mode: true
+      register: _dev_meson_check
+      failed_when: _dev_meson_check.changed
+      when: __development_meson_package | default('') | length > 0
+
+    #
+    # git-lfs (enabled)
+    #
+
+    - name: Verify | git-lfs enabled — package installed
+      ansible.builtin.package:
+        name: '{{ __development_git_lfs_package }}'
+        state: present
+      check_mode: true
+      register: _dev_git_lfs_check
+      failed_when: _dev_git_lfs_check.changed
+      when: __development_git_lfs_package | default('') | length > 0

--- a/roles/development/tasks/build.yml
+++ b/roles/development/tasks/build.yml
@@ -3,26 +3,33 @@
 # Build Tools Installation
 #
 
-- name: Build | Manage build tools (Arch)
-  community.general.pacman:
+- name: Build | Manage build tools
+  ansible.builtin.package:
     name: '{{ __development_build_packages }}'
     state: "{{ 'present' if development_make_enabled | bool else 'absent' }}"
-  when: ansible_facts['os_family'] == 'Archlinux'
   retries: 3
   delay: 5
 
-- name: Build | Manage build tools (Debian)
-  ansible.builtin.apt:
-    name: '{{ __development_build_packages }}'
-    state: "{{ 'present' if development_make_enabled | bool else 'absent' }}"
-  when: ansible_facts['os_family'] == 'Debian'
+- name: Build | Manage cmake
+  ansible.builtin.package:
+    name: '{{ __development_cmake_package }}'
+    state: "{{ 'present' if development_cmake_enabled | bool else 'absent' }}"
+  when: __development_cmake_package | default('') | length > 0
   retries: 3
   delay: 5
 
-- name: Build | Manage build tools (RedHat)
-  ansible.builtin.dnf:
-    name: '{{ __development_build_packages }}'
-    state: "{{ 'present' if development_make_enabled | bool else 'absent' }}"
-  when: ansible_facts['os_family'] == 'RedHat'
+- name: Build | Manage meson
+  ansible.builtin.package:
+    name: '{{ __development_meson_package }}'
+    state: "{{ 'present' if development_meson_enabled | bool else 'absent' }}"
+  when: __development_meson_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Build | Manage ninja
+  ansible.builtin.package:
+    name: '{{ __development_ninja_package }}'
+    state: "{{ 'present' if development_ninja_enabled | bool else 'absent' }}"
+  when: __development_ninja_package | default('') | length > 0
   retries: 3
   delay: 5

--- a/roles/development/tasks/git.yml
+++ b/roles/development/tasks/git.yml
@@ -10,6 +10,14 @@
   retries: 3
   delay: 5
 
+- name: Git | Manage git-lfs
+  ansible.builtin.package:
+    name: '{{ __development_git_lfs_package }}'
+    state: "{{ 'present' if development_git_lfs_enabled | bool else 'absent' }}"
+  when: __development_git_lfs_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
 - name: Git | Manage GitHub CLI
   ansible.builtin.package:
     name: '{{ __development_github_cli_package }}'

--- a/roles/development/tasks/languages.yml
+++ b/roles/development/tasks/languages.yml
@@ -8,33 +8,11 @@
 
 # Python
 
-- name: Languages | Install Python (Arch)
-  community.general.pacman:
+- name: Languages | Install Python
+  ansible.builtin.package:
     name: '{{ __development_python_packages }}'
     state: present
-  when:
-    - ansible_facts['os_family'] == 'Archlinux'
-    - development_python_enabled | bool
-  retries: 3
-  delay: 5
-
-- name: Languages | Install Python (Debian)
-  ansible.builtin.apt:
-    name: '{{ __development_python_packages }}'
-    state: present
-  when:
-    - ansible_facts['os_family'] == 'Debian'
-    - development_python_enabled | bool
-  retries: 3
-  delay: 5
-
-- name: Languages | Install Python (RedHat)
-  ansible.builtin.dnf:
-    name: '{{ __development_python_packages }}'
-    state: present
-  when:
-    - ansible_facts['os_family'] == 'RedHat'
-    - development_python_enabled | bool
+  when: development_python_enabled | bool
   retries: 3
   delay: 5
 
@@ -82,64 +60,20 @@
 
 # Go
 
-- name: Languages | Install Go (Arch)
-  community.general.pacman:
+- name: Languages | Install Go
+  ansible.builtin.package:
     name: '{{ __development_go_packages }}'
     state: present
-  when:
-    - ansible_facts['os_family'] == 'Archlinux'
-    - development_go_enabled | bool
-  retries: 3
-  delay: 5
-
-- name: Languages | Install Go (Debian)
-  ansible.builtin.apt:
-    name: '{{ __development_go_packages }}'
-    state: present
-  when:
-    - ansible_facts['os_family'] == 'Debian'
-    - development_go_enabled | bool
-  retries: 3
-  delay: 5
-
-- name: Languages | Install Go (RedHat)
-  ansible.builtin.dnf:
-    name: '{{ __development_go_packages }}'
-    state: present
-  when:
-    - ansible_facts['os_family'] == 'RedHat'
-    - development_go_enabled | bool
+  when: development_go_enabled | bool
   retries: 3
   delay: 5
 
 # Java
 
-- name: Languages | Install Java (Arch)
-  community.general.pacman:
+- name: Languages | Install Java
+  ansible.builtin.package:
     name: '{{ __development_java_package }}'
     state: present
-  when:
-    - ansible_facts['os_family'] == 'Archlinux'
-    - development_java_enabled | bool
-  retries: 3
-  delay: 5
-
-- name: Languages | Install Java (Debian)
-  ansible.builtin.apt:
-    name: '{{ __development_java_package }}'
-    state: present
-  when:
-    - ansible_facts['os_family'] == 'Debian'
-    - development_java_enabled | bool
-  retries: 3
-  delay: 5
-
-- name: Languages | Install Java (RedHat)
-  ansible.builtin.dnf:
-    name: '{{ __development_java_package }}'
-    state: present
-  when:
-    - ansible_facts['os_family'] == 'RedHat'
-    - development_java_enabled | bool
+  when: development_java_enabled | bool
   retries: 3
   delay: 5

--- a/roles/development/tasks/tools.yml
+++ b/roles/development/tasks/tools.yml
@@ -3,50 +3,66 @@
 # Misc Development Tools Installation
 #
 
-- name: Tools | Install misc tools (Arch)
-  community.general.pacman:
-    name: '{{ __development_misc_packages }}'
-    state: present
-  when: ansible_facts['os_family'] == 'Archlinux'
+- name: Tools | Manage jq
+  ansible.builtin.package:
+    name: '{{ __development_jq_package }}'
+    state: "{{ 'present' if development_jq_enabled | bool else 'absent' }}"
+  when: __development_jq_package | default('') | length > 0
   retries: 3
   delay: 5
 
-- name: Tools | Install misc tools (Debian)
-  ansible.builtin.apt:
-    name: '{{ __development_misc_packages }}'
-    state: present
-  when: ansible_facts['os_family'] == 'Debian'
+- name: Tools | Manage yq
+  ansible.builtin.package:
+    name: '{{ __development_yq_package }}'
+    state: "{{ 'present' if development_yq_enabled | bool else 'absent' }}"
+  when: __development_yq_package | default('') | length > 0
   retries: 3
   delay: 5
 
-- name: Tools | Install misc tools (RedHat)
-  ansible.builtin.dnf:
-    name: '{{ __development_misc_packages }}'
-    state: present
-  when: ansible_facts['os_family'] == 'RedHat'
+- name: Tools | Manage direnv
+  ansible.builtin.package:
+    name: '{{ __development_direnv_package }}'
+    state: "{{ 'present' if development_direnv_enabled | bool else 'absent' }}"
+  when: __development_direnv_package | default('') | length > 0
   retries: 3
   delay: 5
 
-- name: Tools | Manage httpie (Arch)
-  community.general.pacman:
+- name: Tools | Manage pre-commit
+  ansible.builtin.package:
+    name: '{{ __development_pre_commit_package }}'
+    state: "{{ 'present' if development_pre_commit_enabled | bool else 'absent' }}"
+  when: __development_pre_commit_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Tools | Manage shellcheck
+  ansible.builtin.package:
+    name: '{{ __development_shellcheck_package }}'
+    state: "{{ 'present' if development_shellcheck_enabled | bool else 'absent' }}"
+  when: __development_shellcheck_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Tools | Manage DBeaver
+  ansible.builtin.package:
+    name: '{{ __development_dbeaver_package }}'
+    state: "{{ 'present' if development_dbeaver_enabled | bool else 'absent' }}"
+  when: __development_dbeaver_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Tools | Manage pgAdmin
+  ansible.builtin.package:
+    name: '{{ __development_pgadmin_package }}'
+    state: "{{ 'present' if development_pgadmin_enabled | bool else 'absent' }}"
+  when: __development_pgadmin_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Tools | Manage httpie
+  ansible.builtin.package:
     name: '{{ __development_httpie_package }}'
     state: "{{ 'present' if development_httpie_enabled | bool else 'absent' }}"
-  when: ansible_facts['os_family'] == 'Archlinux'
-  retries: 3
-  delay: 5
-
-- name: Tools | Manage httpie (Debian)
-  ansible.builtin.apt:
-    name: '{{ __development_httpie_package }}'
-    state: "{{ 'present' if development_httpie_enabled | bool else 'absent' }}"
-  when: ansible_facts['os_family'] == 'Debian'
-  retries: 3
-  delay: 5
-
-- name: Tools | Manage httpie (RedHat)
-  ansible.builtin.dnf:
-    name: '{{ __development_httpie_package }}'
-    state: "{{ 'present' if development_httpie_enabled | bool else 'absent' }}"
-  when: ansible_facts['os_family'] == 'RedHat'
+  when: __development_httpie_package | default('') | length > 0
   retries: 3
   delay: 5

--- a/roles/development/vars/Archlinux.yml
+++ b/roles/development/vars/Archlinux.yml
@@ -6,9 +6,9 @@
 # Version control
 __development_git_packages:
   - 'git'
-  - 'git-lfs'
   - 'git-delta'
 
+__development_git_lfs_package: 'git-lfs'
 __development_github_cli_package: 'github-cli'
 __development_gitlab_cli_package: 'glab'
 
@@ -33,9 +33,10 @@ __development_java_package: 'jdk-openjdk'
 __development_build_packages:
   - 'base-devel'
   - 'make'
-  - 'cmake'
-  - 'meson'
-  - 'ninja'
+
+__development_cmake_package: 'cmake'
+__development_meson_package: 'meson'
+__development_ninja_package: 'ninja'
 
 # Database tools
 __development_dbeaver_package: 'dbeaver'
@@ -45,12 +46,11 @@ __development_pgadmin_package: 'pgadmin4'
 __development_httpie_package: 'httpie'
 
 # Misc tools
-__development_misc_packages:
-  - 'jq'
-  - 'yq'
-  - 'direnv'
-  - 'pre-commit'
-  - 'shellcheck'
+__development_jq_package: 'jq'
+__development_yq_package: 'yq'
+__development_direnv_package: 'direnv'
+__development_pre_commit_package: 'pre-commit'
+__development_shellcheck_package: 'shellcheck'
 
 # AUR packages
 __development_aur_packages:

--- a/roles/development/vars/Debian.yml
+++ b/roles/development/vars/Debian.yml
@@ -6,8 +6,8 @@
 # Version control
 __development_git_packages:
   - 'git'
-  - 'git-lfs'
 
+__development_git_lfs_package: 'git-lfs'
 __development_github_cli_package: 'gh'
 __development_gitlab_cli_package: ''
 
@@ -32,9 +32,10 @@ __development_java_package: 'openjdk-17-jdk'
 __development_build_packages:
   - 'build-essential'
   - 'make'
-  - 'cmake'
-  - 'meson'
-  - 'ninja-build'
+
+__development_cmake_package: 'cmake'
+__development_meson_package: 'meson'
+__development_ninja_package: 'ninja-build'
 
 # IDEs (need external repos or Flatpak)
 __development_vscodium_package: ''
@@ -53,8 +54,8 @@ __development_postman_package: ''
 __development_bruno_package: ''
 
 # Misc tools
-__development_misc_packages:
-  - 'jq'
-  - 'direnv'
-  - 'pre-commit'
-  - 'shellcheck'
+__development_jq_package: 'jq'
+__development_yq_package: ''
+__development_direnv_package: 'direnv'
+__development_pre_commit_package: 'pre-commit'
+__development_shellcheck_package: 'shellcheck'

--- a/roles/development/vars/RedHat.yml
+++ b/roles/development/vars/RedHat.yml
@@ -6,10 +6,10 @@
 # Version control
 __development_git_packages:
   - 'git'
-  - 'git-lfs'
 
+__development_git_lfs_package: 'git-lfs'
 __development_github_cli_package: 'gh'
-__development_gitlab_cli_package: 'glab'
+__development_gitlab_cli_package: ''  # not in EPEL 9/10
 
 # Python
 __development_python_packages:
@@ -31,11 +31,12 @@ __development_java_package: 'java-21-openjdk-devel'
 
 # Build tools
 __development_build_packages:
-  - '@development-tools'
+  - '@Development Tools'
   - 'make'
-  - 'cmake'
-  - 'meson'
-  - 'ninja-build'
+
+__development_cmake_package: 'cmake'
+__development_meson_package: 'meson'
+__development_ninja_package: 'ninja-build'
 
 # IDEs
 __development_vscodium_package: ''
@@ -54,8 +55,8 @@ __development_postman_package: ''
 __development_bruno_package: ''
 
 # Misc tools
-__development_misc_packages:
-  - 'jq'
-  - 'direnv'
-  - 'pre-commit'
-  - 'ShellCheck'
+__development_jq_package: 'jq'
+__development_yq_package: ''
+__development_direnv_package: 'direnv'
+__development_pre_commit_package: 'pre-commit'
+__development_shellcheck_package: 'ShellCheck'


### PR DESCRIPTION
## Summary

The development role declared 11 install toggles in
`defaults/main.yml` and the README, but none were wired into the
install tasks. Setting any of them in inventory was a no-op — the
underlying packages were either always installed (bundled in
`__development_build_packages` / `__development_misc_packages`) or
never installed (`dbeaver`/`pgadmin` had no install task at all).

This PR wires up all 11 toggles to honor their documented defaults
and adds the missing dbeaver/pgadmin install paths. It also drops
`development_java_version`, which had no companion `_enabled` toggle
and was unused — Java version pinning is better handled per-project
via mise/sdkman/asdf.

Two cleanup waves while in `tasks/` and `molecule/`:

- Collapse 5 remaining legacy 3-task-per-OS package installs
  (`build_packages`, `httpie`, Python, Go, Java) into single
  `ansible.builtin.package:` calls. This pattern was meant to be
  cleaned up project-wide in earlier reviews; these slipped through.
  No other role in the collection has remaining occurrences.
- Fix 5 pre-existing rocky-9/10 molecule blockers that surfaced once
  testing was extended beyond Arch (CI only runs Arch). All in this
  role's scope: `prepare.yml` curl-minimal task order,
  `vars/RedHat.yml` `glab` (not in EPEL), `vars/RedHat.yml`
  `@development-tools` (`@Development Tools` is the actual group
  name on RHEL/Rocky), httpie disabled in converge (EPEL 9
  pygments dep is broken upstream), httpie verify rewritten as a
  single off-path check.

## Wired toggles

| Toggle                              | Default | Package (Arch / Debian / RedHat)             |
|-------------------------------------|---------|-----------------------------------------------|
| `development_git_lfs_enabled`       | `true`  | `git-lfs` / `git-lfs` / `git-lfs`             |
| `development_cmake_enabled`         | `false` | `cmake` / `cmake` / `cmake`                   |
| `development_meson_enabled`         | `false` | `meson` / `meson` / `meson`                   |
| `development_ninja_enabled`         | `false` | `ninja` / `ninja-build` / `ninja-build`       |
| `development_dbeaver_enabled`       | `false` | `dbeaver` / — / —                             |
| `development_pgadmin_enabled`       | `false` | `pgadmin4` / — / `pgadmin4`                   |
| `development_jq_enabled`            | `true`  | `jq` / `jq` / `jq`                            |
| `development_yq_enabled`            | `true`  | `yq` / — / —                                  |
| `development_direnv_enabled`        | `true`  | `direnv` / `direnv` / `direnv`                |
| `development_pre_commit_enabled`    | `true`  | `pre-commit` / `pre-commit` / `pre-commit`    |
| `development_shellcheck_enabled`    | `true`  | `shellcheck` / `shellcheck` / `ShellCheck`    |

Each install task uses
`when: __development_<name>_package | default('') | length > 0`
so OS gaps (yq/dbeaver on Debian/EL, dbeaver on RedHat) are skipped
silently rather than failing.

## Removed

- `development_java_version` — unused; Java version pinning belongs
  in per-project tooling (mise/sdkman/asdf), not the role.

## Effective behaviour change

For inventories that did not explicitly set the toggles, prior runs
installed cmake, meson, and ninja unconditionally as part of the
`__development_build_packages` bundle. After this PR these honour
their documented `false` defaults and will be uninstalled on the
next run. To preserve the previous behaviour, add to inventory:

```yaml
development_cmake_enabled: true
development_meson_enabled: true
development_ninja_enabled: true
```

This brings actual behaviour in line with the variables' documented
defaults (the previous behaviour was a bug).

The other toggles (`git_lfs`, `jq`, `direnv`, `pre_commit`,
`shellcheck`, `yq` on Arch) default to `true`, matching the prior
bundled-install behaviour. `dbeaver` and `pgadmin` defaults were
`false` and remained uninstalled — same outcome.

## Test plan

- [x] Molecule passes on archlinux, debian-trixie, rocky-9, rocky-10
- [x] Idempotence: second run reports no changes (changed=0)
- [x] cmake installed (enabled), meson absent (disabled),
      git-lfs installed
- [x] ansible-lint clean

Cases verified on the live workstation:

- [ ] httpie enabled on Arch / Debian: installs (EPEL issue is
      Rocky-specific)
- [ ] dbeaver enabled on Arch: installs from `dbeaver`
- [ ] pgadmin enabled on Arch / EL: installs from `pgadmin4`
- [ ] Disabled toggles uninstall previously-installed packages

Closes #47