### PR TITLE
ci(matrix): per-PR multi-platform molecule + weekly cron full-matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Weekly on Sunday 07:00 UTC — catches upstream package drift
+    # (EPEL / Arch repos / Debian) without code changes.
+    - cron: '0 7 * * 0'
+  workflow_dispatch:
 
 jobs:
   # =============================================================================
@@ -119,6 +124,8 @@ jobs:
   # Determines which podman roles need molecule testing based on git diff.
   # Only substantive changes trigger tests (not README-only edits).
   # Shared file changes (galaxy.yml, plugins/, meta/runtime.yml) test all roles.
+  # On schedule / workflow_dispatch: full matrix (all roles × all platforms)
+  # to catch upstream package drift.
   # =============================================================================
   detect-changes:
     name: Detect Changed Roles
@@ -132,7 +139,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine changed roles
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      - name: Determine roles and platforms to test
         id: set-matrix
         run: |
           # Auto-detect podman roles from molecule driver config
@@ -144,59 +154,76 @@ jobs:
             fi
           done
 
-          # Determine base commit for diff
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            BASE="${{ github.event.before }}"
-          else
-            # Force push or initial push — test all roles
-            echo "Initial or force push — testing all roles"
-            BASE=""
-          fi
-
-          # If no valid base, test all podman roles
-          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+          # On schedule or manual dispatch: test everything
+          EVENT="${{ github.event_name }}"
+          if [ "$EVENT" = "schedule" ] || [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "Event '$EVENT' — full matrix (all roles × all platforms)"
             ROLES="$ALL_PODMAN_ROLES"
           else
-            CHANGED=$(git diff --name-only "$BASE" "${{ github.sha }}")
+            # Determine base commit for diff
+            if [ "$EVENT" = "pull_request" ]; then
+              BASE="${{ github.event.pull_request.base.sha }}"
+            elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+              BASE="${{ github.event.before }}"
+            else
+              echo "Initial or force push — testing all roles"
+              BASE=""
+            fi
 
-            # Shared files that require testing all roles
-            if echo "$CHANGED" | grep -qE '^(galaxy\.yml|requirements\.yml|plugins/|meta/runtime\.yml)'; then
-              echo "Shared files changed — testing all roles"
+            # If no valid base, test all podman roles
+            if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
               ROLES="$ALL_PODMAN_ROLES"
             else
-              # Find roles with substantive changes (skip README-only)
-              ROLES=$(echo "$CHANGED" \
-                | grep '^roles/' \
-                | grep -v '/README\.md$' \
-                | sed 's|^roles/\([^/]*\)/.*|\1|' \
-                | sort -u \
-                | tr '\n' ' ')
+              CHANGED=$(git diff --name-only "$BASE" "${{ github.sha }}")
 
-              # Filter to podman roles only
-              FILTERED=""
-              for role in $ROLES; do
-                if echo " $ALL_PODMAN_ROLES " | grep -q " $role "; then
-                  FILTERED="$FILTERED $role"
-                fi
-              done
-              ROLES="$FILTERED"
+              # Shared files that require testing all roles
+              if echo "$CHANGED" | grep -qE '^(galaxy\.yml|requirements\.yml|plugins/|meta/runtime\.yml)'; then
+                echo "Shared files changed — testing all roles"
+                ROLES="$ALL_PODMAN_ROLES"
+              else
+                # Find roles with substantive changes (skip README-only)
+                ROLES=$(echo "$CHANGED" \
+                  | grep '^roles/' \
+                  | grep -v '/README\.md$' \
+                  | sed 's|^roles/\([^/]*\)/.*|\1|' \
+                  | sort -u \
+                  | tr '\n' ' ')
+
+                # Filter to podman roles only
+                FILTERED=""
+                for role in $ROLES; do
+                  if echo " $ALL_PODMAN_ROLES " | grep -q " $role "; then
+                    FILTERED="$FILTERED $role"
+                  fi
+                done
+                ROLES="$FILTERED"
+              fi
             fi
           fi
 
-          # Build JSON matrix
+          # Build JSON matrix: one entry per (role, platform) pair.
+          # Platforms are parsed from each role's molecule.yml so roles
+          # with fewer platforms (elgato, tuxedo, wine) get fewer entries.
           MATRIX="["
           FIRST=true
           for role in $ROLES; do
             [ -z "$role" ] && continue
-            platform="$(echo "$role" | tr '_' '-')-archlinux"
-            if [ "$FIRST" = "true" ]; then
-              FIRST=false
-            else
-              MATRIX="${MATRIX},"
-            fi
-            MATRIX="${MATRIX}{\"role\":\"${role}\",\"platform\":\"${platform}\"}"
+            platforms=$(python3 -c "
+          import yaml, sys
+          with open(sys.argv[1]) as f:
+              data = yaml.safe_load(f)
+          for p in data.get('platforms', []):
+              print(p['name'])
+          " "roles/$role/molecule/default/molecule.yml")
+
+            for platform in $platforms; do
+              if [ "$FIRST" = "true" ]; then
+                FIRST=false
+              else
+                MATRIX="${MATRIX},"
+              fi
+              MATRIX="${MATRIX}{\"role\":\"${role}\",\"platform\":\"${platform}\"}"
+            done
           done
           MATRIX="${MATRIX}]"
 
@@ -206,12 +233,14 @@ jobs:
           else
             echo "has_roles=true" >> "$GITHUB_OUTPUT"
             echo "Roles to test: $ROLES"
+            echo "Matrix entries: $(echo "$MATRIX" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')"
           fi
 
           echo "matrix={\"include\":${MATRIX}}" >> "$GITHUB_OUTPUT"
 
   # =============================================================================
-  # MOLECULE ROLE-BY-ROLE (changed roles only, Arch Linux)
+  # MOLECULE ROLE × PLATFORM (changed roles × all their platforms;
+  # full matrix on schedule / workflow_dispatch)
   # =============================================================================
   molecule-roles:
     name: Molecule ${{ matrix.role }} (${{ matrix.platform }})

--- a/roles/browser/molecule/default/molecule.yml
+++ b/roles/browser/molecule/default/molecule.yml
@@ -22,7 +22,7 @@ platforms:
     tmpfs:
       /run: rw,nosuid,nodev,size=65536k
       /tmp: rw,nosuid,nodev
-  - name: browser-rocky9
+  - name: browser-rocky-9
     image: docker.io/geerlingguy/docker-rockylinux9-ansible:latest
     pre_build_image: true
     command: /usr/lib/systemd/systemd
@@ -32,7 +32,7 @@ platforms:
     tmpfs:
       /run: rw,nosuid,nodev,size=65536k
       /tmp: rw,nosuid,nodev
-  - name: browser-rocky10
+  - name: browser-rocky-10
     image: docker.io/geerlingguy/docker-rockylinux10-ansible:latest
     pre_build_image: true
     command: /usr/lib/systemd/systemd
@@ -56,9 +56,9 @@ provisioner:
         ansible_python_interpreter: /usr/bin/python
       browser-debian-trixie:
         ansible_python_interpreter: /usr/bin/python3
-      browser-rocky9:
+      browser-rocky-9:
         ansible_python_interpreter: /usr/bin/python3
-      browser-rocky10:
+      browser-rocky-10:
         ansible_python_interpreter: /usr/bin/python3
 verifier:
   name: ansible


### PR DESCRIPTION
Extends the existing `detect-changes` job so it emits one matrix entry per `(role, platform)` pair instead of just per role × archlinux. Platforms are parsed from each role's `molecule.yml` at workflow time, so roles with fewer platforms (`elgato`/`tuxedo` arch-only, `wine` without rocky-10) get fewer matrix entries automatically — no hardcoded list.

## Triggers

| Event | Behaviour |
|---|---|
| `pull_request` / `push` | changed roles × all their platforms (existing diff logic, expanded matrix) |
| `schedule` (weekly Sun 07:00 UTC) | full matrix: all podman roles × all their platforms |
| `workflow_dispatch` | manual full matrix |

The weekly cron catches upstream package drift (EPEL, Arch repos) without code changes — exactly the class of bug that surfaced manually in #61: curl-minimal ordering, `glab` missing in EPEL, `@Development Tools` group naming, httpie pygments dep.

## Implementation

- `on:` adds `schedule` and `workflow_dispatch`.
- `detect-changes`: installs pyyaml; outer branch on `github.event_name`; per-role inner loop calls a small `python3 -c '...'` snippet to extract platform names from `molecule/default/molecule.yml`; matrix entries built per platform.
- `molecule-roles`: step body unchanged — drives entirely off the new matrix shape.
- `molecule-compat` (ansible-2.20): unchanged.
- `ci-gate`: unchanged — already reads `molecule-roles` result.

## Housekeeping

Normalises `roles/browser/molecule/default/molecule.yml` platform names from `browser-rocky9`/`browser-rocky10` to `browser-rocky-9`/`browser-rocky-10` to match the project-wide `<role>-rocky-<N>` pattern. The hardcoded matrix entry in `molecule-compat` is unaffected (only references `browser-archlinux`).

## Test plan

- [x] Local sanity-test of platform parser: 25 podman roles correctly parsed (elgato + tuxedo: 1 platform; wine: 3; rest: 4).
- [x] Local sanity-test of matrix JSON construction with mixed roles (elgato, wine, browser) yields 8 entries with correct shape.
- [x] yamllint clean on `ci.yml` and browser `molecule.yml`.
- [ ] First PR after merge: confirm 4 platform jobs spawn for one changed role.
- [ ] First scheduled run: confirm full matrix (~100 jobs) executes.
- [ ] CI Gate stays green when all roles green, red on any failure.

## Out of scope

Cross-collection propagation — port to common, rocky, archlinux, server after this CI iteration has run 1-2 weeks and the pattern proves stable. Probably as reusable workflows in a shared repo (`marcstraube/ansible-ci-shared`).

Closes #62