### PR TITLE
feat: per-user VSCode/VSCodium settings + telemetry opt-out

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -77,6 +77,25 @@ overrides if needed.
 | `development_phpstorm_enabled`          | `false` | Enable PHPStorm          |
 | `development_zed_enabled`               | `false` | Enable Zed Editor        |
 
+#### VSCode / VSCodium settings
+
+| Variable                      | Default | Description                                    |
+|-------------------------------|---------|------------------------------------------------|
+| `development_vscode_settings` | `{...}` | Per-user `settings.json` content (dict)        |
+| `development_vscode_argv`     | `{...}` | Per-user `argv.json` (Electron-runtime flags) |
+
+Defaults opt out of editor-core, common Microsoft, and Red Hat extension
+telemetry. **Caveat:** extensions (Pylance, C/C++, GitLens, …) have
+their own telemetry channels that are not centrally controllable; this
+role only covers the editor core, the Electron runtime, and a few
+well-known extension switches.
+
+Files are deployed under `~/.config/Code/User/settings.json` and
+`~/.vscode/argv.json` (VSCode), and the corresponding `VSCodium` /
+`.vscode-oss` paths. The role overwrites these files in `managed` mode —
+inventory should populate `development_vscode_settings` with everything
+intended, not just deltas.
+
 ### Database Tools
 
 | Variable                      | Default | Description    |
@@ -105,18 +124,28 @@ overrides if needed.
 
 ### User Configuration
 
-| Variable            | Default | Description                          |
-|---------------------|---------|--------------------------------------|
-| `development_users` | `[]`    | Users to configure with git settings |
+| Variable                       | Default     | Description                                      |
+|--------------------------------|-------------|--------------------------------------------------|
+| `development_users`            | `[]`        | Users to configure with git + IDE settings       |
+| `development_user_config_mode` | `'initial'` | Default mode: `managed` / `initial` / `disabled` |
 
 Each user entry supports:
 
-| Key               | Required | Description        |
-|-------------------|----------|--------------------|
-| `username`        | yes      | System username    |
-| `git_name`        | no       | Git user.name      |
-| `git_email`       | no       | Git user.email     |
-| `git_signing_key` | no       | GPG signing key ID |
+| Key               | Required | Description                                  |
+|-------------------|----------|----------------------------------------------|
+| `username`        | yes      | System username                              |
+| `mode`            | no       | Per-user override of the global config mode  |
+| `git_name`        | no       | Git user.name                                |
+| `git_email`       | no       | Git user.email                               |
+| `git_signing_key` | no       | GPG signing key ID                           |
+
+Mode semantics — analog to `marcstraube.desktop.browser`:
+
+| Mode       | First run                  | Subsequent runs                        |
+|------------|----------------------------|----------------------------------------|
+| `managed`  | deploy                     | overwrite (always reconcile)           |
+| `initial`  | deploy if user is newly created | leave existing user customisations alone |
+| `disabled` | skip                       | skip                                   |
 
 ## Tags
 

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -158,10 +158,44 @@ development_shellcheck_enabled: true
 # User Configuration
 #
 
-# Users to configure with git settings
+# Users to configure with development settings (git + IDEs).
+# Per-user mode (managed/initial/disabled) can be set per entry; the
+# top-level default below applies when an entry omits it.
 development_users: []
 # Example:
 #   - username: 'johndoe'
+#     mode: 'managed'                        # optional, overrides global
 #     git_name: 'John Doe'
 #     git_email: 'john@example.com'
 #     git_signing_key: '0x1234567890ABCDEF'
+
+# Default mode when a user entry does not set its own `mode`:
+#   managed  — overwrite the file on every run
+#   initial  — deploy only when the user was created in this run
+#   disabled — skip user-config deploy entirely
+development_user_config_mode: 'initial'
+
+#
+# VSCode / VSCodium settings (per-user)
+#
+# Deployed under <user-home>/.config/Code/User/settings.json (VSCode)
+# and/or <user-home>/.config/VSCodium/User/settings.json. Both editors
+# read the same key syntax. Defaults below opt out of telemetry from
+# the editor core and from common Microsoft/Red Hat extensions; user
+# inventory can override or extend.
+
+development_vscode_settings:
+  telemetry.telemetryLevel: 'off'                          # editor core
+  workbench.enableExperiments: false                       # A/B experiments
+  workbench.settings.enableNaturalLanguageSearch: false    # cloud search lookup
+  update.mode: 'none'                                      # OS package manager handles updates
+  extensions.autoCheckUpdates: false
+  redhat.telemetry.enabled: false                          # all Red Hat-published extensions
+  workbench.welcomePage.walkthroughs.openOnInstall: false  # UX, but unwanted phone-home
+
+# argv.json deployed under <user-home>/.vscode/argv.json (VSCode) and
+# <user-home>/.vscode-oss/argv.json (VSCodium). Electron-runtime level;
+# distinct from the editor settings above.
+development_vscode_argv:
+  enable-crash-reporter: false
+  enable-telemetry: false

--- a/roles/development/tasks/users.yml
+++ b/roles/development/tasks/users.yml
@@ -2,17 +2,51 @@
 #
 # Development User Configuration
 #
+# Respects mode: managed | initial | disabled
+#   managed  — overwrite on every run
+#   initial  — deploy only when user is newly created in this run
+#   disabled — skip entirely
+# Per-user `mode:` overrides `development_user_config_mode`.
 
-- name: Users | Configure Git for users
+- name: Users | Include Git user config
   ansible.builtin.include_tasks:
     file: users_git.yml
     apply:
       tags:
         - development
         - development:users
-  loop: '{{ development_users }}'
-  loop_control:
-    loop_var: dev_user
   tags:
     - development
     - development:users
+  loop: '{{ development_users }}'
+  loop_control:
+    loop_var: dev_user
+    label: '{{ dev_user.username }}'
+  when:
+    - (dev_user.mode | default(development_user_config_mode)) != 'disabled'
+    - >-
+      (dev_user.mode | default(development_user_config_mode)) == 'managed'
+      or ((dev_user.mode | default(development_user_config_mode)) == 'initial'
+          and dev_user.username in (__users_newly_created | default([])))
+
+- name: Users | Include VSCode user config
+  ansible.builtin.include_tasks:
+    file: users_vscode.yml
+    apply:
+      tags:
+        - development
+        - development:users
+  tags:
+    - development
+    - development:users
+  loop: '{{ development_users }}'
+  loop_control:
+    loop_var: dev_user
+    label: '{{ dev_user.username }}'
+  when:
+    - development_vscode_enabled | bool or development_vscodium_enabled | bool
+    - (dev_user.mode | default(development_user_config_mode)) != 'disabled'
+    - >-
+      (dev_user.mode | default(development_user_config_mode)) == 'managed'
+      or ((dev_user.mode | default(development_user_config_mode)) == 'initial'
+          and dev_user.username in (__users_newly_created | default([])))

--- a/roles/development/tasks/users_vscode.yml
+++ b/roles/development/tasks/users_vscode.yml
@@ -1,0 +1,105 @@
+---
+- name: Users VSCode | Get user info
+  ansible.builtin.getent:
+    database: passwd
+    key: '{{ dev_user.username }}'
+
+- name: Users VSCode | Set user home fact
+  ansible.builtin.set_fact:
+    __development_user_home: "{{ ansible_facts['getent_passwd'][dev_user.username][4] }}"
+
+#
+# VSCode (proprietary)
+#
+
+- name: Users VSCode | Ensure VSCode User config directory exists
+  ansible.builtin.file:
+    path: '{{ __development_user_home }}/.config/Code/User'
+    state: directory
+    owner: '{{ dev_user.username }}'
+    group: '{{ dev_user.username }}'
+    mode: '0700'
+  when:
+    - development_vscode_enabled | bool
+    - development_vscode_settings | length > 0
+
+- name: Users VSCode | Deploy VSCode settings.json
+  ansible.builtin.copy:
+    content: '{{ development_vscode_settings | to_nice_json(indent=2) }}'
+    dest: '{{ __development_user_home }}/.config/Code/User/settings.json'
+    owner: '{{ dev_user.username }}'
+    group: '{{ dev_user.username }}'
+    mode: '0600'
+  when:
+    - development_vscode_enabled | bool
+    - development_vscode_settings | length > 0
+
+- name: Users VSCode | Ensure VSCode runtime directory exists
+  ansible.builtin.file:
+    path: '{{ __development_user_home }}/.vscode'
+    state: directory
+    owner: '{{ dev_user.username }}'
+    group: '{{ dev_user.username }}'
+    mode: '0700'
+  when:
+    - development_vscode_enabled | bool
+    - development_vscode_argv | length > 0
+
+- name: Users VSCode | Deploy VSCode argv.json
+  ansible.builtin.copy:
+    content: '{{ development_vscode_argv | to_nice_json(indent=2) }}'
+    dest: '{{ __development_user_home }}/.vscode/argv.json'
+    owner: '{{ dev_user.username }}'
+    group: '{{ dev_user.username }}'
+    mode: '0600'
+  when:
+    - development_vscode_enabled | bool
+    - development_vscode_argv | length > 0
+
+#
+# VSCodium (FOSS build, no MS telemetry code)
+#
+
+- name: Users VSCode | Ensure VSCodium User config directory exists
+  ansible.builtin.file:
+    path: '{{ __development_user_home }}/.config/VSCodium/User'
+    state: directory
+    owner: '{{ dev_user.username }}'
+    group: '{{ dev_user.username }}'
+    mode: '0700'
+  when:
+    - development_vscodium_enabled | bool
+    - development_vscode_settings | length > 0
+
+- name: Users VSCode | Deploy VSCodium settings.json
+  ansible.builtin.copy:
+    content: '{{ development_vscode_settings | to_nice_json(indent=2) }}'
+    dest: '{{ __development_user_home }}/.config/VSCodium/User/settings.json'
+    owner: '{{ dev_user.username }}'
+    group: '{{ dev_user.username }}'
+    mode: '0600'
+  when:
+    - development_vscodium_enabled | bool
+    - development_vscode_settings | length > 0
+
+- name: Users VSCode | Ensure VSCodium runtime directory exists
+  ansible.builtin.file:
+    path: '{{ __development_user_home }}/.vscode-oss'
+    state: directory
+    owner: '{{ dev_user.username }}'
+    group: '{{ dev_user.username }}'
+    mode: '0700'
+  when:
+    - development_vscodium_enabled | bool
+    - development_vscode_argv | length > 0
+
+- name: Users VSCode | Deploy VSCodium argv.json
+  ansible.builtin.copy:
+    content: '{{ development_vscode_argv | to_nice_json(indent=2) }}'
+    dest: '{{ __development_user_home }}/.vscode-oss/argv.json'
+    owner: '{{ dev_user.username }}'
+    group: '{{ dev_user.username }}'
+    mode: '0600'
+  when:
+    - development_vscodium_enabled | bool
+    - development_vscode_argv | length > 0


### PR DESCRIPTION
## Summary

Closes #82.

Adds per-user `settings.json` and `argv.json` deployment for VSCode and VSCodium to the `development` role. Defaults opt out of editor-core telemetry, A/B experiments, cloud search lookups, auto-updates, and a few well-known third-party telemetry channels (Red Hat extensions, Microsoft welcome page). Both editors share the same dict (`development_vscode_settings` / `development_vscode_argv`) — the toggle-asymmetry from the browser role does not apply here, since VSCode and VSCodium read identical syntax.

### What changed

- `defaults/main.yml`:
  - `development_users` entries now accept a per-user `mode:` field (managed/initial/disabled).
  - New top-level `development_user_config_mode: 'initial'` — same semantics as the browser role.
  - New `development_vscode_settings` dict (7 default prefs).
  - New `development_vscode_argv` dict (2 default flags).
- `tasks/users.yml`: rewritten as a dispatcher that respects the mode pattern; includes the new `users_vscode.yml` alongside the existing `users_git.yml`.
- `tasks/users_vscode.yml` (**new**): per-editor deploy of `settings.json` + `argv.json` under the correct paths:
  - VSCode: `~/.config/Code/User/settings.json`, `~/.vscode/argv.json`
  - VSCodium: `~/.config/VSCodium/User/settings.json`, `~/.vscode-oss/argv.json`
- `README.md`: new VSCode-settings sub-section, user-config table extended with the mode column and per-user fields.

### Why opt-out is best-effort

VSCode extensions (Pylance, C/C++, GitLens, GitHub Pull Requests, …) each carry their own telemetry implementation, and these change between versions. The role covers the editor core, the Electron runtime, and the few well-known extension switches (`redhat.telemetry.enabled`). Inventory can add extension-specific prefs by populating `development_vscode_settings` — the dict overwrites the role default, so users keep what they set and merge in whatever else they need.

VSCodium is built from the same source without Microsoft's telemetry code, but `update.mode: "none"`, `workbench.enableExperiments: false`, and the `redhat.*` prefs still make sense there.

### Behavior change for existing inventories

Previously `users_git.yml` ran on every play regardless of mode (effectively `managed`). Now it respects `development_user_config_mode` (default `initial`). Users wanting the old behavior need to set `development_user_config_mode: 'managed'`, or per-user `mode: 'managed'` in their `development_users` entry. This is a v2.0.0-window change and matches the pattern used in `browser`, `wine`, `keepassxc`, `shell`.

## Test plan

- [x] `ansible-lint roles/development` — 0 failures, 0 warnings
- [x] Live verify on host (Arch, VSCodium installed): first run with `mode: managed` deploys both `settings.json` (7 prefs) and `argv.json` (2 flags) under `~/.config/VSCodium/User/` and `~/.vscode-oss/`, git config tasks run idempotently
- [x] Live verify: second run is fully idempotent (0 changed)
- [x] Live verify: VSCodium UI honors the settings (Telemetry switch shows Off, welcome page does not open on launch)

Molecule coverage for VSCode-user-tasks intentionally skipped — installing the editor (AUR-only) in the molecule container takes ~30 min and the file-deploy logic is structurally identical to the equivalent browser-role tasks already covered by molecule there.