### PR TITLE
fix(terminal): export $TERMINAL to login shells via /etc/profile.d

### DIFF
--- a/roles/terminal/tasks/configure.yml
+++ b/roles/terminal/tasks/configure.yml
@@ -1,6 +1,12 @@
 ---
 #
-# Default Terminal — $TERMINAL via /etc/environment.d
+# Default Terminal — $TERMINAL
+#
+# Deployed in two places so the variable is visible to both user-service
+# (graphical session, dbus-spawned apps) and shell-login contexts:
+#   /etc/environment.d/terminal.conf  — systemd user manager
+#   /etc/profile.d/terminal.sh        — bash/sh login shells (and zsh via
+#                                       /etc/zsh/zprofile)
 #
 
 - name: Configure | Ensure /etc/environment.d exists
@@ -21,8 +27,23 @@
     mode: '0644'
   when: terminal_default | default('') | length > 0
 
+- name: Configure | Deploy default terminal profile script
+  ansible.builtin.template:
+    src: terminal.sh.j2
+    dest: /etc/profile.d/terminal.sh
+    owner: root
+    group: root
+    mode: '0644'
+  when: terminal_default | default('') | length > 0
+
 - name: Configure | Remove default terminal env file when unset
   ansible.builtin.file:
     path: /etc/environment.d/terminal.conf
+    state: absent
+  when: terminal_default | default('') | length == 0
+
+- name: Configure | Remove default terminal profile script when unset
+  ansible.builtin.file:
+    path: /etc/profile.d/terminal.sh
     state: absent
   when: terminal_default | default('') | length == 0

--- a/roles/terminal/templates/terminal.sh.j2
+++ b/roles/terminal/templates/terminal.sh.j2
@@ -1,0 +1,2 @@
+{{ ansible_managed | comment }}
+export TERMINAL='{{ terminal_default }}'


### PR DESCRIPTION
## Summary

- Add `/etc/profile.d/terminal.sh` deployment alongside the existing `/etc/environment.d/terminal.conf` so `$TERMINAL` is also exported into login shells.
- Mirror the absent-state task so both files are removed when `terminal_default` is unset.

`/etc/environment.d/*.conf` is read by the systemd user manager (graphical / user-service sessions) but is not loaded by PAM and is not sourced by login shells. Verified on a deployed host: the env file existed, but `bash -lc 'echo $TERMINAL'` returned empty. `/etc/profile.d/*.sh` is sourced by `/etc/profile` for bash/sh login shells (and by `/etc/zsh/zprofile` on zsh setups), so tools spawned from shells now see the value.

Closes #90

## Test plan

- [x] `ansible-lint roles/terminal/tasks/configure.yml` clean (production profile)
- [ ] After deploy: `bash -lc 'echo $TERMINAL'` returns the configured value
- [ ] Both files exist when `terminal_default` is set; both absent when empty
- [ ] Idempotence: second run reports no changes