### PR TITLE
fix: Firefox/LibreWolf profile bootstrap + policies.json valid JSON

### DIFF
--- a/roles/browser/README.md
+++ b/roles/browser/README.md
@@ -67,10 +67,11 @@ Chromium on Rocky Linux requires EPEL.
 
 ### LibreWolf Options
 
-| Variable                                      | Default     | Description                      |
-| --------------------------------------------- | ----------- | -------------------------------- |
-| `browser_librewolf_policies_enabled`          | `true`      | Deploy policies.json             |
-| `browser_librewolf_extensions`                | `{...}`     | Extensions (defaults to Firefox) |
+| Variable                                      | Default     | Description                       |
+| --------------------------------------------- | ----------- | --------------------------------- |
+| `browser_librewolf_policies_enabled`          | `true`      | Deploy policies.json              |
+| `browser_librewolf_user_js_enabled`           | `true`      | Deploy per-user user.js           |
+| `browser_librewolf_extensions`                | `{...}`     | Extensions (defaults to Firefox)  |
 | `browser_librewolf_preferences`               | `{}`        | Additional preferences           |
 | `browser_librewolf_disable_telemetry`         | `true`      | Disable telemetry                |
 | `browser_librewolf_disable_pocket`            | `true`      | Disable Pocket                   |
@@ -128,6 +129,34 @@ in `mimeapps.list` are preserved on each run. The same
 `managed`/`initial`/`disabled` mode that governs per-user profile
 config applies here too — `initial` deploys only on newly created
 users, leaving subsequent manual changes intact.
+
+### Firefox / LibreWolf profile bootstrap
+
+For Firefox and LibreWolf, the role writes the profile directory,
+`profiles.ini`, and `user.js` directly (Mozilla's `-CreateProfile`
+CLI is a silent no-op in non-interactive contexts). To make the
+bootstrapped profile actually take effect on first launch, the role
+also writes a per-install `[Install<hash>]` section in
+`profiles.ini` — without it, modern Firefox (>= 67) ignores
+`[Profile0].Default=1` and auto-creates its own random-prefix
+profile, locking the install to that one.
+
+The install hash is `CityHash64` of the UTF-16-LE encoded install
+directory path (see Mozilla source `commonupdatedir.cpp::GetInstallHash`).
+Pre-computed hashes for the standard distro install paths are
+hardcoded in `vars/{Archlinux,Debian,RedHat}.yml`
+(`__browser_firefox_install_hash`, `__browser_librewolf_install_hash`).
+
+To compute the hash for a custom install path:
+
+```bash
+go run github.com/bradenhilton/mozillainstallhash/cmd/mozhash@latest <path>
+# e.g. mozhash /opt/firefox  → custom 16-char uppercase hex
+```
+
+If the install hash is left empty, the profile is still written but
+the browser will not pick it up as default — fall back to detecting
+the random-prefix profile the browser creates on first launch.
 
 ## Tags
 

--- a/roles/browser/defaults/main.yml
+++ b/roles/browser/defaults/main.yml
@@ -55,6 +55,9 @@ browser_firefox_user_js_enabled: true
 # LibreWolf already has good defaults, fewer customizations needed
 browser_librewolf_policies_enabled: true
 
+# Deploy per-user user-overrides.js (LibreWolf's user.js equivalent)
+browser_librewolf_user_js_enabled: true
+
 #
 # Chromium Options
 #
@@ -164,9 +167,6 @@ browser_firefox_preferences:
   # Disable Pocket
   'extensions.pocket.enabled': false
 
-  # Disable Firefox accounts
-  'identity.fxaccounts.enabled': false
-
   # HTTPS-only mode
   'dom.security.https_only_mode': true
   'dom.security.https_only_mode_ever_enabled': true
@@ -246,6 +246,7 @@ browser_extension_default_mode: 'blocked'
 
 browser_librewolf_preferences: {}
 browser_librewolf_extensions: '{{ browser_firefox_extensions }}'
+browser_librewolf_extensions_optional: '{{ browser_firefox_extensions_optional | default({}) }}'
 browser_librewolf_disable_telemetry: true
 browser_librewolf_disable_pocket: true
 browser_librewolf_disable_firefox_studies: true

--- a/roles/browser/molecule/default/converge.yml
+++ b/roles/browser/molecule/default/converge.yml
@@ -15,10 +15,9 @@
     browser_firefox_policies_enabled: true
     browser_chromium_policies_enabled: true
 
-    # Skip Firefox per-user user.js in container test (no graphical
-    # session for profile creation); keep browser_users populated so
-    # the mimeapps.list handler path is exercised.
-    browser_firefox_user_js_enabled: false
+    # Per-user paths now bootstrap profiles via filesystem writes,
+    # no DISPLAY/D-Bus needed — keep enabled in container tests.
+    browser_firefox_user_js_enabled: true
 
     browser_default: 'firefox'
     browser_user_config_mode: 'managed'

--- a/roles/browser/molecule/default/verify.yml
+++ b/roles/browser/molecule/default/verify.yml
@@ -3,6 +3,18 @@
   hosts: all
   gather_facts: true
   tasks:
+    - name: Verify | Load OS-specific role vars
+      ansible.builtin.include_vars: '{{ item }}'
+      with_first_found:
+        - files:
+            - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["distribution"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}.yml'
+          paths:
+            - '{{ playbook_dir }}/../../vars'
+          skip: true
+
     #
     # Firefox Verification
     #
@@ -168,7 +180,7 @@
 
     - name: Verify | Check Firefox profile directory exists
       ansible.builtin.stat:
-        path: /home/browser_test_user/.mozilla/firefox/profile.default-release
+        path: /home/browser_test_user/.mozilla/firefox/{{ __browser_firefox_profile_dirname }}
       register: __browser_verify_firefox_profile
 
     - name: Verify | Assert Firefox profile directory exists
@@ -176,7 +188,7 @@
         that:
           - __browser_verify_firefox_profile.stat.exists
           - __browser_verify_firefox_profile.stat.isdir
-        fail_msg: 'Firefox profile.default-release directory not created'
+        fail_msg: 'Firefox bootstrap profile directory not created'
 
     - name: Verify | Check Firefox profiles.ini exists
       ansible.builtin.stat:
@@ -197,21 +209,18 @@
     - name: Verify | Assert profiles.ini registers the profile correctly
       ansible.builtin.assert:
         that:
-          - (__browser_verify_firefox_profiles_ini_content.content | b64decode)
-            is search('Path\s*=\s*profile\.default-release')
-          - (__browser_verify_firefox_profiles_ini_content.content | b64decode)
-            is search('Default\s*=\s*1')
-          - (__browser_verify_firefox_profiles_ini_content.content | b64decode)
-            is search('Version\s*=\s*2')
-          - (__browser_verify_firefox_profiles_ini_content.content | b64decode)
-            is search('\[Install4F96D1932A9F858E\]')
-          - (__browser_verify_firefox_profiles_ini_content.content | b64decode)
-            is search('Default\s*=\s*profile\.default-release')
-        fail_msg: 'profiles.ini does not register profile.default-release correctly'
+          - "'Path=' + __browser_firefox_profile_dirname in __profiles_ini_text"
+          - "'Default=1' in __profiles_ini_text"
+          - "'Version=2' in __profiles_ini_text"
+          - "'[Install' + __browser_firefox_install_hash + ']' in __profiles_ini_text"
+          - "'Default=' + __browser_firefox_profile_dirname in __profiles_ini_text"
+        fail_msg: 'profiles.ini does not register the bootstrap profile correctly'
+      vars:
+        __profiles_ini_text: '{{ __browser_verify_firefox_profiles_ini_content.content | b64decode }}'
 
     - name: Verify | Check Firefox user.js exists in profile
       ansible.builtin.stat:
-        path: /home/browser_test_user/.mozilla/firefox/profile.default-release/user.js
+        path: /home/browser_test_user/.mozilla/firefox/{{ __browser_firefox_profile_dirname }}/user.js
       register: __browser_verify_firefox_user_js
 
     - name: Verify | Assert Firefox user.js deployed

--- a/roles/browser/molecule/default/verify.yml
+++ b/roles/browser/molecule/default/verify.yml
@@ -55,6 +55,12 @@
           - __browser_verify_ublock.stdout | int > 0
         fail_msg: 'uBlock Origin not found in Firefox policies.json'
 
+    - name: Verify | Validate Firefox policies.json is valid JSON
+      ansible.builtin.command:
+        cmd: 'python3 -c "import json; json.load(open(''{{ __browser_verify_policies_path | trim }}/policies.json''))"'
+      register: __browser_verify_firefox_policies_json
+      changed_when: false
+
     #
     # Chromium Verification
     #
@@ -82,6 +88,12 @@
         that:
           - __browser_verify_chromium_policies.stat.exists
         fail_msg: 'Chromium policies.json not found'
+
+    - name: Verify | Validate Chromium policies.json is valid JSON
+      ansible.builtin.command:
+        cmd: 'python3 -c "import json; json.load(open(''/etc/chromium/policies/managed/policies.json''))"'
+      register: __browser_verify_chromium_policies_json
+      changed_when: false
 
     #
     # Firefox Autoconfig Verification
@@ -149,3 +161,61 @@
           - (__browser_verify_mimeapps_content.content | b64decode)
             is search('x-scheme-handler/https\s*=\s*firefox\.desktop')
         fail_msg: 'x-scheme-handler/https not set to firefox.desktop'
+
+    #
+    # Firefox Profile Bootstrap (filesystem-based)
+    #
+
+    - name: Verify | Check Firefox profile directory exists
+      ansible.builtin.stat:
+        path: /home/browser_test_user/.mozilla/firefox/profile.default-release
+      register: __browser_verify_firefox_profile
+
+    - name: Verify | Assert Firefox profile directory exists
+      ansible.builtin.assert:
+        that:
+          - __browser_verify_firefox_profile.stat.exists
+          - __browser_verify_firefox_profile.stat.isdir
+        fail_msg: 'Firefox profile.default-release directory not created'
+
+    - name: Verify | Check Firefox profiles.ini exists
+      ansible.builtin.stat:
+        path: /home/browser_test_user/.mozilla/firefox/profiles.ini
+      register: __browser_verify_firefox_profiles_ini
+
+    - name: Verify | Assert Firefox profiles.ini exists
+      ansible.builtin.assert:
+        that:
+          - __browser_verify_firefox_profiles_ini.stat.exists
+        fail_msg: 'Firefox profiles.ini not created'
+
+    - name: Verify | Read Firefox profiles.ini content
+      ansible.builtin.slurp:
+        src: /home/browser_test_user/.mozilla/firefox/profiles.ini
+      register: __browser_verify_firefox_profiles_ini_content
+
+    - name: Verify | Assert profiles.ini registers the profile correctly
+      ansible.builtin.assert:
+        that:
+          - (__browser_verify_firefox_profiles_ini_content.content | b64decode)
+            is search('Path\s*=\s*profile\.default-release')
+          - (__browser_verify_firefox_profiles_ini_content.content | b64decode)
+            is search('Default\s*=\s*1')
+          - (__browser_verify_firefox_profiles_ini_content.content | b64decode)
+            is search('Version\s*=\s*2')
+          - (__browser_verify_firefox_profiles_ini_content.content | b64decode)
+            is search('\[Install4F96D1932A9F858E\]')
+          - (__browser_verify_firefox_profiles_ini_content.content | b64decode)
+            is search('Default\s*=\s*profile\.default-release')
+        fail_msg: 'profiles.ini does not register profile.default-release correctly'
+
+    - name: Verify | Check Firefox user.js exists in profile
+      ansible.builtin.stat:
+        path: /home/browser_test_user/.mozilla/firefox/profile.default-release/user.js
+      register: __browser_verify_firefox_user_js
+
+    - name: Verify | Assert Firefox user.js deployed
+      ansible.builtin.assert:
+        that:
+          - __browser_verify_firefox_user_js.stat.exists
+        fail_msg: 'Firefox user.js not deployed into profile'

--- a/roles/browser/tasks/brave.yml
+++ b/roles/browser/tasks/brave.yml
@@ -1,5 +1,5 @@
 ---
-- name: Brave | Ensure Brave policies directories exist (Arch)
+- name: Brave | Ensure policies directories exist (Arch)
   ansible.builtin.file:
     path: '{{ item }}'
     state: directory
@@ -13,7 +13,7 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - __browser_brave_policies_path | length > 0
 
-- name: Brave | Deploy Brave managed policies (Arch)
+- name: Brave | Deploy managed policies (Arch)
   ansible.builtin.template:
     src: brave-policies.json.j2
     dest: '{{ __browser_brave_policies_path }}/managed/policies.json'
@@ -24,7 +24,7 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - __browser_brave_policies_path | length > 0
 
-- name: Brave | Brave configuration not available notice
+- name: Brave | Configuration not available notice
   ansible.builtin.debug:
     msg: >-
       Brave policy configuration requires the Brave repository.

--- a/roles/browser/tasks/chromium.yml
+++ b/roles/browser/tasks/chromium.yml
@@ -1,5 +1,5 @@
 ---
-- name: Chromium | Ensure Chromium policies directories exist
+- name: Chromium | Ensure policies directories exist
   ansible.builtin.file:
     path: '{{ item }}'
     state: directory
@@ -10,7 +10,7 @@
     - '{{ __browser_chromium_policies_path }}/managed'
     - '{{ __browser_chromium_policies_path }}/recommended'
 
-- name: Chromium | Deploy Chromium managed policies
+- name: Chromium | Deploy managed policies
   ansible.builtin.template:
     src: chromium-policies.json.j2
     dest: '{{ __browser_chromium_policies_path }}/managed/policies.json'
@@ -29,7 +29,7 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - browser_chromium_wayland_gestures_enabled | bool
 
-- name: Chromium | Deploy Chromium Wayland gestures hook (Arch)
+- name: Chromium | Deploy Wayland gestures hook (Arch)
   ansible.builtin.template:
     src: chromium-wayland-gestures.hook.j2
     dest: '/etc/pacman.d/hooks/chromium-wayland-gestures.hook'

--- a/roles/browser/tasks/firefox.yml
+++ b/roles/browser/tasks/firefox.yml
@@ -1,5 +1,5 @@
 ---
-- name: Firefox | Ensure Firefox policies directory exists
+- name: Firefox | Ensure policies directory exists
   ansible.builtin.file:
     path: '{{ __browser_firefox_policies_path }}'
     state: directory
@@ -7,7 +7,7 @@
     group: root
     mode: '0755'
 
-- name: Firefox | Deploy Firefox policies.json
+- name: Firefox | Deploy policies.json
   ansible.builtin.template:
     src: firefox-policies.json.j2
     dest: '{{ __browser_firefox_policies_path }}/policies.json'
@@ -15,7 +15,7 @@
     group: root
     mode: '0644'
 
-- name: Firefox | Deploy Firefox autoconfig.js
+- name: Firefox | Deploy autoconfig.js
   ansible.builtin.template:
     src: autoconfig.js.j2
     dest: '{{ __browser_firefox_autoconfig_path }}/autoconfig.js'
@@ -24,7 +24,7 @@
     mode: '0644'
   when: browser_firefox_preferences | length > 0
 
-- name: Firefox | Deploy Firefox firefox.cfg
+- name: Firefox | Deploy firefox.cfg
   ansible.builtin.template:
     src: firefox.cfg.j2
     dest: '{{ __browser_firefox_config_path }}/firefox.cfg'

--- a/roles/browser/tasks/users.yml
+++ b/roles/browser/tasks/users.yml
@@ -40,6 +40,7 @@
     label: '{{ browser_user.username }}'
   when:
     - browser_librewolf_enabled | bool
+    - browser_librewolf_user_js_enabled | bool
     - ansible_facts['os_family'] == 'Archlinux'
     - (browser_user.mode | default(browser_user_config_mode)) != 'disabled'
     - >-

--- a/roles/browser/tasks/users_default_handler.yml
+++ b/roles/browser/tasks/users_default_handler.yml
@@ -6,7 +6,7 @@
 
 - name: Users Default Handler | Set user home fact
   ansible.builtin.set_fact:
-    __browser_user_home: '{{ getent_passwd[browser_user.username][4] }}'
+    __browser_user_home: "{{ ansible_facts['getent_passwd'][browser_user.username][4] }}"
 
 - name: Users Default Handler | Stat ~/.config
   ansible.builtin.stat:

--- a/roles/browser/tasks/users_firefox.yml
+++ b/roles/browser/tasks/users_firefox.yml
@@ -6,49 +6,120 @@
 
 - name: Users Firefox | Set user home fact
   ansible.builtin.set_fact:
-    __browser_user_home: '{{ getent_passwd[browser_user.username][4] }}'
+    __browser_user_home: "{{ ansible_facts['getent_passwd'][browser_user.username][4] }}"
 
-- name: Users Firefox | Check for existing Firefox profile
+# Ensure parent directory exists before find — avoids a 'not a directory'
+# warning on hosts where the user has never opened Firefox.
+- name: Users Firefox | Ensure ~/.mozilla/firefox directory exists
+  ansible.builtin.file:
+    path: '{{ __browser_user_home }}/.mozilla/firefox'
+    state: directory
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0700'
+
+# Detect any existing profile (random-prefixed by Firefox on first
+# interactive launch, e.g. xyz123.default-release) — if one is
+# already there, use it instead of bootstrapping a new one.
+- name: Users Firefox | Discover existing profile
   ansible.builtin.find:
     paths: '{{ __browser_user_home }}/.mozilla/firefox'
     patterns: '{{ __browser_firefox_profile_pattern }}'
     file_type: directory
   register: __browser_firefox_existing_profiles
-  # Profile directory may not exist yet on first run
-  failed_when: false
 
-- name: Users Firefox | Create Firefox profile if none exists
-  ansible.builtin.command:
-    cmd: 'firefox --headless -CreateProfile "default-release"'
-  become: true
-  become_user: '{{ browser_user.username }}'
-  register: __browser_create_firefox_profile
-  changed_when: __browser_create_firefox_profile.rc == 0
-  when: >-
-    __browser_firefox_existing_profiles.files is not defined or
-    __browser_firefox_existing_profiles.files | length == 0
-
-- name: Users Firefox | Find Firefox profile after creation
-  ansible.builtin.find:
-    paths: '{{ __browser_user_home }}/.mozilla/firefox'
-    patterns: '{{ __browser_firefox_profile_pattern }}'
-    file_type: directory
-  register: __browser_firefox_profiles
-  when: >-
-    __browser_firefox_existing_profiles.files is not defined or
-    __browser_firefox_existing_profiles.files | length == 0
-
-- name: Users Firefox | Set Firefox profile path fact
+- name: Users Firefox | Set profile path from existing
   ansible.builtin.set_fact:
     __browser_firefox_profile_path: >-
-      {{ ((__browser_firefox_profiles | default(__browser_firefox_existing_profiles)).files
-         | sort(attribute='path') | first).path }}
+      {{ (__browser_firefox_existing_profiles.files
+          | sort(attribute='path') | first).path }}
+  when:
+    - __browser_firefox_existing_profiles.files | length > 0
 
-- name: Users Firefox | Deploy Firefox user.js
+# Bootstrap profile when no existing one is found. Firefox/LibreWolf
+# -CreateProfile is unreliable in non-interactive contexts (silent
+# no-op without DISPLAY/D-Bus/UI init), so the role writes the
+# profile dir and profiles.ini directly.
+- name: Users Firefox | Set profile path from bootstrap
+  ansible.builtin.set_fact:
+    __browser_firefox_profile_path: '{{ __browser_user_home }}/.mozilla/firefox/{{ __browser_firefox_profile_dirname }}'
+  when:
+    - __browser_firefox_existing_profiles.files | length == 0
+
+- name: Users Firefox | Ensure profile directory exists
+  ansible.builtin.file:
+    path: '{{ __browser_firefox_profile_path }}'
+    state: directory
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0700'
+
+- name: Users Firefox | Register profile in profiles.ini
+  community.general.ini_file:
+    path: '{{ __browser_user_home }}/.mozilla/firefox/profiles.ini'
+    section: 'Profile0'
+    option: '{{ item.option }}'
+    value: '{{ item.value }}'
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0600'
+    no_extra_spaces: true
+    create: true
+  loop:
+    - { option: 'Name', value: 'default-release' }
+    - { option: 'IsRelative', value: '1' }
+    - { option: 'Path', value: '{{ __browser_firefox_profile_path | basename }}' }
+    - { option: 'Default', value: '1' }
+  loop_control:
+    label: '{{ item.option }}'
+
+- name: Users Firefox | Set General section in profiles.ini
+  community.general.ini_file:
+    path: '{{ __browser_user_home }}/.mozilla/firefox/profiles.ini'
+    section: 'General'
+    option: '{{ item.option }}'
+    value: '{{ item.value }}'
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0600'
+    no_extra_spaces: true
+    create: true
+  loop:
+    - { option: 'StartWithLastProfile', value: '1' }
+    - { option: 'Version', value: '2' }
+  loop_control:
+    label: '{{ item.option }}'
+
+# Modern Firefox (>= 67) routes the default-profile decision through
+# the per-install section, which overrides [Profile0].Default=1.
+# Writing it here makes the browser actually use our bootstrapped
+# profile on first launch (otherwise Firefox creates a random-prefix
+# profile and locks the install to that one).
+- name: Users Firefox | Set Install section in profiles.ini
+  community.general.ini_file:
+    path: '{{ __browser_user_home }}/.mozilla/firefox/profiles.ini'
+    section: 'Install{{ __browser_firefox_install_hash }}'
+    option: '{{ item.option }}'
+    value: '{{ item.value }}'
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0600'
+    no_extra_spaces: true
+    create: true
+  loop:
+    - { option: 'Default', value: '{{ __browser_firefox_profile_path | basename }}' }
+    - { option: 'Locked', value: '1' }
+  loop_control:
+    label: '{{ item.option }}'
+  when: __browser_firefox_install_hash | length > 0
+
+- name: Users Firefox | Deploy user.js
   ansible.builtin.template:
     src: user.js.j2
     dest: '{{ __browser_firefox_profile_path }}/user.js'
     owner: '{{ browser_user.username }}'
     group: '{{ browser_user.username }}'
     mode: '0644'
+  vars:
+    __browser_template_prefs: '{{ browser_firefox_preferences }}'
   when: browser_firefox_preferences | length > 0

--- a/roles/browser/tasks/users_librewolf.yml
+++ b/roles/browser/tasks/users_librewolf.yml
@@ -6,49 +6,115 @@
 
 - name: Users LibreWolf | Set user home fact
   ansible.builtin.set_fact:
-    __browser_user_home: '{{ getent_passwd[browser_user.username][4] }}'
+    __browser_user_home: "{{ ansible_facts['getent_passwd'][browser_user.username][4] }}"
 
-- name: Users LibreWolf | Check for existing profile
+# Ensure parent directory exists before find — avoids a 'not a directory'
+# warning on hosts where the user has never opened LibreWolf.
+- name: Users LibreWolf | Ensure ~/.librewolf directory exists
+  ansible.builtin.file:
+    path: '{{ __browser_user_home }}/.librewolf'
+    state: directory
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0700'
+
+# Detect any existing profile (random-prefixed by LibreWolf on first
+# interactive launch, e.g. xyz123.default-default) — if one is
+# already there, use it instead of bootstrapping a new one.
+- name: Users LibreWolf | Discover existing profile
   ansible.builtin.find:
     paths: '{{ __browser_user_home }}/.librewolf'
     patterns: '{{ __browser_librewolf_profile_pattern }}'
     file_type: directory
   register: __browser_librewolf_existing_profiles
-  # Profile directory may not exist yet on first run
-  failed_when: false
 
-- name: Users LibreWolf | Create profile if none exists
-  ansible.builtin.command:
-    cmd: 'librewolf --headless -CreateProfile "default"'
-  become: true
-  become_user: '{{ browser_user.username }}'
-  register: __browser_create_librewolf_profile
-  changed_when: __browser_create_librewolf_profile.rc == 0
-  when: >-
-    __browser_librewolf_existing_profiles.files is not defined or
-    __browser_librewolf_existing_profiles.files | length == 0
-
-- name: Users LibreWolf | Find profile after creation
-  ansible.builtin.find:
-    paths: '{{ __browser_user_home }}/.librewolf'
-    patterns: '{{ __browser_librewolf_profile_pattern }}'
-    file_type: directory
-  register: __browser_librewolf_profiles
-  when: >-
-    __browser_librewolf_existing_profiles.files is not defined or
-    __browser_librewolf_existing_profiles.files | length == 0
-
-- name: Users LibreWolf | Set profile path fact
+- name: Users LibreWolf | Set profile path from existing
   ansible.builtin.set_fact:
     __browser_librewolf_profile_path: >-
-      {{ ((__browser_librewolf_profiles | default(__browser_librewolf_existing_profiles)).files
-         | sort(attribute='path') | first).path }}
+      {{ (__browser_librewolf_existing_profiles.files
+          | sort(attribute='path') | first).path }}
+  when:
+    - __browser_librewolf_existing_profiles.files | length > 0
 
-- name: Users LibreWolf | Deploy user-overrides.js
+# Bootstrap profile when no existing one is found. -CreateProfile is
+# unreliable in non-interactive contexts, so the role writes the
+# profile dir and profiles.ini directly.
+- name: Users LibreWolf | Set profile path from bootstrap
+  ansible.builtin.set_fact:
+    __browser_librewolf_profile_path: '{{ __browser_user_home }}/.librewolf/{{ __browser_librewolf_profile_dirname }}'
+  when:
+    - __browser_librewolf_existing_profiles.files | length == 0
+
+- name: Users LibreWolf | Ensure profile directory exists
+  ansible.builtin.file:
+    path: '{{ __browser_librewolf_profile_path }}'
+    state: directory
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0700'
+
+- name: Users LibreWolf | Register profile in profiles.ini
+  community.general.ini_file:
+    path: '{{ __browser_user_home }}/.librewolf/profiles.ini'
+    section: 'Profile0'
+    option: '{{ item.option }}'
+    value: '{{ item.value }}'
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0600'
+    no_extra_spaces: true
+    create: true
+  loop:
+    - { option: 'Name', value: 'default' }
+    - { option: 'IsRelative', value: '1' }
+    - { option: 'Path', value: '{{ __browser_librewolf_profile_path | basename }}' }
+    - { option: 'Default', value: '1' }
+  loop_control:
+    label: '{{ item.option }}'
+
+- name: Users LibreWolf | Set General section in profiles.ini
+  community.general.ini_file:
+    path: '{{ __browser_user_home }}/.librewolf/profiles.ini'
+    section: 'General'
+    option: '{{ item.option }}'
+    value: '{{ item.value }}'
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0600'
+    no_extra_spaces: true
+    create: true
+  loop:
+    - { option: 'StartWithLastProfile', value: '1' }
+    - { option: 'Version', value: '2' }
+  loop_control:
+    label: '{{ item.option }}'
+
+# See users_firefox.yml for the why — same mechanism for LibreWolf.
+- name: Users LibreWolf | Set Install section in profiles.ini
+  community.general.ini_file:
+    path: '{{ __browser_user_home }}/.librewolf/profiles.ini'
+    section: 'Install{{ __browser_librewolf_install_hash }}'
+    option: '{{ item.option }}'
+    value: '{{ item.value }}'
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0600'
+    no_extra_spaces: true
+    create: true
+  loop:
+    - { option: 'Default', value: '{{ __browser_librewolf_profile_path | basename }}' }
+    - { option: 'Locked', value: '1' }
+  loop_control:
+    label: '{{ item.option }}'
+  when: __browser_librewolf_install_hash | length > 0
+
+- name: Users LibreWolf | Deploy user.js
   ansible.builtin.template:
     src: user.js.j2
-    dest: '{{ __browser_librewolf_profile_path }}/user-overrides.js'
+    dest: '{{ __browser_librewolf_profile_path }}/user.js'
     owner: '{{ browser_user.username }}'
     group: '{{ browser_user.username }}'
     mode: '0644'
+  vars:
+    __browser_template_prefs: '{{ browser_librewolf_preferences }}'
   when: browser_librewolf_preferences | length > 0

--- a/roles/browser/templates/brave-policies.json.j2
+++ b/roles/browser/templates/brave-policies.json.j2
@@ -1,5 +1,5 @@
-{{ ansible_managed | comment('cblock') }}
 {
+  "_comment": "{{ ansible_managed }}",
 {% if browser_brave_extensions | length > 0 %}
   "ExtensionSettings": {
     "*": {

--- a/roles/browser/templates/chromium-policies.json.j2
+++ b/roles/browser/templates/chromium-policies.json.j2
@@ -1,5 +1,5 @@
-{{ ansible_managed | comment('cblock') }}
 {
+  "_comment": "{{ ansible_managed }}",
 {% if browser_chromium_extensions | length > 0 %}
   "ExtensionSettings": {
     "*": {

--- a/roles/browser/templates/firefox-policies.json.j2
+++ b/roles/browser/templates/firefox-policies.json.j2
@@ -1,5 +1,5 @@
-{{ ansible_managed | comment('cblock') }}
 {
+  "_comment": "{{ ansible_managed }}",
   "policies": {
 {% if browser_firefox_extensions | length > 0 or browser_firefox_extensions_optional | default({}) | length > 0 %}
     "ExtensionSettings": {

--- a/roles/browser/templates/librewolf-policies.json.j2
+++ b/roles/browser/templates/librewolf-policies.json.j2
@@ -1,5 +1,5 @@
-{{ ansible_managed | comment('cblock') }}
 {
+  "_comment": "{{ ansible_managed }}",
   "policies": {
 {% if browser_librewolf_disable_telemetry | bool %}
     "DisableTelemetry": true,
@@ -17,14 +17,13 @@
       "Locked": {{ browser_librewolf_dns_over_https.locked | default(false) | lower }}
     },
 {% endif %}
-{% if browser_librewolf_extensions | length > 0 %}
+{% if browser_librewolf_extensions | length > 0 or browser_librewolf_extensions_optional | default({}) | length > 0 %}
     "ExtensionSettings": {
       "*": {
         "blocked_install_message": "Extension installation is managed by system policy.",
         "installation_mode": "{{ browser_extension_default_mode }}"
-      }{% if browser_librewolf_extensions | length > 0 %},{% endif %}
-
-{% for ext_id, ext_config in browser_librewolf_extensions | dictsort %}
+      },
+{% for ext_id, ext_config in (browser_librewolf_extensions | combine(browser_librewolf_extensions_optional | default({}))) | dictsort %}
       "{{ ext_id }}": {
         "installation_mode": "{{ ext_config.mode | default('normal_installed') }}"{% if ext_config.url is defined %},
         "install_url": "{{ ext_config.url }}"{% endif %}

--- a/roles/browser/templates/user.js.j2
+++ b/roles/browser/templates/user.js.j2
@@ -1,9 +1,9 @@
 {{ ansible_managed | comment('c') }}
 //
-// Firefox user preferences
+// Browser user preferences
 // Reference: https://kb.mozillazine.org/About:config_entries
 
-{% for key, value in browser_firefox_preferences | dictsort %}
+{% for key, value in __browser_template_prefs | dictsort %}
 {% if value is sameas true %}
 user_pref("{{ key }}", true);
 {% elif value is sameas false %}

--- a/roles/browser/vars/Archlinux.yml
+++ b/roles/browser/vars/Archlinux.yml
@@ -19,6 +19,21 @@ __browser_librewolf_policies_path: '/usr/lib/librewolf/distribution'
 __browser_chromium_policies_path: '/etc/chromium/policies'
 __browser_brave_policies_path: '/etc/brave/policies'
 
-# Firefox profile directory pattern (for find)
+# Profile detection: pattern to discover any existing profile
+# (random-prefixed by Firefox itself, e.g. xyz123.default-release).
 __browser_firefox_profile_pattern: '*.default-release'
 __browser_librewolf_profile_pattern: '*.default-default'
+
+# Profile bootstrap: deterministic dirname used when no profile exists.
+# Firefox -CreateProfile is unreliable in non-interactive contexts,
+# so the role writes profiles.ini and the profile dir directly.
+__browser_firefox_profile_dirname: 'profile.default-release'
+__browser_librewolf_profile_dirname: 'profile.default-default'
+
+# Mozilla install hash — CityHash64 of UTF-16-LE encoded install dir path.
+# Identifies which profile is the default for THIS install in profiles.ini
+# (via the [Install<hash>] section). Without it, the browser ignores
+# [Profile0].Default=1 and auto-creates its own random-prefix profile.
+# Regenerate via: github.com/bradenhilton/mozillainstallhash
+__browser_firefox_install_hash: '4F96D1932A9F858E'        # /usr/lib/firefox
+__browser_librewolf_install_hash: '6C1CE26D3274EA5B'      # /usr/lib/librewolf

--- a/roles/browser/vars/Debian.yml
+++ b/roles/browser/vars/Debian.yml
@@ -13,6 +13,17 @@ __browser_librewolf_policies_path: ''
 __browser_chromium_policies_path: '/etc/chromium/policies'
 __browser_brave_policies_path: ''
 
-# Firefox profile directory pattern (for find)
+# Profile detection: pattern to discover any existing profile
+# (random-prefixed by Firefox itself).
 __browser_firefox_profile_pattern: '*.default-esr'
 __browser_librewolf_profile_pattern: '*.default-default'
+
+# Profile bootstrap: deterministic dirname used when no profile exists.
+__browser_firefox_profile_dirname: 'profile.default-esr'
+__browser_librewolf_profile_dirname: 'profile.default-default'
+
+# Mozilla install hash — see Archlinux.yml for explanation.
+# Regenerate via: github.com/bradenhilton/mozillainstallhash
+__browser_firefox_install_hash: '3B6073811A6ABF12'        # /usr/lib/firefox-esr
+# LibreWolf is not packaged for Debian — leave empty.
+__browser_librewolf_install_hash: ''

--- a/roles/browser/vars/RedHat.yml
+++ b/roles/browser/vars/RedHat.yml
@@ -13,6 +13,17 @@ __browser_librewolf_policies_path: ''
 __browser_chromium_policies_path: '/etc/chromium/policies'
 __browser_brave_policies_path: ''
 
-# Firefox profile directory pattern (for find)
+# Profile detection: pattern to discover any existing profile
+# (random-prefixed by Firefox itself).
 __browser_firefox_profile_pattern: '*.default-release'
 __browser_librewolf_profile_pattern: '*.default-default'
+
+# Profile bootstrap: deterministic dirname used when no profile exists.
+__browser_firefox_profile_dirname: 'profile.default-release'
+__browser_librewolf_profile_dirname: 'profile.default-default'
+
+# Mozilla install hash — see Archlinux.yml for explanation.
+# Regenerate via: github.com/bradenhilton/mozillainstallhash
+__browser_firefox_install_hash: '11457493C5A56847'        # /usr/lib64/firefox
+# LibreWolf is not packaged for RHEL/Rocky — leave empty.
+__browser_librewolf_install_hash: ''


### PR DESCRIPTION
## Summary

Fixes the entire Firefox/LibreWolf per-user config chain. The original profile-bootstrap bug from #101 was just the first of three silent failures masking each other; live-verification on a fresh user exposed the rest.

### Profile bootstrap (original #101 bug)

`firefox --headless -CreateProfile "default-release"` is a silent no-op on modern Mozilla browsers without DISPLAY/D-Bus/UI init. Replaced with direct filesystem writes: parent-dir-ensure → discover existing → bootstrap deterministic (`profile.default-release` / `profile.default-default`) → write `profiles.ini` via `ini_file`.

### Install hash for profile pinning

Modern Firefox (>= 67) routes the default-profile decision through a per-install `[Install<hash>]` section in `profiles.ini`, which overrides `[Profile0].Default=1`. Without it the browser silently ignores our bootstrapped profile and creates its own random-prefix profile, locking the install to that one. user.js then lands in the wrong dir.

Hash is `CityHash64` of UTF-16-LE encoded install dir path (Mozilla `commonupdatedir.cpp::GetInstallHash`). Pre-computed values hardcoded in `vars/{Archlinux,Debian,RedHat}.yml` (regenerable via `github.com/bradenhilton/mozillainstallhash`).

### policies.json templates produced invalid JSON

All four browser-policies templates (firefox / librewolf / chromium / brave) started with a C-block comment from `{{ ansible_managed | comment('cblock') }}` — JSON forbids comments, Mozilla's `IOUtils.readJSON` silently rejected the file and **all** policies were inactive. Extensions never auto-installed, `*: blocked` was never enforced, `NoDefaultBookmarks` never set, etc. Pre-existing bug; was hidden behind the profile-bootstrap failure.

Replaced with a JSON-key `_comment`. Added a JSON-validity assert to molecule verify so it can't regress.

### LibreWolf API gap

- Missing `browser_librewolf_user_js_enabled` toggle (Firefox had one)
- Missing `browser_librewolf_extensions_optional` (Firefox had one)
- LibreWolf user-config wrote `user-overrides.js` — that file is an arkenfox-updater artifact LibreWolf itself does not read. Switched to `user.js`.
- Shared `user.js.j2` template now iterates over `__browser_template_prefs`, parametrized per caller. Previously hardcoded to `browser_firefox_preferences` even when invoked for LibreWolf.

### Other fixes

- `ansible_facts['getent_passwd']` instead of deprecated top-level `getent_passwd` (3 files; ansible-core 2.24 removes auto-injection)
- Removed `identity.fxaccounts.enabled: false` from default preferences — was deployed as `lockPref` via `firefox.cfg` and blocked Mozilla Sync entirely, conflicting with `DisableFirefoxAccounts: false` in the policy
- Task-name redundancy cleanup (`Firefox | Deploy Firefox …` → `Firefox | Deploy …`, same for Chromium/Brave/LibreWolf user-tasks)

Closes #101

## Test plan

- [x] `ansible-lint roles/browser` — 0 failures, 0 warnings
- [x] `molecule test -p browser-archlinux` — 33 ok converge / 32 ok idempotent / 0 failed (incl. new JSON-validity, profile dir, `profiles.ini` content, install-hash section asserts)
- [x] Live verify: profile bootstrap creates `profile.default-release` / `profile.default-default`; browser picks it up as default (no random-prefix profile created)
- [x] Live verify: user.js lands in the active profile and is read on launch
- [x] Live verify: extensions auto-install on first browser launch (force_installed uBlock/ClearURLs/LocalCDN visible in about:addons)
- [x] Live verify: `mimeapps.list` http/https handler points to the configured browser; `xdg-mime query default x-scheme-handler/https` returns the correct `.desktop`
- [x] Live verify: clicking an external URL in an Electron app opens the configured browser
- [x] Live verify: Mozilla Sync works (account login proceeds past email entry)
- [x] Live verify: second playbook run is idempotent (`changed=0`)