### PR TITLE
docs: add References sections to roles touched in v2.0.0 prep

### DIFF
--- a/roles/browser/README.md
+++ b/roles/browser/README.md
@@ -153,6 +153,18 @@ molecule test
 - **Driver:** Podman
 - **Platforms:** Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [Firefox](https://www.mozilla.org/firefox/) — Open-source web browser
+- [Mozilla Policy Templates](https://mozilla.github.io/policy-templates/) — Reference for `policies.json` keys deployed by this role
+- [arkenfox/user.js](https://github.com/arkenfox/user.js) — Hardened Firefox `user.js` template the role's defaults derive from
+- [Chromium](https://www.chromium.org/) — Open-source browser project
+- [Chromium Enterprise Policy List](https://chromeenterprise.google/policies/) — Reference for Chromium/Brave policy keys
+- [LibreWolf](https://librewolf.net/) — Privacy-focused Firefox fork
+- [Brave](https://brave.com/) — Privacy-focused Chromium fork
+- [Tor Browser](https://www.torproject.org/) — Anonymity-focused Firefox fork
+- [Zen Browser](https://zen-browser.app/) — Productivity-focused Firefox fork
+
 ## License
 
 MIT

--- a/roles/desktop_environment/README.md
+++ b/roles/desktop_environment/README.md
@@ -190,6 +190,19 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [Hyprland](https://hypr.land/) — Dynamic tiling Wayland compositor
+- [Sway](https://swaywm.org/) — i3-compatible Wayland compositor
+- [i3](https://i3wm.org/) — Tiling window manager (X11)
+- [KDE Plasma](https://kde.org/plasma-desktop/) — Full-featured Qt desktop environment
+- [GNOME](https://www.gnome.org/) — Modern GTK desktop environment
+- [XFCE](https://xfce.org/) — Lightweight GTK desktop environment
+- [LXDE](https://lxde.org/) — Lightweight X11 desktop environment
+- [LXQt](https://lxqt-project.org/) — Lightweight Qt desktop environment
+- [UWSM](https://github.com/Vladimir-csp/uwsm) — Universal Wayland Session Manager
+- [hyprland-qt-support](https://github.com/hyprwm/hyprland-qt-support) and the Hypr* ecosystem (hypridle, hyprlock, hyprpaper, hyprpicker, hyprshot, hyprsunset, hyprlauncher) — Companion utilities to Hyprland
+
 ## License
 
 MIT

--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -168,6 +168,21 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [Git](https://git-scm.com/) — Distributed version control system
+- [GitHub CLI](https://cli.github.com/) — `gh` command-line tool for GitHub
+- [glab](https://gitlab.com/gitlab-org/cli) — GitLab CLI
+- [pipx](https://pipx.pypa.io/) — Install Python applications in isolated environments
+- [rustup](https://rustup.rs/) — Rust toolchain installer (used on non-Arch)
+- [VSCodium](https://vscodium.com/) — Free/libre Code-OSS binaries (telemetry-free VS Code build)
+- [JetBrains Toolbox](https://www.jetbrains.com/toolbox-app/) — Manager for JetBrains IDEs
+- [Zed](https://zed.dev/) — High-performance multiplayer code editor
+- [HTTPie](https://httpie.io/) — Modern HTTP CLI client
+- [pre-commit](https://pre-commit.com/) — Multi-language git hook framework
+- [direnv](https://direnv.net/) — Per-directory environment variable loader
+- [ShellCheck](https://www.shellcheck.net/) — Shell script static analyser
+
 ## License
 
 MIT

--- a/roles/display_manager/README.md
+++ b/roles/display_manager/README.md
@@ -128,6 +128,16 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [SDDM](https://github.com/sddm/sddm) — Simple Desktop Display Manager (Qt-based)
+- [GDM](https://gitlab.gnome.org/GNOME/gdm) — GNOME Display Manager
+- [LightDM](https://github.com/canonical/lightdm) — Lightweight cross-desktop display manager
+- [greetd](https://sr.ht/~kennylevinsen/greetd/) — Minimal and flexible login daemon
+- [tuigreet](https://github.com/apognu/tuigreet) — Console-based greeter for greetd
+- [gtkgreet](https://git.sr.ht/~kennylevinsen/gtkgreet) — GTK-based greeter for greetd
+- [regreet](https://github.com/rharish101/ReGreet) — Clean and customizable GTK4 greeter for greetd
+
 ## License
 
 MIT

--- a/roles/keepassxc/README.md
+++ b/roles/keepassxc/README.md
@@ -136,6 +136,13 @@ cd collections/ansible_collections/marcstraube/desktop
 molecule test -s default -- --tags keepassxc
 ```
 
+## References
+
+- [KeePassXC](https://keepassxc.org/) — Cross-platform community-driven password manager
+- [KeePassXC Documentation](https://keepassxc.org/docs/) — User guide and configuration reference
+- [KeePassXC-Browser](https://github.com/keepassxreboot/keepassxc-browser) — Browser extension for autofill
+- [Freedesktop Secret Service API](https://specifications.freedesktop.org/secret-service-spec/latest/) — D-Bus API KeePassXC implements
+
 ## License
 
 MIT

--- a/roles/shell/README.md
+++ b/roles/shell/README.md
@@ -167,6 +167,23 @@ cd collections/ansible_collections/marcstraube/desktop
 molecule test -s default -- --limit shell-archlinux
 ```
 
+## References
+
+- [Bash](https://www.gnu.org/software/bash/) — GNU Bourne Again SHell
+- [Zsh](https://www.zsh.org/) — Z Shell — extended Bourne shell with many improvements
+- [Fish](https://fishshell.com/) — Smart and user-friendly command line shell
+- [Oh My Zsh](https://ohmyz.sh/) — Community-driven framework for managing Zsh configuration
+- [Starship](https://starship.rs/) — Minimal, fast, customizable cross-shell prompt
+- [Starship Presets](https://starship.rs/presets/) — Curated configuration presets (`starship preset --list`)
+- [grml-zsh-config](https://grml.org/zsh/) — Feature-rich Zsh setup from the GRML project
+- [fzf](https://github.com/junegunn/fzf) — Command-line fuzzy finder
+- [zoxide](https://github.com/ajeetdsouza/zoxide) — Smarter `cd` command
+- [eza](https://github.com/eza-community/eza) — Modern replacement for `ls`
+- [bat](https://github.com/sharkdp/bat) — `cat` clone with syntax highlighting and Git integration
+- [fd](https://github.com/sharkdp/fd) — Simple, fast, user-friendly alternative to `find`
+- [ripgrep](https://github.com/BurntSushi/ripgrep) — Recursive `grep` alternative respecting gitignore
+- [tldr](https://tldr.sh/) — Simplified, community-driven man pages
+
 ## License
 
 MIT

--- a/roles/terminal/README.md
+++ b/roles/terminal/README.md
@@ -84,6 +84,15 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [Ghostty](https://ghostty.org/) — Fast, native, GPU-accelerated terminal emulator
+- [Alacritty](https://alacritty.org/) — Cross-platform GPU-accelerated terminal emulator
+- [Kitty](https://sw.kovidgoyal.net/kitty/) — Fast, feature-rich, GPU-based terminal with image support
+- [Foot](https://codeberg.org/dnkl/foot) — Fast, lightweight, minimalist Wayland terminal emulator
+- [WezTerm](https://wezterm.org/) — GPU-accelerated cross-platform terminal emulator and multiplexer
+- [systemd.environment-generators(7)](https://www.freedesktop.org/software/systemd/man/latest/environment.d.html) — `/etc/environment.d/` reference
+
 ## License
 
 MIT

--- a/roles/wine/README.md
+++ b/roles/wine/README.md
@@ -138,6 +138,15 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9
 - NTsync (`wine_sync: 'ntsync'`) requires kernel 6.14+ and Wine 11+ for best
   performance
 
+## References
+
+- [Wine](https://www.winehq.org/) — Compatibility layer for running Windows applications on POSIX systems
+- [Wine Wiki](https://gitlab.winehq.org/wine/wine/-/wikis/home) — Documentation, configuration, and troubleshooting
+- [Wine AppDB](https://appdb.winehq.org/) — Application compatibility database
+- [DXVK](https://github.com/doitsujin/dxvk) — Vulkan-based DirectX 9/10/11 implementation for Wine
+- [VKD3D-Proton](https://github.com/HansKristian-Work/vkd3d-proton) — Vulkan-based DirectX 12 implementation
+- [winetricks](https://github.com/Winetricks/winetricks) — Helper script for installing common Windows DLLs and apps
+
 ## License
 
 MIT


### PR DESCRIPTION
Per the project memory note "README References section — add upstream links when working on any role", and matching the existing convention in marcstraube.common roles (`## References` between content and `## License`, format `[Tool](URL) — One-line description`).

Adds References sections to the 8 desktop roles modified during the v2.0.0 preparation cycle:

| Role | Tools / upstream links |
|---|---|
| `browser` | Firefox, Mozilla Policy Templates, arkenfox/user.js, Chromium + Enterprise Policy List, LibreWolf, Brave, Tor Browser, Zen Browser |
| `desktop_environment` | Hyprland, Sway, i3, KDE Plasma, GNOME, XFCE, LXDE, LXQt, UWSM, Hypr* ecosystem |
| `development` | Git, GitHub CLI, glab, pipx, rustup, VSCodium, JetBrains Toolbox, Zed, HTTPie, pre-commit, direnv, ShellCheck |
| `display_manager` | SDDM, GDM, LightDM, greetd, tuigreet, gtkgreet, regreet |
| `keepassxc` | KeePassXC, KeePassXC Documentation, KeePassXC-Browser, Freedesktop Secret Service API |
| `shell` | Bash, Zsh, Fish, Oh My Zsh, Starship, Starship Presets, grml-zsh-config, fzf, zoxide, eza, bat, fd, ripgrep, tldr |
| `terminal` | Ghostty, Alacritty, Kitty, Foot, WezTerm, systemd.environment-generators(7) |
| `wine` | Wine, Wine Wiki, Wine AppDB, DXVK, VKD3D-Proton, winetricks |

No code changes. The remaining ~18 desktop roles still need References sections but are out of scope for this PR (the rule is "add when working on the role" — those weren't touched in v2.0.0 prep).

## Test plan

- [x] ansible-lint clean
- [ ] Markdown Lint (CI)

Closes #66