### PR TITLE
fix(graphics_apps): include full var set on RedHat

### DIFF
--- a/roles/graphics_apps/tasks/install.yml
+++ b/roles/graphics_apps/tasks/install.yml
@@ -5,6 +5,7 @@
     state: present
   when:
     - graphics_apps_gimp_enabled | bool
+    - __graphics_apps_gimp_package | default('') | length > 0
   retries: 3
   delay: 5
 
@@ -34,6 +35,7 @@
     state: present
   when:
     - graphics_apps_inkscape_enabled | bool
+    - __graphics_apps_inkscape_package | default('') | length > 0
   retries: 3
   delay: 5
 

--- a/roles/graphics_apps/vars/RedHat-10.yml
+++ b/roles/graphics_apps/vars/RedHat-10.yml
@@ -1,0 +1,9 @@
+---
+#
+# RedHat 10 Packages (Rocky 10 / EPEL 10)
+#
+
+# None of these are in EPEL 10
+__graphics_apps_gimp_package: ''
+__graphics_apps_krita_package: ''
+__graphics_apps_inkscape_package: ''

--- a/roles/graphics_apps/vars/RedHat-9.yml
+++ b/roles/graphics_apps/vars/RedHat-9.yml
@@ -3,5 +3,7 @@
 # RedHat 9 Packages (Rocky 9 / EPEL 9)
 #
 
+__graphics_apps_gimp_package: 'gimp'
 # Not in EPEL 9
 __graphics_apps_krita_package: ''
+__graphics_apps_inkscape_package: 'inkscape'


### PR DESCRIPTION
Molecule converge fails on rocky-9, rocky-10.

**rocky-9:** `__graphics_apps_gimp_package is undefined`. RedHat-9.yml carried only the krita override; gimp and inkscape entries from RedHat.yml were not reaching Rocky 9 because `with_first_found` shadows the base file. Added gimp + inkscape (both in EPEL 9).

**rocky-10:** `No package gimp available`. None of gimp, krita, inkscape are packaged in EPEL 10. Added RedHat-10.yml that empties all three.

Also added `length > 0` guards to gimp + inkscape install tasks (matching the existing krita / filemanagers pattern), so empty package names no longer raise.

## Test plan

- [x] ansible-lint clean
- [ ] Molecule passes on rocky-9 and rocky-10
- [ ] No regression on archlinux/debian

Closes #74