### PR TITLE
fix: assert multilib repo enabled before installing lib32 packages

### DIFF
--- a/roles/gaming/README.md
+++ b/roles/gaming/README.md
@@ -22,6 +22,16 @@ to exist on managed hosts.
 - `kewlfft.aur` collection (AUR packages on Arch Linux)
 - EPEL repository enabled (for Lutris on EL 9/10)
 - `aur_builder` system user with passwordless sudo (Arch Linux only)
+- Arch Linux + `gaming_steam_enabled: true`: `multilib` repository
+  enabled — set `pacman_multilib_enabled: true` in inventory and run
+  the `marcstraube.common.package_management` role first (or use the
+  `base-system` tag). Steam lives in `multilib` and pulls `lib32-*`
+  dependencies. The role asserts this precondition before installing
+  Steam.
+- Arch Linux + Lutris: although Lutris itself installs without
+  multilib, running 32-bit Windows games via Wine/Proton needs the
+  `lib32-*` optional dependencies. Enabling `multilib` is strongly
+  recommended.
 
 ## Supported Platforms
 

--- a/roles/gaming/tasks/install.yml
+++ b/roles/gaming/tasks/install.yml
@@ -13,6 +13,19 @@
   retries: 3
   delay: 5
 
+- name: Install | Assert multilib repo is enabled for Steam (Arch)
+  ansible.builtin.assert:
+    that:
+      - pacman_multilib_enabled | default(false) | bool
+    fail_msg: >-
+      Steam on Arch lives in the multilib repository and pulls lib32
+      dependencies. Set `pacman_multilib_enabled: true` in inventory
+      and run the `marcstraube.common.package_management` role first
+      (or use the `base-system` tag).
+  when:
+    - gaming_steam_enabled | bool
+    - ansible_facts['os_family'] == 'Archlinux'
+
 - name: Install | Steam
   ansible.builtin.package:
     name: '{{ __gaming_steam_package }}'

--- a/roles/wine/README.md
+++ b/roles/wine/README.md
@@ -12,6 +12,12 @@ environment configuration, and per-user Wine prefix initialization.
 ## Requirements
 
 - ansible-core >= 2.17
+- Arch Linux: `multilib` repository enabled — set
+  `pacman_multilib_enabled: true` in inventory and run the
+  `marcstraube.common.package_management` role first (or use the
+  `base-system` tag). Required for the `lib32-*` packages and the
+  32-bit Vulkan driver. The role asserts this precondition before
+  installation.
 - EPEL repository enabled (for Wine on Rocky Linux 9, managed by
   `marcstraube.common.package_management`)
 - Wine is **not available** for EL 10 (no EPEL package exists)

--- a/roles/wine/tasks/install.yml
+++ b/roles/wine/tasks/install.yml
@@ -67,6 +67,19 @@
 # 32-bit Support (Arch Linux)
 #
 
+- name: Install | Assert multilib repo is enabled (Arch)
+  ansible.builtin.assert:
+    that:
+      - pacman_multilib_enabled | default(false) | bool
+    fail_msg: >-
+      The wine role requires the Arch multilib repository for lib32
+      packages. Set `pacman_multilib_enabled: true` in inventory and
+      run the `marcstraube.common.package_management` role first
+      (or use the `base-system` tag).
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - wine_lib32_packages | default([]) | length > 0
+
 - name: Install | lib32 packages (Arch)
   ansible.builtin.package:
     name: '{{ wine_lib32_packages }}'


### PR DESCRIPTION
## Summary

- Adds a pre-flight `assert` to the `wine` and `gaming` roles (Arch path only) that fails with a clear remediation message when the `multilib` repository is not enabled. Replaces the previous generic `error: 'lib32-mesa': could not find or read package` failure.
- `wine`: assert triggers when `wine_lib32_packages | length > 0` (covers both the lib32 packages task and the lib32 Vulkan driver task — same code path).
- `gaming`: assert is scoped to `gaming_steam_enabled`. Systematic verification (`pacman -Si` for repo packages, AUR RPC API for AUR packages) showed that of all gaming packages, **only Steam** has hard `lib32-*` dependencies on Arch. Lutris, RetroArch, Dolphin, Moonlight, Heroic, PCSX2 and Playback install without multilib.
- Documents the prerequisite in the Requirements section of both READMEs. The gaming README also notes that Lutris itself installs without multilib but recommends enabling it for 32-bit Windows games via Wine/Proton.

Closes #87

## Test plan

- [x] `ansible-lint roles/wine roles/gaming` passes (0 failures, 0 warnings)
- [x] `ansible-playbook --syntax-check` passes for both `wine` and `gaming` converge files
- [x] Negative test: assert fails with the expected `fail_msg` when `pacman_multilib_enabled: false` and `wine_lib32_packages` is non-empty on Arch
- [x] Positive test: assert passes when `pacman_multilib_enabled: true`
- [x] Skip test: assert is skipped on `os_family: Debian`