### PR TITLE
fix(filemanagers): handle Rocky 9/10 EPEL packaging gaps

### DIFF
--- a/roles/filemanagers/molecule/default/converge.yml
+++ b/roles/filemanagers/molecule/default/converge.yml
@@ -5,9 +5,12 @@
 
   vars:
     filemanagers_enabled: true
-    filemanagers_thunar_enabled: true
+    # Test with nautilus — universally available across Arch, Debian,
+    # EPEL 9, EPEL 10. Thunar is missing from EPEL 10, dolphin pulls
+    # the full KDE stack (heavy in CI).
+    filemanagers_thunar_enabled: false
     filemanagers_dolphin_enabled: false
-    filemanagers_nautilus_enabled: false
+    filemanagers_nautilus_enabled: true
     filemanagers_pcmanfm_enabled: false
     filemanagers_nemo_enabled: false
     filemanagers_doublecmd_enabled: false

--- a/roles/filemanagers/molecule/default/verify.yml
+++ b/roles/filemanagers/molecule/default/verify.yml
@@ -16,29 +16,14 @@
             - '../../vars'
 
     #
-    # Thunar
+    # Nautilus (default test target — universally available)
     #
 
-    - name: Verify | Check Thunar installed (Arch)
-      ansible.builtin.command:
-        cmd: pacman -Q {{ __filemanagers_thunar_package }}
-      register: __verify_thunar_arch
-      changed_when: false
-      failed_when: __verify_thunar_arch.rc != 0
-      when: ansible_facts['os_family'] == 'Archlinux'
-
-    - name: Verify | Check Thunar installed (Debian)
-      ansible.builtin.command:
-        cmd: dpkg -l {{ __filemanagers_thunar_package }}
-      register: __verify_thunar_debian
-      changed_when: false
-      failed_when: __verify_thunar_debian.rc != 0
-      when: ansible_facts['os_family'] == 'Debian'
-
-    - name: Verify | Check Thunar installed (RedHat)  # noqa: command-instead-of-module
-      ansible.builtin.command:
-        cmd: rpm -q {{ __filemanagers_thunar_package }}
-      register: __verify_thunar_redhat
-      changed_when: false
-      failed_when: __verify_thunar_redhat.rc != 0
-      when: ansible_facts['os_family'] == 'RedHat'
+    - name: Verify | nautilus enabled — package installed
+      ansible.builtin.package:
+        name: '{{ __filemanagers_nautilus_package }}'
+        state: present
+      check_mode: true
+      register: __verify_nautilus
+      failed_when: __verify_nautilus.changed
+      when: __filemanagers_nautilus_package | default('') | length > 0

--- a/roles/filemanagers/tasks/install.yml
+++ b/roles/filemanagers/tasks/install.yml
@@ -9,6 +9,7 @@
     state: present
   when:
     - filemanagers_thunar_enabled | bool
+    - __filemanagers_thunar_package | default('') | length > 0
   retries: 3
   delay: 5
 
@@ -18,6 +19,7 @@
     state: present
   when:
     - filemanagers_dolphin_enabled | bool
+    - __filemanagers_dolphin_package | default('') | length > 0
   retries: 3
   delay: 5
 
@@ -27,6 +29,7 @@
     state: present
   when:
     - filemanagers_nautilus_enabled | bool
+    - __filemanagers_nautilus_package | default('') | length > 0
   retries: 3
   delay: 5
 
@@ -36,6 +39,7 @@
     state: present
   when:
     - filemanagers_pcmanfm_enabled | bool
+    - __filemanagers_pcmanfm_package | default('') | length > 0
   retries: 3
   delay: 5
 
@@ -45,6 +49,7 @@
     state: present
   when:
     - filemanagers_nemo_enabled | bool
+    - __filemanagers_nemo_package | default('') | length > 0
   retries: 3
   delay: 5
 

--- a/roles/filemanagers/vars/RedHat-10.yml
+++ b/roles/filemanagers/vars/RedHat-10.yml
@@ -1,0 +1,11 @@
+---
+#
+# RedHat 10 Overrides
+#
+# EPEL 10 packages a smaller subset of GUI file managers than EPEL 9.
+# Only dolphin and nautilus are available — Thunar, pcmanfm, nemo
+# are not packaged.
+#
+
+__filemanagers_thunar_package: ''
+__filemanagers_nemo_package: ''

--- a/roles/filemanagers/vars/RedHat.yml
+++ b/roles/filemanagers/vars/RedHat.yml
@@ -3,9 +3,9 @@
 # RedHat Packages
 #
 
-__filemanagers_thunar_package: 'thunar'
+__filemanagers_thunar_package: 'Thunar'  # EPEL packages with capital T; rpm -q is case-sensitive
 __filemanagers_dolphin_package: 'dolphin'
 __filemanagers_nautilus_package: 'nautilus'
-__filemanagers_pcmanfm_package: 'pcmanfm'
+__filemanagers_pcmanfm_package: ''  # not in EPEL on any EL
 __filemanagers_nemo_package: 'nemo'
 __filemanagers_doublecmd_package: ''


### PR DESCRIPTION
Surfaced by the new CI matrix (#63) running molecule on Rocky 9 + 10:

- EPEL 9 ships Thunar with capital T (`rpm -q` is case-sensitive — `dnf install` resolves case-insensitively but the molecule verify task fails on lowercase 'thunar')
- EPEL 9 has no `pcmanfm` package
- EPEL 10 has neither Thunar, pcmanfm, nor nemo — only dolphin and nautilus

## Changes

- `vars/RedHat.yml`: `Thunar` capitalisation; `pcmanfm` set to empty (not in EPEL on any EL)
- `vars/RedHat-10.yml` (new): override `Thunar` and `nemo` to empty (EPEL 10 packaging subset)
- `tasks/install.yml`: add `__filemanagers_<name>_package | default('') | length > 0` guard to all 5 install tasks (matching the existing doublecmd pattern) — skips silently where the package is unavailable
- `molecule/default/converge.yml`: switch primary test target from Thunar to nautilus (universally available across Arch, Debian, EPEL 9, EPEL 10)
- `molecule/default/verify.yml`: assert nautilus installed using the cross-distro `package check_mode` pattern (replaces the per-OS pacman/dpkg/rpm trio for thunar)

## Test plan

- [x] ansible-lint clean
- [ ] Molecule passes on archlinux, debian-trixie, rocky-9, rocky-10
- [ ] nautilus installs and verify passes on all four