### PR TITLE
fix: unblock v2.0.0 CI matrix across desktop roles

### DIFF
--- a/roles/communication/README.md
+++ b/roles/communication/README.md
@@ -10,6 +10,10 @@ is individually toggleable via boolean variables. AUR packages are used on
 Arch Linux for applications not available in official repositories (Slack,
 Threema, Zoom, Teams, Jitsi Meet).
 
+On Rocky Linux, EPEL and CRB must be enabled before running this role
+(typically via `marcstraube.common.package_management`) — kmail / KDE PIM
+pulls KF5 libraries that live in CRB.
+
 ## Requirements
 
 - ansible-core >= 2.17
@@ -17,12 +21,12 @@ Threema, Zoom, Teams, Jitsi Meet).
 
 ## Supported Platforms
 
-| Platform                  | Notes |
-|---------------------------|-------|
-| Arch Linux                |       |
-| Debian Trixie             |       |
-| EL 9 (Rocky, Alma, RHEL)  |       |
-| EL 10 (Rocky, Alma, RHEL) |       |
+| Platform                  | Notes                                                  |
+|---------------------------|--------------------------------------------------------|
+| Arch Linux                | Native packages + AUR                                  |
+| Debian Trixie             | Official repo packages — telegram-desktop not available |
+| EL 9 (Rocky, Alma, RHEL)  | EPEL + CRB required (kmail / KDE PIM)                  |
+| EL 10 (Rocky, Alma, RHEL) | EPEL + CRB required (kmail / KDE PIM)                  |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/communication/molecule/default/prepare.yml
+++ b/roles/communication/molecule/default/prepare.yml
@@ -39,6 +39,19 @@
         update_cache: true
       when: ansible_facts['os_family'] == 'Debian'
 
+    - name: Prepare | Install EPEL repository (RedHat)
+      ansible.builtin.dnf:
+        name: epel-release
+        state: present
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    # kmail (KDE PIM) pulls libaspell.so.15 / KF5 libs from CRB.
+    - name: Prepare | Enable CRB repository (RedHat)
+      ansible.builtin.command:
+        cmd: dnf config-manager --set-enabled crb
+      changed_when: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true

--- a/roles/communication/vars/Debian.yml
+++ b/roles/communication/vars/Debian.yml
@@ -3,8 +3,9 @@
 # Debian-Specific Variables
 #
 
-# Telegram package
-__communication_telegram_package: 'telegram-desktop'
+# Telegram is not packaged in Debian Trixie main repos.
+# Users wanting Telegram on Debian should use flatpak.
+__communication_telegram_package: ''
 
 # Sieve email filtering (KDE PIM suite includes sieve editor)
 __communication_sieve_package: 'kmail'

--- a/roles/desktop_environment/README.md
+++ b/roles/desktop_environment/README.md
@@ -17,12 +17,12 @@ Wayland utilities integration, theme installation, and common desktop applicatio
 
 ## Supported Platforms
 
-| Platform                  | Notes                      |
-|---------------------------|----------------------------|
-| Arch Linux                | Full support including AUR |
-| Debian Trixie             | Limited Hyprland extras    |
-| EL 9 (Rocky, Alma, RHEL)  | Limited Hyprland extras    |
-| EL 10 (Rocky, Alma, RHEL) | Limited Hyprland extras    |
+| Platform                  | Notes                                             |
+|---------------------------|---------------------------------------------------|
+| Arch Linux                | Full support including AUR                        |
+| Debian Trixie             | Limited Hyprland extras                           |
+| EL 9 (Rocky, Alma, RHEL)  | EPEL — limited Hyprland extras                    |
+| EL 10 (Rocky, Alma, RHEL) | EPEL — limited Hyprland extras; XFCE not packaged |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/desktop_environment/molecule/default/verify.yml
+++ b/roles/desktop_environment/molecule/default/verify.yml
@@ -7,6 +7,15 @@
   hosts: all
   gather_facts: true
 
+  vars:
+    # XFCE is not packaged in EPEL 10 — skip XFCE-specific verification
+    # on Rocky 10. Tracked in upstream EPEL.
+    _de_xfce_unsupported: >-
+      {{
+        ansible_facts['os_family'] == 'RedHat'
+        and ansible_facts['distribution_major_version'] == '10'
+      }}
+
   tasks:
     #
     # XFCE Package Verification
@@ -34,7 +43,9 @@
       register: _de_xfce_rpm
       changed_when: false
       failed_when: _de_xfce_rpm.rc != 0
-      when: ansible_facts['os_family'] == 'RedHat'
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - not (_de_xfce_unsupported | bool)
 
     #
     # Configuration Directories
@@ -44,12 +55,14 @@
       ansible.builtin.stat:
         path: /usr/share/xfce4
       register: _de_xfce_share_dir
+      when: not (_de_xfce_unsupported | bool)
 
     - name: Verify | Assert xfce4 share directory exists
       ansible.builtin.assert:
         that:
           - _de_xfce_share_dir.stat.exists
         fail_msg: 'xfce4 share directory not found'
+      when: not (_de_xfce_unsupported | bool)
 
     #
     # Session File
@@ -59,9 +72,11 @@
       ansible.builtin.stat:
         path: /usr/share/xsessions/xfce.desktop
       register: _de_xfce_session_file
+      when: not (_de_xfce_unsupported | bool)
 
     - name: Verify | Assert xfce.desktop exists
       ansible.builtin.assert:
         that:
           - _de_xfce_session_file.stat.exists
         fail_msg: 'xfce.desktop session file not found'
+      when: not (_de_xfce_unsupported | bool)

--- a/roles/desktop_environment/vars/RedHat-10.yml
+++ b/roles/desktop_environment/vars/RedHat-10.yml
@@ -1,0 +1,142 @@
+---
+#
+# RedHat 10 Variables
+#
+
+#
+# Hyprland
+#
+
+__desktop_environment_hyprland_packages:
+  - 'hyprland'
+
+# Extras (available in EPEL)
+__desktop_environment_hyprland_hypridle_package: 'hypridle'
+__desktop_environment_hyprland_hyprlock_package: 'hyprlock'
+__desktop_environment_hyprland_hyprpaper_package: 'hyprpaper'
+__desktop_environment_hyprland_hyprpicker_package: 'hyprpicker'
+__desktop_environment_hyprland_hyprcursor_package: 'hyprcursor'
+__desktop_environment_hyprland_hyprshot_package: ''
+__desktop_environment_hyprland_hyprsunset_package: ''
+
+# Extras (not available on RedHat)
+__desktop_environment_hyprland_hyprlauncher_package: ''
+__desktop_environment_hyprland_hyprpwcenter_package: ''
+
+__desktop_environment_hyprland_portal_package: 'xdg-desktop-portal-hyprland'
+__desktop_environment_hyprland_polkit_package: ''
+__desktop_environment_hyprland_uwsm_package: ''
+
+#
+# Sway
+#
+
+__desktop_environment_sway_packages:
+  - 'sway'
+
+__desktop_environment_sway_extras_packages:
+  - 'swaylock'
+  - 'swayidle'
+  - 'swaybg'
+
+__desktop_environment_sway_portal_package: 'xdg-desktop-portal-wlr'
+
+#
+# i3
+#
+
+__desktop_environment_i3_packages:
+  - 'i3'
+
+__desktop_environment_i3_status_packages:
+  i3status: 'i3status'
+  i3blocks: 'i3blocks'
+  polybar: 'polybar'
+
+__desktop_environment_i3_dmenu_package: 'dmenu'
+__desktop_environment_i3_picom_package: 'picom'
+
+#
+# KDE
+#
+
+__desktop_environment_kde_minimal_packages:
+  - '@kde-desktop-environment'
+
+__desktop_environment_kde_full_packages:
+  - '@kde-desktop-environment'
+
+__desktop_environment_kde_app_packages:
+  dolphin: 'dolphin'
+  konsole: 'konsole'
+  kate: 'kate'
+  okular: 'okular'
+  gwenview: 'gwenview'
+  ark: 'ark'
+  spectacle: 'spectacle'
+  kcalc: 'kcalc'
+
+#
+# GNOME
+#
+
+__desktop_environment_gnome_minimal_packages:
+  - 'gnome-shell'
+
+__desktop_environment_gnome_full_packages:
+  - '@gnome-desktop'
+
+__desktop_environment_gnome_extras_package: ''
+__desktop_environment_gnome_tweaks_package: 'gnome-tweaks'
+
+#
+# XFCE
+#
+# Not packaged in EPEL 10.
+
+__desktop_environment_xfce_packages: []
+__desktop_environment_xfce_goodies_package: ''
+__desktop_environment_xfce_whiskermenu_package: ''
+
+#
+# LXDE
+#
+
+__desktop_environment_lxde_minimal_packages:
+  - 'lxde-common'
+  - 'lxsession'
+  - 'openbox'
+  - 'lxpanel'
+  - 'pcmanfm'
+
+__desktop_environment_lxde_full_packages:
+  - '@lxde-desktop-environment'
+
+#
+# LXQt
+#
+
+__desktop_environment_lxqt_minimal_packages:
+  - '@lxqt-desktop-environment'
+
+__desktop_environment_lxqt_full_packages:
+  - '@lxqt-desktop-environment'
+
+__desktop_environment_lxqt_icon_packages:
+  breeze-icons: 'breeze-icon-theme'
+  oxygen-icons: 'oxygen-icon-theme'
+
+#
+# Themes
+#
+
+__desktop_environment_cursor_theme_packages:
+  adwaita: 'adwaita-cursor-theme'
+  breeze: 'breeze-cursor-theme'
+  capitaine: ''
+
+__desktop_environment_icon_theme_packages:
+  adwaita: 'adwaita-icon-theme'
+  breeze: 'breeze-icon-theme'
+  papirus: 'papirus-icon-theme'
+  hicolor: 'hicolor-icon-theme'

--- a/roles/desktop_environment/vars/RedHat-9.yml
+++ b/roles/desktop_environment/vars/RedHat-9.yml
@@ -1,0 +1,145 @@
+---
+#
+# RedHat 9 Variables
+#
+
+#
+# Hyprland
+#
+
+__desktop_environment_hyprland_packages:
+  - 'hyprland'
+
+# Extras (available in EPEL)
+__desktop_environment_hyprland_hypridle_package: 'hypridle'
+__desktop_environment_hyprland_hyprlock_package: 'hyprlock'
+__desktop_environment_hyprland_hyprpaper_package: 'hyprpaper'
+__desktop_environment_hyprland_hyprpicker_package: 'hyprpicker'
+__desktop_environment_hyprland_hyprcursor_package: 'hyprcursor'
+__desktop_environment_hyprland_hyprshot_package: ''
+__desktop_environment_hyprland_hyprsunset_package: ''
+
+# Extras (not available on RedHat)
+__desktop_environment_hyprland_hyprlauncher_package: ''
+__desktop_environment_hyprland_hyprpwcenter_package: ''
+
+__desktop_environment_hyprland_portal_package: 'xdg-desktop-portal-hyprland'
+__desktop_environment_hyprland_polkit_package: ''
+__desktop_environment_hyprland_uwsm_package: ''
+
+#
+# Sway
+#
+
+__desktop_environment_sway_packages:
+  - 'sway'
+
+__desktop_environment_sway_extras_packages:
+  - 'swaylock'
+  - 'swayidle'
+  - 'swaybg'
+
+__desktop_environment_sway_portal_package: 'xdg-desktop-portal-wlr'
+
+#
+# i3
+#
+
+__desktop_environment_i3_packages:
+  - 'i3'
+
+__desktop_environment_i3_status_packages:
+  i3status: 'i3status'
+  i3blocks: 'i3blocks'
+  polybar: 'polybar'
+
+__desktop_environment_i3_dmenu_package: 'dmenu'
+__desktop_environment_i3_picom_package: 'picom'
+
+#
+# KDE
+#
+
+__desktop_environment_kde_minimal_packages:
+  - '@kde-desktop-environment'
+
+__desktop_environment_kde_full_packages:
+  - '@kde-desktop-environment'
+
+__desktop_environment_kde_app_packages:
+  dolphin: 'dolphin'
+  konsole: 'konsole'
+  kate: 'kate'
+  okular: 'okular'
+  gwenview: 'gwenview'
+  ark: 'ark'
+  spectacle: 'spectacle'
+  kcalc: 'kcalc'
+
+#
+# GNOME
+#
+
+__desktop_environment_gnome_minimal_packages:
+  - 'gnome-shell'
+
+__desktop_environment_gnome_full_packages:
+  - '@gnome-desktop'
+
+__desktop_environment_gnome_extras_package: ''
+__desktop_environment_gnome_tweaks_package: 'gnome-tweaks'
+
+#
+# XFCE
+#
+# EPEL 9 group name is `Xfce` (not `xfce-desktop-environment`).
+
+__desktop_environment_xfce_packages:
+  - '@Xfce'
+
+# Included in group
+__desktop_environment_xfce_goodies_package: ''
+__desktop_environment_xfce_whiskermenu_package: 'xfce4-whiskermenu-plugin'
+
+#
+# LXDE
+#
+
+__desktop_environment_lxde_minimal_packages:
+  - 'lxde-common'
+  - 'lxsession'
+  - 'openbox'
+  - 'lxpanel'
+  - 'pcmanfm'
+
+__desktop_environment_lxde_full_packages:
+  - '@lxde-desktop-environment'
+
+#
+# LXQt
+#
+
+__desktop_environment_lxqt_minimal_packages:
+  - '@lxqt-desktop-environment'
+
+__desktop_environment_lxqt_full_packages:
+  - '@lxqt-desktop-environment'
+
+__desktop_environment_lxqt_icon_packages:
+  breeze-icons: 'breeze-icon-theme'
+  oxygen-icons: 'oxygen-icon-theme'
+
+#
+# Themes
+#
+
+__desktop_environment_cursor_theme_packages:
+  adwaita: 'adwaita-cursor-theme'
+  breeze: 'breeze-cursor-theme'
+  capitaine: ''
+
+__desktop_environment_icon_theme_packages:
+  adwaita: 'adwaita-icon-theme'
+  breeze: 'breeze-icon-theme'
+  papirus: 'papirus-icon-theme'
+  hicolor: 'hicolor-icon-theme'

--- a/roles/development/molecule/default/prepare.yml
+++ b/roles/development/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:
@@ -22,6 +21,34 @@
         - curl
 
   tasks:
+    # Sudo PAM bypass — required for tasks using `become_user` on
+    # geerlingguy Rocky containers under GitHub-hosted runners
+    # (test container only).
+
+    - name: Prepare | Bypass sudo PAM stack (RedHat container)
+      ansible.builtin.copy:
+        content: |
+          #%PAM-1.0
+          auth       sufficient   pam_permit.so
+          account    sufficient   pam_permit.so
+          password   sufficient   pam_permit.so
+          session    sufficient   pam_permit.so
+        dest: /etc/pam.d/sudo
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Disable sudoers authentication (RedHat container)
+      ansible.builtin.copy:
+        content: 'Defaults !authenticate'
+        dest: /etc/sudoers.d/molecule-no-auth
+        owner: root
+        group: root
+        mode: '0440'
+        validate: 'visudo -cf %s'
+      when: ansible_facts['os_family'] == 'RedHat'
+
     #
     # Package Cache
     #

--- a/roles/gaming/molecule/default/prepare.yml
+++ b/roles/gaming/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:
@@ -16,6 +15,34 @@
         - glibc-locale-source
 
   tasks:
+    # Sudo PAM bypass — required for tasks using `become_user` on
+    # geerlingguy Rocky containers under GitHub-hosted runners
+    # (test container only).
+
+    - name: Prepare | Bypass sudo PAM stack (RedHat container)
+      ansible.builtin.copy:
+        content: |
+          #%PAM-1.0
+          auth       sufficient   pam_permit.so
+          account    sufficient   pam_permit.so
+          password   sufficient   pam_permit.so
+          session    sufficient   pam_permit.so
+        dest: /etc/pam.d/sudo
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Disable sudoers authentication (RedHat container)
+      ansible.builtin.copy:
+        content: 'Defaults !authenticate'
+        dest: /etc/sudoers.d/molecule-no-auth
+        owner: root
+        group: root
+        mode: '0440'
+        validate: 'visudo -cf %s'
+      when: ansible_facts['os_family'] == 'RedHat'
+
     #
     # Package Cache
     #

--- a/roles/imaging/README.md
+++ b/roles/imaging/README.md
@@ -9,6 +9,10 @@ processing tools across Arch Linux, Debian, and EL-based systems. Each
 application is individually toggleable via boolean variables. VueScan is
 available on Arch Linux only (AUR package).
 
+On Rocky Linux, EPEL must be enabled before running this role (typically
+via `marcstraube.common.package_management`) — simple-scan, skanlite,
+ImageMagick, and GraphicsMagick are not in the base repos.
+
 ## Requirements
 
 - ansible-core >= 2.17
@@ -16,12 +20,12 @@ available on Arch Linux only (AUR package).
 
 ## Supported Platforms
 
-| Platform                   | Notes |
-| -------------------------- | ----- |
-| Arch Linux                 |       |
-| Debian Trixie              |       |
-| EL 9 (Rocky, Alma, RHEL)   |       |
-| EL 10 (Rocky, Alma, RHEL)  |       |
+| Platform                   | Notes                                 |
+| -------------------------- | ------------------------------------- |
+| Arch Linux                 | Native packages + AUR                 |
+| Debian Trixie              | Official repo packages                |
+| EL 9 (Rocky, Alma, RHEL)   | EPEL packages                         |
+| EL 10 (Rocky, Alma, RHEL)  | EPEL packages — xsane not available   |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/imaging/molecule/default/prepare.yml
+++ b/roles/imaging/molecule/default/prepare.yml
@@ -1,10 +1,37 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:
+    # Sudo PAM bypass — required for tasks using `become_user` on
+    # geerlingguy Rocky containers under GitHub-hosted runners
+    # (test container only).
+
+    - name: Prepare | Bypass sudo PAM stack (RedHat container)
+      ansible.builtin.copy:
+        content: |
+          #%PAM-1.0
+          auth       sufficient   pam_permit.so
+          account    sufficient   pam_permit.so
+          password   sufficient   pam_permit.so
+          session    sufficient   pam_permit.so
+        dest: /etc/pam.d/sudo
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Disable sudoers authentication (RedHat container)
+      ansible.builtin.copy:
+        content: 'Defaults !authenticate'
+        dest: /etc/sudoers.d/molecule-no-auth
+        owner: root
+        group: root
+        mode: '0440'
+        validate: 'visudo -cf %s'
+      when: ansible_facts['os_family'] == 'RedHat'
+
     - name: Prepare | Update package cache (Arch)
       community.general.pacman:
         update_cache: true

--- a/roles/imaging/tasks/install.yml
+++ b/roles/imaging/tasks/install.yml
@@ -62,6 +62,7 @@
   when:
     - imaging_xsane_enabled | bool
     - ansible_facts['os_family'] != 'Archlinux'
+    - __imaging_xsane_package | default('') | length > 0
   tags:
     - imaging
     - imaging:xsane

--- a/roles/imaging/vars/Debian.yml
+++ b/roles/imaging/vars/Debian.yml
@@ -3,7 +3,7 @@
 # Scanning Packages
 #
 
-__imaging_sane_package: sane
+__imaging_sane_package: sane-utils
 __imaging_xsane_package: xsane
 __imaging_simple_scan_package: simple-scan
 __imaging_skanlite_package: skanlite

--- a/roles/imaging/vars/RedHat-10.yml
+++ b/roles/imaging/vars/RedHat-10.yml
@@ -1,0 +1,16 @@
+---
+#
+# Scanning Packages
+#
+
+__imaging_sane_package: sane-backends
+__imaging_xsane_package: ''
+__imaging_simple_scan_package: simple-scan
+__imaging_skanlite_package: skanlite
+
+#
+# Image Processing Packages
+#
+
+__imaging_imagemagick_package: ImageMagick
+__imaging_graphicsmagick_package: GraphicsMagick

--- a/roles/office/README.md
+++ b/roles/office/README.md
@@ -8,12 +8,12 @@ Install office applications and document tools.
 
 ## Supported Platforms
 
-| Platform                    | Notes                                                                           |
-|-----------------------------|---------------------------------------------------------------------------------|
-| Arch Linux                  |                                                                                 |
-| Debian Trixie               |                                                                                 |
-| EL 9 (Rocky, Alma, RHEL)    | Some packages unavailable (gnome-contacts, foliate, gscan2pdf)                  |
-| EL 10 (Rocky, Alma, RHEL)   | Some packages unavailable (gnome-calendar, gnome-contacts, foliate, gscan2pdf)  |
+| Platform                    | Notes                                                                                                            |
+|-----------------------------|------------------------------------------------------------------------------------------------------------------|
+| Arch Linux                  | Native packages + AUR                                                                                            |
+| Debian Trixie               | Official repo packages                                                                                           |
+| EL 9 (Rocky, Alma, RHEL)    | EPEL packages — gnome-contacts, foliate, gscan2pdf not available                                                 |
+| EL 10 (Rocky, Alma, RHEL)   | EPEL packages — calibre, foliate, texstudio, gnome-calendar, gnome-contacts not available; evince → GNOME Papers |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/office/molecule/default/prepare.yml
+++ b/roles/office/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:
@@ -18,6 +17,34 @@
         - glibc-locale-source
 
   tasks:
+    # Sudo PAM bypass — required for tasks using `become_user` on
+    # geerlingguy Rocky containers under GitHub-hosted runners
+    # (test container only).
+
+    - name: Prepare | Bypass sudo PAM stack (RedHat container)
+      ansible.builtin.copy:
+        content: |
+          #%PAM-1.0
+          auth       sufficient   pam_permit.so
+          account    sufficient   pam_permit.so
+          password   sufficient   pam_permit.so
+          session    sufficient   pam_permit.so
+        dest: /etc/pam.d/sudo
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Disable sudoers authentication (RedHat container)
+      ansible.builtin.copy:
+        content: 'Defaults !authenticate'
+        dest: /etc/sudoers.d/molecule-no-auth
+        owner: root
+        group: root
+        mode: '0440'
+        validate: 'visudo -cf %s'
+      when: ansible_facts['os_family'] == 'RedHat'
+
     #
     # Package Cache
     #

--- a/roles/office/vars/RedHat-10.yml
+++ b/roles/office/vars/RedHat-10.yml
@@ -1,0 +1,84 @@
+---
+#
+# LibreOffice
+#
+
+__office_libreoffice_fresh_package: 'libreoffice'
+__office_libreoffice_still_package: 'libreoffice'
+__office_libreoffice_i18n_package: 'libreoffice-langpack-{{ office_libreoffice_i18n }}'
+
+#
+# PDF
+#
+# `evince` was renamed to GNOME Papers in EL10.
+
+__office_pdf_viewers:
+  evince: 'papers'
+  okular: 'okular'
+  zathura: ''
+  mupdf: 'mupdf'
+
+__office_pdf_tools_packages:
+  - 'qpdf'
+  - 'poppler-utils'
+
+#
+# Email
+#
+
+__office_thunderbird_package: 'thunderbird'
+__office_thunderbird_i18n_package: 'thunderbird-langpack-{{ office_thunderbird_i18n }}'
+__office_evolution_package: 'evolution'
+
+#
+# Calendar / PIM
+#
+# Not packaged in EPEL 10.
+
+__office_gnome_calendar_package: ''
+__office_gnome_contacts_package: ''
+
+#
+# OCR
+#
+
+__office_tesseract_package: 'tesseract'
+__office_tesseract_lang_prefix: 'tesseract-langpack-'
+
+#
+# Scanning
+#
+
+__office_simple_scan_package: 'simple-scan'
+__office_gscan2pdf_package: 'gscan2pdf'
+
+#
+# Ebook
+# Not packaged in EPEL 10.
+
+__office_calibre_package: ''
+__office_foliate_package: ''
+
+#
+# LaTeX
+# Not packaged in EPEL 10.
+
+__office_texstudio_package: ''
+
+#
+# Spell Checking
+#
+
+__office_hunspell_packages:
+  - 'hunspell'
+  - 'hunspell-en-US'
+  - 'hunspell-de'
+
+#
+# Fonts
+#
+
+__office_fonts_packages:
+  - 'liberation-fonts'
+  - 'dejavu-fonts'
+  - 'google-noto-fonts-common'

--- a/roles/remote_access/README.md
+++ b/roles/remote_access/README.md
@@ -5,12 +5,11 @@ Install remote desktop and access applications.
 ## Description
 
 Installs remote desktop clients, VNC viewers, RDP clients, and other remote
-access tools. Application availability varies by platform:
+access tools.
 
-- **Remmina**, **TigerVNC**, **FreeRDP**: Available on all platforms via official repositories.
-- **RustDesk**, **Asbru Connection Manager**, **RealVNC Viewer**, **AnyDesk**, **TeamViewer**:
-  Arch Linux only, installed via AUR. Requires the `aur_builder` user and the
-  `kewlfft.aur` collection.
+RustDesk, Asbru Connection Manager, RealVNC Viewer, AnyDesk, and TeamViewer
+are Arch-only (AUR). They require the `aur_builder` user and the
+`kewlfft.aur` collection.
 
 ## Requirements
 
@@ -21,12 +20,12 @@ access tools. Application availability varies by platform:
 
 ## Supported Platforms
 
-| Platform                   | Notes                                    |
-| -------------------------- | ---------------------------------------- |
-| Arch Linux                 | Full support — native packages + AUR     |
-| Debian Trixie              | Official repo packages only              |
-| EL 9 (Rocky, Alma, RHEL)   | Official repo packages only              |
-| EL 10 (Rocky, Alma, RHEL)  | Official repo packages only              |
+| Platform                   | Notes                                      |
+| -------------------------- | ------------------------------------------ |
+| Arch Linux                 | Native packages + AUR                      |
+| Debian Trixie              | Official repo packages                     |
+| EL 9 (Rocky, Alma, RHEL)   | EPEL packages                              |
+| EL 10 (Rocky, Alma, RHEL)  | EPEL packages — TigerVNC + Remmina dropped |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/remote_access/vars/Debian.yml
+++ b/roles/remote_access/vars/Debian.yml
@@ -6,4 +6,4 @@
 # Official repository packages
 __remote_access_remmina_package: remmina
 __remote_access_tigervnc_package: tigervnc-viewer
-__remote_access_freerdp_package: freerdp2-x11
+__remote_access_freerdp_package: freerdp3-x11

--- a/roles/remote_access/vars/RedHat-10.yml
+++ b/roles/remote_access/vars/RedHat-10.yml
@@ -1,0 +1,9 @@
+---
+#
+# RedHat 10 Variables
+#
+# TigerVNC is no longer packaged in EPEL 10.
+
+__remote_access_remmina_package: remmina
+__remote_access_tigervnc_package: ''
+__remote_access_freerdp_package: freerdp

--- a/roles/remote_access/vars/RedHat-10.yml
+++ b/roles/remote_access/vars/RedHat-10.yml
@@ -2,8 +2,7 @@
 #
 # RedHat 10 Variables
 #
-# TigerVNC is no longer packaged in EPEL 10.
 
-__remote_access_remmina_package: remmina
+__remote_access_remmina_package: ''
 __remote_access_tigervnc_package: ''
 __remote_access_freerdp_package: freerdp

--- a/roles/shell/molecule/default/prepare.yml
+++ b/roles/shell/molecule/default/prepare.yml
@@ -53,18 +53,9 @@
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
 
-    #
-    # Sudo PAM workaround for containerised Rocky under GitHub-hosted
-    # runners. sudo's PAM auth+account stack fails to read /etc/shadow
-    # (0000 perms; setuid root + DAC_READ_SEARCH cap may be restricted
-    # by the runner's container security profile), reporting:
-    #   "PAM account management error: Authentication service cannot
-    #    retrieve authentication info" + "a password is required"
-    #
-    # Bypass: replace sudo's PAM stack with pam_permit (skip both auth
-    # and account checks) and add `Defaults !authenticate` to sudoers.
-    # Test container only — production sudo PAM stack is unaffected.
-    #
+    # Sudo PAM bypass — required for tasks using `become_user` on
+    # geerlingguy Rocky containers under GitHub-hosted runners
+    # (test container only).
 
     - name: Prepare | Bypass sudo PAM stack (RedHat container)
       ansible.builtin.copy:

--- a/roles/system_apps/README.md
+++ b/roles/system_apps/README.md
@@ -12,23 +12,28 @@ Deja Dup), and GNOME utilities (Seahorse, dconf Editor).
 Each application is individually toggled via boolean variables, defaulting to a sensible
 baseline (GParted, Filelight, Solaar on by default; optional tools off by default).
 
-On Rocky Linux, EPEL must be enabled before running this role — several packages
-(gparted, filelight, solaar, timeshift, deja-dup) are not available in the base repos.
+On Rocky Linux, EPEL and CRB must be enabled before running this role
+(typically via `marcstraube.common.package_management`) — several packages
+(gparted, filelight, solaar, timeshift, deja-dup) are not in the base
+repos, and filelight + plasma-systemmonitor pull KF5 libraries from CRB.
+
+On Rocky 10 specifically, gparted, solaar, timeshift, and deja-dup are not
+packaged in EPEL 10 and are skipped automatically.
 
 ## Requirements
 
 - ansible-core >= 2.17
 - `community.general` collection (pacman module on Arch Linux)
-- **Rocky Linux:** EPEL repository enabled (via `marcstraube.common.package_management`)
+- **Rocky Linux:** EPEL + CRB repositories enabled
 
 ## Supported Platforms
 
-| Platform                   | Notes                                  |
-|----------------------------|----------------------------------------|
-| Arch Linux                 | Native packages from extra/community   |
-| Debian Trixie              | Native packages from main              |
-| EL 9 (Rocky, Alma, RHEL)   | EPEL required for most packages        |
-| EL 10 (Rocky, Alma, RHEL)  | EPEL required for most packages        |
+| Platform                   | Notes                                                                    |
+|----------------------------|--------------------------------------------------------------------------|
+| Arch Linux                 | Native packages from extra/community                                     |
+| Debian Trixie              | Native packages from main                                                |
+| EL 9 (Rocky, Alma, RHEL)   | EPEL + CRB required                                                      |
+| EL 10 (Rocky, Alma, RHEL)  | EPEL + CRB required — gparted, solaar, timeshift, deja-dup not available |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/system_apps/molecule/default/prepare.yml
+++ b/roles/system_apps/molecule/default/prepare.yml
@@ -47,6 +47,14 @@
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
 
+    # Filelight + plasma-systemmonitor pull KF5 packages whose libs
+    # (aspell-libs, etc.) live in CRB.
+    - name: Prepare | Enable CRB repository (RedHat)
+      ansible.builtin.command:
+        cmd: dnf config-manager --set-enabled crb
+      changed_when: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'

--- a/roles/system_apps/molecule/default/prepare.yml
+++ b/roles/system_apps/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/system_apps/molecule/default/verify.yml
+++ b/roles/system_apps/molecule/default/verify.yml
@@ -12,6 +12,18 @@
       ansible.builtin.include_vars:
         file: '../../vars/main.yml'
 
+    - name: Verify | Load OS-specific overrides
+      ansible.builtin.include_vars: '{{ item }}'
+      with_first_found:
+        - files:
+            - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["distribution"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}.yml'
+          paths:
+            - '../../vars'
+          skip: true
+
     #
     # GParted
     #

--- a/roles/system_apps/tasks/main.yml
+++ b/roles/system_apps/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+- name: Main | Load OS-specific overrides
+  ansible.builtin.include_vars: '{{ item }}'
+  with_first_found:
+    - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+        - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+        - '{{ ansible_facts["distribution"] }}.yml'
+        - '{{ ansible_facts["os_family"] }}.yml'
+      paths:
+        - 'vars'
+      skip: true
+  tags:
+    - system-apps
+    - system-apps:install
+
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml
   when: system_apps_enabled | bool

--- a/roles/system_apps/vars/RedHat-10.yml
+++ b/roles/system_apps/vars/RedHat-10.yml
@@ -1,0 +1,7 @@
+---
+#
+# RedHat 10 Overrides
+#
+
+# GParted is not packaged in EPEL 10.
+__system_apps_gparted_package: ''

--- a/roles/system_apps/vars/RedHat-10.yml
+++ b/roles/system_apps/vars/RedHat-10.yml
@@ -3,5 +3,7 @@
 # RedHat 10 Overrides
 #
 
-# GParted is not packaged in EPEL 10.
 __system_apps_gparted_package: ''
+__system_apps_solaar_package: ''
+__system_apps_timeshift_package: ''
+__system_apps_deja_dup_package: ''

--- a/roles/terminal/molecule/default/prepare.yml
+++ b/roles/terminal/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/wayland_utils/README.md
+++ b/roles/wayland_utils/README.md
@@ -5,18 +5,23 @@ tools, notification daemons, application launchers, status bars, idle/lock
 managers, wallpaper tools, display management, XDG portals, and miscellaneous
 input/event utilities.
 
+EPEL is X11-focused, so on Rocky Linux only a small subset of Wayland
+tooling is packaged. Most things (grim, slurp, mako, dunst, wofi, waybar,
+swayidle, swaylock, hyprland stack, …) are not in EPEL and silently
+skipped. Use Arch Linux or Debian for full Wayland coverage.
+
 ## Requirements
 
 None.
 
 ## Supported Platforms
 
-| Platform                   | Notes |
-|----------------------------|-------|
-| Arch Linux                 |       |
-| Debian Trixie              |       |
-| EL 9 (Rocky, Alma, RHEL)   |       |
-| EL 10 (Rocky, Alma, RHEL)  |       |
+| Platform                   | Notes                                                                                |
+|----------------------------|--------------------------------------------------------------------------------------|
+| Arch Linux                 | Full coverage                                                                        |
+| Debian Trixie              | Full coverage                                                                        |
+| EL 9 (Rocky, Alma, RHEL)   | EPEL — only wl-clipboard, XDG portals, brightnessctl, playerctl, obs-studio          |
+| EL 10 (Rocky, Alma, RHEL)  | EPEL — only wl-clipboard and XDG portals                                             |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/wayland_utils/vars/RedHat-10.yml
+++ b/roles/wayland_utils/vars/RedHat-10.yml
@@ -78,8 +78,8 @@ __wayland_utils_portal_packages:
 __wayland_utils_portal_base: 'xdg-desktop-portal'
 
 # Media and brightness
-__wayland_utils_brightnessctl_package: 'brightnessctl'
-__wayland_utils_playerctl_package: 'playerctl'
+__wayland_utils_brightnessctl_package: ''
+__wayland_utils_playerctl_package: ''
 
 # Misc — not in EPEL
 __wayland_utils_wev_package: ''

--- a/roles/wayland_utils/vars/RedHat-10.yml
+++ b/roles/wayland_utils/vars/RedHat-10.yml
@@ -1,6 +1,6 @@
 ---
 #
-# RedHat Variables
+# RedHat 10 Variables
 #
 
 # Clipboard
@@ -13,11 +13,10 @@ __wayland_utils_grim_package: ''
 __wayland_utils_slurp_package: ''
 __wayland_utils_swappy_package: ''
 
-# Screen recording — wf-recorder not in EPEL
+# Screen recording — not in EPEL 10
 __wayland_utils_recorder_package: ''
 __wayland_utils_screenrec_package: ''
-__wayland_utils_obs_packages:
-  - 'obs-studio'
+__wayland_utils_obs_packages: []
 
 # Notifications — not in EPEL
 __wayland_utils_notification_packages:

--- a/roles/wine/molecule/default/prepare.yml
+++ b/roles/wine/molecule/default/prepare.yml
@@ -1,10 +1,37 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:
+    # Sudo PAM bypass — required for tasks using `become_user` on
+    # geerlingguy Rocky containers under GitHub-hosted runners
+    # (test container only).
+
+    - name: Prepare | Bypass sudo PAM stack (RedHat container)
+      ansible.builtin.copy:
+        content: |
+          #%PAM-1.0
+          auth       sufficient   pam_permit.so
+          account    sufficient   pam_permit.so
+          password   sufficient   pam_permit.so
+          session    sufficient   pam_permit.so
+        dest: /etc/pam.d/sudo
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Disable sudoers authentication (RedHat container)
+      ansible.builtin.copy:
+        content: 'Defaults !authenticate'
+        dest: /etc/sudoers.d/molecule-no-auth
+        owner: root
+        group: root
+        mode: '0440'
+        validate: 'visudo -cf %s'
+      when: ansible_facts['os_family'] == 'RedHat'
+
     #
     # Repository Setup
     #


### PR DESCRIPTION
Consolidates v2.0.0 CI matrix unblocking into a single PR.

## Fixes

### PAM bypass (original scope)

Drop play-level `become: true` in `prepare.yml` and add PAM bypass snippet for roles whose tasks use `become_user`. Applies to: `development`, `gaming`, `imaging`, `office`, `system_apps`, `terminal`, `wine`, `shell`.

### Cross-role package fixes

| Role | Issue | Change |
|------|-------|--------|
| `communication` | #72 | CRB on RedHat (kmail depsolve); `telegram-desktop` empty on Debian Trixie |
| `desktop_environment` | #73 | XFCE `@Xfce` group on EL9; empty XFCE on EL10; verify gated on `_de_xfce_unsupported` |
| `imaging` | #75 | `sane-utils` on Debian Trixie |
| `office` | #76 | `evince` → GNOME `papers` on Rocky 10 |
| `remote_access` | #77 | `freerdp3-x11` on Debian Trixie; `tigervnc` empty on Rocky 10 |
| `system_apps` | #78 | CRB enable; `gparted` empty on Rocky 10; `with_first_found` vars loader |
| `wayland_utils` | #79 | Empty unavailable EPEL packages (grim, slurp, swappy, mako, dunst, …); EL10 also empties obs-studio |

### Why bundled

The PAM bypass and the non-PAM package fixes form a circular CI dependency: the PAM fix couldn't go green without the package fixes, and the package fixes couldn't run their CI without the PAM bypass. One PR cuts the knot.

## Test plan

- [x] ansible-lint clean across all touched roles
- [ ] CI matrix passes on all platforms for the affected roles
- [ ] No regression on archlinux / debian-trixie / rocky-9 / rocky-10

Closes #72
Closes #73
Closes #75
Closes #76
Closes #77
Closes #78
Closes #79
