### PR TITLE
fix(development): flip cmake/meson/ninja default to true

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -63,9 +63,9 @@ overrides if needed.
 | Variable                    | Default | Description                      |
 |-----------------------------|---------|----------------------------------|
 | `development_make_enabled`  | `true`  | Enable make and core build tools |
-| `development_cmake_enabled` | `false` | Enable cmake                     |
-| `development_meson_enabled` | `false` | Enable meson                     |
-| `development_ninja_enabled` | `false` | Enable ninja                     |
+| `development_cmake_enabled` | `true`  | Enable cmake                     |
+| `development_meson_enabled` | `true`  | Enable meson                     |
+| `development_ninja_enabled` | `true`  | Enable ninja                     |
 
 ### IDEs and Editors
 

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -82,13 +82,13 @@ development_java_enabled: false
 development_make_enabled: true
 
 # Enable cmake
-development_cmake_enabled: false
+development_cmake_enabled: true
 
 # Enable meson
-development_meson_enabled: false
+development_meson_enabled: true
 
 # Enable ninja
-development_ninja_enabled: false
+development_ninja_enabled: true
 
 #
 # IDEs and Editors


### PR DESCRIPTION
#47 / PR #61 wired up the previously no-op `development_cmake_enabled`, `_meson_enabled`, `_ninja_enabled` toggles and kept their documented `false` defaults. That was technically correct (honour the documented value) but missed the project's de-facto convention: primary packages within a role default to `true`; only heavy/specialised features default to `false`.

cmake/meson/ninja are a build-toolchain bundle, not a multi-tool switch — ninja is the backend for both cmake and meson, and projects commonly need either cmake or meson at the configure stage. Pre-#61 they were unconditionally installed via the bundled `__development_build_packages` list. Keeping defaults at `false` after #61 silently uninstalled them on inventories that did not override.

Flip to `true` so:

- New defaults match the project convention (core packages = `true`)
- Pre-#61 behaviour is preserved for inventories that don't override
- AUR / Python C-extension / Rust FFI workflows keep working out of the box

## Implementation

- `defaults/main.yml`: `development_cmake_enabled`, `_meson_enabled`, `_ninja_enabled` → `true`
- `README.md`: update default column to match

The molecule converge keeps `meson` and `ninja` explicitly at `false` and `cmake` explicitly at `true` to continue exercising both the on-path and off-path verify assertions — no test change needed.

## Test plan

- [x] ansible-lint clean
- [ ] Molecule passes on all 4 platforms (CI runs the full matrix per #63)
- [ ] Verify cmake installed (existing on-path test stays valid)
- [ ] Verify meson NOT installed (existing off-path test stays valid)

Closes #67