### PR TITLE
fix: manage browser default via mimeapps.list instead of xdg-settings

### DIFF
--- a/roles/browser/README.md
+++ b/roles/browser/README.md
@@ -51,7 +51,7 @@ Chromium on Rocky Linux requires EPEL.
 | `browser_brave_enabled`      | `false`     | Install Brave (Arch only)     |
 | `browser_tor_enabled`        | `false`     | Install Tor Browser           |
 | `browser_zen_enabled`        | `false`     | Install Zen Browser (Arch)    |
-| `browser_default`            | `'firefox'` | Default browser (xdg)         |
+| `browser_default`            | `'firefox'` | Default http/https handler    |
 
 ### Firefox Options
 
@@ -116,6 +116,18 @@ Chromium on Rocky Linux requires EPEL.
 | -------------------------- | ----------- | -------------------------------------- |
 | `browser_users`            | `[]`        | Users for per-user profile settings    |
 | `browser_user_config_mode` | `'initial'` | Default mode: managed/initial/disabled |
+
+`browser_default` is applied per-user via `~/.config/mimeapps.list`
+(sections `[Default Applications]`, keys `x-scheme-handler/http`
+and `x-scheme-handler/https`). Previously this used `xdg-settings`,
+which silently failed without a graphical session. The value must
+match the `.desktop` basename of an installed browser, without the
+suffix (e.g. `firefox`, `librewolf`, `chromium`, `brave-browser`).
+Set to an empty string to skip handler management. Other entries
+in `mimeapps.list` are preserved on each run. The same
+`managed`/`initial`/`disabled` mode that governs per-user profile
+config applies here too — `initial` deploys only on newly created
+users, leaving subsequent manual changes intact.
 
 ## Tags
 

--- a/roles/browser/defaults/main.yml
+++ b/roles/browser/defaults/main.yml
@@ -28,7 +28,11 @@ browser_tor_enabled: false
 # Install Zen Browser (Firefox fork)
 browser_zen_enabled: false
 
-# Default browser for xdg-settings
+# Default browser for the http/https URL handler.
+# Sets x-scheme-handler/http and x-scheme-handler/https in each
+# browser_users home's ~/.config/mimeapps.list. Use the .desktop
+# basename without the suffix (e.g. 'firefox', 'librewolf',
+# 'chromium', 'brave-browser'). Empty string disables.
 browser_default: 'firefox'
 
 #

--- a/roles/browser/molecule/default/converge.yml
+++ b/roles/browser/molecule/default/converge.yml
@@ -15,8 +15,15 @@
     browser_firefox_policies_enabled: true
     browser_chromium_policies_enabled: true
 
-    # Skip user configuration in container test
-    browser_users: []
+    # Skip Firefox per-user user.js in container test (no graphical
+    # session for profile creation); keep browser_users populated so
+    # the mimeapps.list handler path is exercised.
+    browser_firefox_user_js_enabled: false
+
+    browser_default: 'firefox'
+    browser_user_config_mode: 'managed'
+    browser_users:
+      - username: 'browser_test_user'
 
     # Minimal extensions for testing
     browser_firefox_extensions:

--- a/roles/browser/molecule/default/prepare.yml
+++ b/roles/browser/molecule/default/prepare.yml
@@ -89,3 +89,13 @@
         mode: '0440'
         validate: 'visudo -cf %s'
       when: ansible_facts['os_family'] == 'Archlinux'
+
+    #
+    # Test User (for mimeapps.list handler verification)
+    #
+
+    - name: Prepare | Create test user
+      ansible.builtin.user:
+        name: browser_test_user
+        create_home: true
+        shell: /bin/bash

--- a/roles/browser/molecule/default/verify.yml
+++ b/roles/browser/molecule/default/verify.yml
@@ -115,3 +115,37 @@
         that:
           - __browser_verify_firefoxcfg.stat.exists
         fail_msg: 'Firefox firefox.cfg not found'
+
+    #
+    # Default Browser Handler (mimeapps.list)
+    #
+
+    - name: Verify | Check mimeapps.list exists for test user
+      ansible.builtin.stat:
+        path: /home/browser_test_user/.config/mimeapps.list
+      register: __browser_verify_mimeapps
+
+    - name: Verify | Assert mimeapps.list exists
+      ansible.builtin.assert:
+        that:
+          - __browser_verify_mimeapps.stat.exists
+        fail_msg: 'mimeapps.list not created for browser_test_user'
+
+    - name: Verify | Read mimeapps.list content
+      ansible.builtin.slurp:
+        src: /home/browser_test_user/.config/mimeapps.list
+      register: __browser_verify_mimeapps_content
+
+    - name: Verify | Assert http handler is firefox.desktop
+      ansible.builtin.assert:
+        that:
+          - (__browser_verify_mimeapps_content.content | b64decode)
+            is search('x-scheme-handler/http\s*=\s*firefox\.desktop')
+        fail_msg: 'x-scheme-handler/http not set to firefox.desktop'
+
+    - name: Verify | Assert https handler is firefox.desktop
+      ansible.builtin.assert:
+        that:
+          - (__browser_verify_mimeapps_content.content | b64decode)
+            is search('x-scheme-handler/https\s*=\s*firefox\.desktop')
+        fail_msg: 'x-scheme-handler/https not set to firefox.desktop'

--- a/roles/browser/tasks/main.yml
+++ b/roles/browser/tasks/main.yml
@@ -94,16 +94,3 @@
   when:
     - browser_enabled | bool
     - browser_users | length > 0
-
-- name: Main | Set default browser
-  ansible.builtin.command:
-    cmd: 'xdg-settings set default-web-browser {{ browser_default }}.desktop'
-  changed_when: false
-  # xdg-settings requires a display server, fails in containers/headless
-  failed_when: false
-  when:
-    - browser_enabled | bool
-    - browser_default | length > 0
-  tags:
-    - browser
-    - browser:default

--- a/roles/browser/tasks/users.yml
+++ b/roles/browser/tasks/users.yml
@@ -46,3 +46,27 @@
       (browser_user.mode | default(browser_user_config_mode)) == 'managed'
       or ((browser_user.mode | default(browser_user_config_mode)) == 'initial'
           and browser_user.username in (__users_newly_created | default([])))
+
+- name: Users | Include default browser handler config
+  ansible.builtin.include_tasks:
+    file: users_default_handler.yml
+    apply:
+      tags:
+        - browser
+        - browser:configure
+        - browser:default
+  tags:
+    - browser
+    - browser:configure
+    - browser:default
+  loop: '{{ browser_users }}'
+  loop_control:
+    loop_var: browser_user
+    label: '{{ browser_user.username }}'
+  when:
+    - browser_default | length > 0
+    - (browser_user.mode | default(browser_user_config_mode)) != 'disabled'
+    - >-
+      (browser_user.mode | default(browser_user_config_mode)) == 'managed'
+      or ((browser_user.mode | default(browser_user_config_mode)) == 'initial'
+          and browser_user.username in (__users_newly_created | default([])))

--- a/roles/browser/tasks/users_default_handler.yml
+++ b/roles/browser/tasks/users_default_handler.yml
@@ -1,0 +1,40 @@
+---
+- name: Users Default Handler | Get user info
+  ansible.builtin.getent:
+    database: passwd
+    key: '{{ browser_user.username }}'
+
+- name: Users Default Handler | Set user home fact
+  ansible.builtin.set_fact:
+    __browser_user_home: '{{ getent_passwd[browser_user.username][4] }}'
+
+- name: Users Default Handler | Stat ~/.config
+  ansible.builtin.stat:
+    path: '{{ __browser_user_home }}/.config'
+  register: __browser_user_config_dir
+
+# Create only when missing — never alter mode of existing dir.
+# XDG private default (0700) when the role has to create it.
+- name: Users Default Handler | Create ~/.config if missing
+  ansible.builtin.file:
+    path: '{{ __browser_user_home }}/.config'
+    state: directory
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0700'
+  when: not __browser_user_config_dir.stat.exists
+
+- name: Users Default Handler | Set http/https handler in mimeapps.list
+  community.general.ini_file:
+    path: '{{ __browser_user_home }}/.config/mimeapps.list'
+    section: 'Default Applications'
+    option: '{{ item }}'
+    value: '{{ browser_default }}.desktop'
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0644'
+    no_extra_spaces: true
+    create: true
+  loop:
+    - 'x-scheme-handler/http'
+    - 'x-scheme-handler/https'


### PR DESCRIPTION
## Summary

- Replaces the `xdg-settings set default-web-browser` system-wide call (which silently failed without a graphical session and masked the failure via `failed_when: false`) with per-user management of `~/.config/mimeapps.list` via `community.general.ini_file`.
- Sets `x-scheme-handler/http` and `x-scheme-handler/https` under `[Default Applications]` to `{{ browser_default }}.desktop`, applied per user in `browser_users`, parallel to the existing `users_firefox.yml` / `users_librewolf.yml` pattern (same `managed`/`initial`/`disabled` mode handling).
- Preserves unrelated entries in `mimeapps.list` (e.g. `x-scheme-handler/claude-cli`, `application/pdf`).
- Native idempotency: no shell wrap, no `environment:` juggling, no `changed_when: false`.
- `browser_default` empty string → handler tasks skipped, file unmanaged.
- The old `Main | Set default browser` task is removed.
- The role only creates `~/.config` when missing (XDG-conformant `0700`); never touches the mode of an existing directory (discovered live during testing — fixed in this PR).
- Adds molecule coverage: `prepare.yml` creates `browser_test_user`, `converge.yml` sets `browser_default: firefox` + `browser_users` + `managed`, `verify.yml` asserts that `mimeapps.list` is created and both http/https handlers are set.

Closes #98

## Test plan

- [x] `ansible-lint roles/browser` — 0 failures, 0 warnings
- [x] `ansible-playbook --syntax-check` — converge / prepare / verify all parse
- [x] Ad-hoc: `community.general.ini_file` preserves unrelated entries; second run is idempotent (`changed=false`); fresh-file path works via `create: true`
- [x] `molecule test -p browser-archlinux` — 22 ok, 0 failed; verify asserts on mimeapps.list pass
- [x] Live verify on production host: `~/.config/mimeapps.list` updated with `librewolf.desktop` for http/https, pre-existing `x-scheme-handler/claude-cli` and `x-scheme-handler/claude` entries preserved
- [x] Live verify: second run is idempotent (`changed=0`)
- [x] Live verify: `~/.config` mode is not altered when the directory already exists

Not verified in this PR (blocked by separate Firefox/LibreWolf profile-bootstrap issue, follow-up incoming):

- `xdg-mime query default x-scheme-handler/https` against an installed `.desktop` target
- Clicking an external URL in an Electron app