### PR TITLE
refactor(wayland_utils)!: rename swww to awww and add matugen toggle

### DIFF
--- a/roles/desktop_environment/defaults/main.yml
+++ b/roles/desktop_environment/defaults/main.yml
@@ -38,7 +38,7 @@ desktop_environment_wayland_utils_config: {}
 desktop_environment_wayland_utils_hyprland_config:
   wayland_utils_idle: 'hypridle'
   wayland_utils_locker: 'hyprlock'
-  wayland_utils_wallpaper: 'swww'
+  wayland_utils_wallpaper: 'awww'
 
 #
 # Hyprland Options

--- a/roles/wayland_utils/README.md
+++ b/roles/wayland_utils/README.md
@@ -85,9 +85,10 @@ overrides if needed.
 
 ### Wallpaper
 
-| Variable                  | Default  | Description                                                   |
-|---------------------------|----------|---------------------------------------------------------------|
-| `wayland_utils_wallpaper` | `'none'` | Wallpaper tool: swww, swaybg, hyprpaper, wpaperd, none        |
+| Variable                         | Default  | Description                                                                 |
+|----------------------------------|----------|-----------------------------------------------------------------------------|
+| `wayland_utils_wallpaper`        | `'none'` | Wallpaper tool: awww, swaybg, hyprpaper, wpaperd, none                      |
+| `wayland_utils_matugen_enabled`  | `false`  | Install matugen (Material You color generation, pairs well with awww)       |
 
 ### Display Management
 

--- a/roles/wayland_utils/defaults/main.yml
+++ b/roles/wayland_utils/defaults/main.yml
@@ -82,9 +82,14 @@ wayland_utils_locker: 'none'
 # Wallpaper
 #
 
-# Wallpaper tool: swww, swaybg, hyprpaper, wpaperd, none
+# Wallpaper tool: awww, swaybg, hyprpaper, wpaperd, none
+# (awww is the upstream-renamed successor of swww; same CLI, same features)
 # Usually set by DE role
 wayland_utils_wallpaper: 'none'
+
+# Install matugen (Material You color generation tool, useful with
+# awww/Hyprland for dynamic theming)
+wayland_utils_matugen_enabled: false
 
 #
 # Display Management

--- a/roles/wayland_utils/tasks/install.yml
+++ b/roles/wayland_utils/tasks/install.yml
@@ -21,6 +21,7 @@
         ([__wayland_utils_idle_packages[wayland_utils_idle] | default('')]) +
         ([__wayland_utils_locker_packages[wayland_utils_locker] | default('')]) +
         ([__wayland_utils_wallpaper_packages[wayland_utils_wallpaper] | default('')]) +
+        (wayland_utils_matugen_enabled | bool | ternary([__wayland_utils_matugen_package], [])) +
         (wayland_utils_wlr_randr_enabled | bool | ternary([__wayland_utils_wlr_randr_package], [])) +
         (wayland_utils_kanshi_enabled | bool | ternary([__wayland_utils_kanshi_package], [])) +
         (wayland_utils_nwg_displays_enabled | bool | ternary([__wayland_utils_nwg_displays_package], [])) +

--- a/roles/wayland_utils/vars/Archlinux.yml
+++ b/roles/wayland_utils/vars/Archlinux.yml
@@ -60,11 +60,14 @@ __wayland_utils_locker_packages:
 
 # Wallpaper
 __wayland_utils_wallpaper_packages:
-  swww: 'swww'
+  awww: 'awww'
   swaybg: 'swaybg'
   hyprpaper: 'hyprpaper'
   wpaperd: 'wpaperd'
   none: ''
+
+# Matugen (Material You color generation)
+__wayland_utils_matugen_package: 'matugen'
 
 # Display management
 __wayland_utils_wlr_randr_package: 'wlr-randr'

--- a/roles/wayland_utils/vars/Debian.yml
+++ b/roles/wayland_utils/vars/Debian.yml
@@ -57,11 +57,14 @@ __wayland_utils_locker_packages:
 
 # Wallpaper
 __wayland_utils_wallpaper_packages:
-  swww: ''  # Not in repos
+  awww: ''  # Not in repos
   swaybg: 'swaybg'
   hyprpaper: ''  # Not in repos
   wpaperd: ''
   none: ''
+
+# Matugen — not in repos
+__wayland_utils_matugen_package: ''
 
 # Display management
 __wayland_utils_wlr_randr_package: 'wlr-randr'

--- a/roles/wayland_utils/vars/RedHat-10.yml
+++ b/roles/wayland_utils/vars/RedHat-10.yml
@@ -56,11 +56,14 @@ __wayland_utils_locker_packages:
 
 # Wallpaper — not in EPEL
 __wayland_utils_wallpaper_packages:
-  swww: ''
+  awww: ''
   swaybg: ''
   hyprpaper: ''
   wpaperd: ''
   none: ''
+
+# Matugen — not in EPEL
+__wayland_utils_matugen_package: ''
 
 # Display management — not in EPEL
 __wayland_utils_wlr_randr_package: ''

--- a/roles/wayland_utils/vars/RedHat.yml
+++ b/roles/wayland_utils/vars/RedHat.yml
@@ -57,11 +57,14 @@ __wayland_utils_locker_packages:
 
 # Wallpaper — not in EPEL
 __wayland_utils_wallpaper_packages:
-  swww: ''
+  awww: ''
   swaybg: ''
   hyprpaper: ''
   wpaperd: ''
   none: ''
+
+# Matugen — not in EPEL
+__wayland_utils_matugen_package: ''
 
 # Display management — not in EPEL
 __wayland_utils_wlr_randr_package: ''


### PR DESCRIPTION
## Summary

Rename the `swww` mapping key to `awww` across `wayland_utils` OS vars and the Hyprland default in `desktop_environment`. Add a `wayland_utils_matugen_enabled` toggle (default off) for the Material You color generation tool. Background and rationale: see linked issue.

Closes #92

## Breaking change

Inventories that set `wayland_utils_wallpaper: swww` must update to `awww`. Inventories that reference `swww` in `desktop_environment_hyprland_autostart` must change to `awww` (the binary name changed).

## Test plan

- [x] `ansible-lint` clean
- [x] Local dry-run on prometheus: `Apply wayland_utils overrides` sets `wayland_utils_wallpaper = awww`, no failures, no fix-specific changes
- [ ] CI passes