### PR TITLE
fix(playbooks): include wine role in desktop_workstation task file

### DIFF
--- a/playbooks/tasks/desktop_workstation.yml
+++ b/playbooks/tasks/desktop_workstation.yml
@@ -247,6 +247,18 @@
     - gaming
   when: gaming_enabled | default(false) | bool
 
+- name: Desktop | Include wine role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.wine
+    apply:
+      tags:
+        - desktop
+        - wine
+  tags:
+    - desktop
+    - wine
+  when: wine_enabled | default(false) | bool
+
 - name: Desktop | Include communication role
   ansible.builtin.include_role:
     name: marcstraube.desktop.communication


### PR DESCRIPTION
## Summary

- Add `wine` role include to `playbooks/tasks/desktop_workstation.yml` (between `gaming` and `communication`).
- Default toggle `wine_enabled: false` — matches other optional application roles.

The wine role itself is fully implemented and was already referenced in `workstation_full.yml` and `laptop_full.yml`. Only the modular task file (imported by infra-level playbooks) was missing the entry, so inventory-driven flows with `wine_enabled: true` silently skipped the role.

Closes #84

## Test plan

- [x] `ansible-lint playbooks/tasks/desktop_workstation.yml` clean (production profile)
- [ ] Live re-run with `wine_enabled: true` in inventory — verify wine packages get installed