### PR TITLE
fix(imaging): use sane-utils on Debian

### DIFF
--- a/roles/imaging/vars/Debian.yml
+++ b/roles/imaging/vars/Debian.yml
@@ -3,7 +3,7 @@
 # Scanning Packages
 #
 
-__imaging_sane_package: sane
+__imaging_sane_package: sane-utils
 __imaging_xsane_package: xsane
 __imaging_simple_scan_package: simple-scan
 __imaging_skanlite_package: skanlite


### PR DESCRIPTION
Molecule converge fails on debian-trixie: `No package matching 'sane' is available`. Debian ships the SANE backends and CLI utilities as `sane-utils` (the `sane` meta-package no longer exists in Trixie).

## Test plan

- [x] ansible-lint clean
- [ ] Molecule passes on debian-trixie
- [ ] No regression on archlinux/rocky

Closes #75