### PR TITLE
docs(keepassxc): document FdoSecrets group assignment as manual setup

### DIFF
--- a/roles/keepassxc/README.md
+++ b/roles/keepassxc/README.md
@@ -51,6 +51,22 @@ overrides if needed.
 | `keepassxc_secret_service_enabled`   | `false` | Enable Secret Service (freedesktop.org) integration |
 | `keepassxc_secret_service_scope`     | `'user'`| Secret Service scope: `'user'` or `'global'`        |
 
+> **Manual setup required after first run.** Enabling
+> `keepassxc_secret_service_enabled` only registers KeePassXC as the
+> freedesktop Secret-Service DBus provider. The database group that
+> KeePassXC actually exposes to Secret-Service clients must be assigned
+> manually **per database** in the KeePassXC GUI — the assignment is
+> stored inside the KDBX file and cannot be set by Ansible.
+>
+> Path in the GUI: `Application Settings → Secret Service Integration →
+> Expose entries under this group`. Pick (or create) a group, then save
+> the database.
+>
+> Without this step, every Secret-Service client (Slack, Claude Desktop,
+> browsers, …) that contacts KeePassXC triggers a one-time setup wizard
+> on first connection that looks like a "create new database" prompt and
+> can be confusing.
+
 ### SSH Agent Integration
 
 | Variable                      | Default | Description                |
@@ -141,7 +157,7 @@ molecule test -s default -- --tags keepassxc
 - [KeePassXC](https://keepassxc.org/) — Cross-platform community-driven password manager
 - [KeePassXC Documentation](https://keepassxc.org/docs/) — User guide and configuration reference
 - [KeePassXC-Browser](https://github.com/keepassxreboot/keepassxc-browser) — Browser extension for autofill
-- [Freedesktop Secret Service API](https://specifications.freedesktop.org/secret-service-spec/latest/) — D-Bus API KeePassXC implements
+- [Secret Service API](https://specifications.freedesktop.org/secret-service-spec/latest/) — D-Bus API KeePassXC uses
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds a note under "Secret Service Integration" in the `keepassxc` role README explaining the manual setup step required after enabling `keepassxc_secret_service_enabled`
- Shortens a pre-existing References entry (135 chars) to stay within the 120-char markdownlint limit

## Context

`keepassxc_secret_service_enabled: true` only registers KeePassXC as the freedesktop Secret-Service DBus provider. The database group that KeePassXC exposes to Secret-Service clients is stored inside the KDBX file itself and must be assigned manually per database via the GUI (`Application Settings → Secret Service Integration → Expose entries under this group`). Without that step, every new Secret-Service client (Slack, Claude Desktop, browsers, …) triggers a one-time KeePassXC setup wizard that looks like a "create new database" prompt and is confusing.

## Test plan

- [x] README renders cleanly on GitHub preview
- [x] `markdownlint` passes via `pre-commit`

Closes #96