### PR TITLE
feat(office): add betterbird (AUR) as Thunderbird alternative

### DIFF
--- a/roles/office/README.md
+++ b/roles/office/README.md
@@ -8,12 +8,17 @@ Install office applications and document tools.
 
 ## Supported Platforms
 
-| Platform                    | Notes                                                                                                            |
-|-----------------------------|------------------------------------------------------------------------------------------------------------------|
-| Arch Linux                  | Native packages + AUR                                                                                            |
-| Debian Trixie               | Official repo packages                                                                                           |
-| EL 9 (Rocky, Alma, RHEL)    | EPEL packages — gnome-contacts, foliate, gscan2pdf not available                                                 |
-| EL 10 (Rocky, Alma, RHEL)   | EPEL packages — calibre, foliate, texstudio, gnome-calendar, gnome-contacts not available; evince → GNOME Papers |
+| Platform                  | Notes                  |
+|---------------------------|------------------------|
+| Arch Linux                | Native packages + AUR  |
+| Debian Trixie             | Official repo packages |
+| EL 9 (Rocky, Alma, RHEL)  | EPEL packages          |
+| EL 10 (Rocky, Alma, RHEL) | EPEL packages          |
+
+Packages not available on EL 9: `gnome-contacts`, `foliate`, `gscan2pdf`.
+
+Packages not available on EL 10: `calibre`, `foliate`, `texstudio`,
+`gnome-calendar`, `gnome-contacts`. `evince` is replaced by GNOME Papers.
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars
@@ -46,11 +51,12 @@ overrides if needed.
 
 ### Email Clients
 
-| Variable                     | Default | Description               |
-|------------------------------|---------|---------------------------|
-| `office_thunderbird_enabled` | `false` | Enable Thunderbird        |
-| `office_thunderbird_i18n`    | `'de'`  | Thunderbird language pack |
-| `office_evolution_enabled`   | `false` | Enable Evolution          |
+| Variable                     | Default | Description                  |
+|------------------------------|---------|------------------------------|
+| `office_thunderbird_enabled` | `false` | Enable Thunderbird           |
+| `office_thunderbird_i18n`    | `'de'`  | Thunderbird language pack    |
+| `office_betterbird_enabled`  | `false` | Enable Betterbird (AUR only) |
+| `office_evolution_enabled`   | `false` | Enable Evolution             |
 
 ### Calendar / PIM
 

--- a/roles/office/defaults/main.yml
+++ b/roles/office/defaults/main.yml
@@ -48,6 +48,10 @@ office_thunderbird_enabled: false
 # Thunderbird language pack
 office_thunderbird_i18n: 'de'
 
+# Enable Betterbird installation (AUR only)
+# Thunderbird fork with quality-of-life patches. Ships all locales.
+office_betterbird_enabled: false
+
 # Enable Evolution installation
 office_evolution_enabled: false
 

--- a/roles/office/molecule/default/converge.yml
+++ b/roles/office/molecule/default/converge.yml
@@ -11,6 +11,7 @@
     office_pdf_viewer: 'evince'
     office_pdf_tools_enabled: false
     office_thunderbird_enabled: false
+    office_betterbird_enabled: false
     office_evolution_enabled: false
     office_gnome_calendar_enabled: false
     office_gnome_contacts_enabled: false

--- a/roles/office/tasks/install.yml
+++ b/roles/office/tasks/install.yml
@@ -89,6 +89,18 @@
   retries: 3
   delay: 5
 
+- name: Install | Betterbird from AUR (Arch)
+  become: true
+  become_user: aur_builder
+  kewlfft.aur.aur:
+    name: '{{ __office_betterbird_package }}'
+    state: present
+  when:
+    - office_betterbird_enabled | bool
+    - __office_betterbird_package | length > 0
+  retries: 3
+  delay: 5
+
 - name: Install | Evolution
   ansible.builtin.package:
     name: '{{ __office_evolution_package }}'

--- a/roles/office/vars/Archlinux.yml
+++ b/roles/office/vars/Archlinux.yml
@@ -30,6 +30,7 @@ __office_pdf_tools_packages:
 
 __office_thunderbird_package: 'thunderbird'
 __office_thunderbird_i18n_package: 'thunderbird-i18n-{{ office_thunderbird_i18n }}'
+__office_betterbird_package: 'betterbird-bin'
 __office_evolution_package: 'evolution'
 
 #

--- a/roles/office/vars/Debian.yml
+++ b/roles/office/vars/Debian.yml
@@ -28,6 +28,7 @@ __office_pdf_tools_packages:
 
 __office_thunderbird_package: 'thunderbird'
 __office_thunderbird_i18n_package: 'thunderbird-l10n-{{ office_thunderbird_i18n }}'
+__office_betterbird_package: ''
 __office_evolution_package: 'evolution'
 
 #

--- a/roles/office/vars/RedHat-10.yml
+++ b/roles/office/vars/RedHat-10.yml
@@ -28,6 +28,7 @@ __office_pdf_tools_packages:
 
 __office_thunderbird_package: 'thunderbird'
 __office_thunderbird_i18n_package: 'thunderbird-langpack-{{ office_thunderbird_i18n }}'
+__office_betterbird_package: ''
 __office_evolution_package: 'evolution'
 
 #

--- a/roles/office/vars/RedHat-9.yml
+++ b/roles/office/vars/RedHat-9.yml
@@ -27,6 +27,7 @@ __office_pdf_tools_packages:
 
 __office_thunderbird_package: 'thunderbird'
 __office_thunderbird_i18n_package: 'thunderbird-langpack-{{ office_thunderbird_i18n }}'
+__office_betterbird_package: ''
 __office_evolution_package: 'evolution'
 
 #

--- a/roles/office/vars/RedHat.yml
+++ b/roles/office/vars/RedHat.yml
@@ -27,6 +27,7 @@ __office_pdf_tools_packages:
 
 __office_thunderbird_package: 'thunderbird'
 __office_thunderbird_i18n_package: 'thunderbird-langpack-{{ office_thunderbird_i18n }}'
+__office_betterbird_package: ''
 __office_evolution_package: 'evolution'
 
 #


### PR DESCRIPTION
## Summary

- Adds `office_betterbird_enabled` toggle (default `false`) — installs `betterbird-bin` from AUR on Arch Linux only
- Empty `__office_betterbird_package` on Debian/EL skips the task via `length > 0` check, no platform filter needed at task level
- Fixes pre-existing MD013/line-length errors in the Supported Platforms table

## Test plan

- [x] `molecule test -p office-archlinux` — all 6 phases passed on all 4 platforms
- [x] `ansible-lint` clean
- [x] `pre-commit run` clean (incl. markdownlint after table reflow)
- [x] Live deploy on `prometheus` (Arch laptop) with `office_betterbird_enabled: true` — installs betterbird-bin, idempotent

Closes #94