### PR TITLE
fix(tuxedo): drop state management for sleep.target-driven tccd-sleep

### DIFF
--- a/roles/tuxedo/tasks/service.yml
+++ b/roles/tuxedo/tasks/service.yml
@@ -11,9 +11,11 @@
     daemon_reload: true
   when: tuxedo_tccd_enabled | bool
 
+# tccd-sleep is a sleep.target-driven oneshot owned by
+# tuxedo-control-center-bin. It must not be started manually — doing
+# so triggers ExecStart (`systemctl stop tccd`) outside a sleep cycle
+# and bounces tccd on every Ansible run. Only manage `enabled`.
 - name: Service | Manage tccd-sleep service
   ansible.builtin.systemd_service:
     name: '{{ __tuxedo_tccd_sleep_service }}'
     enabled: "{{ tuxedo_tccd_sleep_enabled | bool }}"
-    state: "{{ tuxedo_tccd_sleep_enabled | bool | ternary('started', 'stopped') }}"
-  when: tuxedo_tccd_sleep_enabled | bool

--- a/roles/tuxedo/tasks/service.yml
+++ b/roles/tuxedo/tasks/service.yml
@@ -14,8 +14,16 @@
 # tccd-sleep is a sleep.target-driven oneshot owned by
 # tuxedo-control-center-bin. It must not be started manually — doing
 # so triggers ExecStart (`systemctl stop tccd`) outside a sleep cycle
-# and bounces tccd on every Ansible run. Only manage `enabled`.
+# and bounces tccd on every Ansible run. Only manage `enabled`, and
+# only when the unit is actually installed on the host (the package is
+# AUR-only and absent in some environments, e.g. molecule containers).
+- name: Service | Check if tccd-sleep service is installed
+  ansible.builtin.stat:
+    path: '/usr/lib/systemd/system/{{ __tuxedo_tccd_sleep_service }}'
+  register: __tuxedo_tccd_sleep_unit
+
 - name: Service | Manage tccd-sleep service
   ansible.builtin.systemd_service:
     name: '{{ __tuxedo_tccd_sleep_service }}'
     enabled: "{{ tuxedo_tccd_sleep_enabled | bool }}"
+  when: __tuxedo_tccd_sleep_unit.stat.exists


### PR DESCRIPTION
## Summary

- Remove `state` and the `when` guard from the `tccd-sleep.service` task in `roles/tuxedo/tasks/service.yml`.
- Manage `enabled` only — the unit is sleep.target-driven and must not be started manually.
- `tccd.service` itself (long-lived `Type=simple`) is unchanged.

The upstream unit (`tuxedo-control-center-bin`) is a oneshot triggered by `WantedBy=sleep.target` whose ExecStart stops tccd at suspend and ExecStop restarts it on resume. Calling `systemctl start tccd-sleep` outside a sleep cycle executes `systemctl stop tccd`; `StopWhenUnneeded=yes` then immediately tears it down which runs ExecStop and starts tccd back. So every Ansible run was bouncing tccd and reporting the task as `changed`.

Closes #88

## Test plan

- [x] `ansible-lint roles/tuxedo/tasks/service.yml` clean (production profile)
- [ ] Live re-run on a Tuxedo Arch host: task no longer reported as `changed` on the second run
- [ ] Verify `systemctl is-enabled tccd-sleep` matches `tuxedo_tccd_sleep_enabled`
- [ ] Verify `tccd.service` keeps running across the playbook run (no momentary stop)
- [ ] Suspend/resume cycle still works (tccd-sleep is triggered by sleep.target, tccd is paused/resumed correctly)