### PR TITLE
feat: add xdg_user_dirs role for managing XDG user directories

### DIFF
--- a/playbooks/tasks/desktop_workstation.yml
+++ b/playbooks/tasks/desktop_workstation.yml
@@ -91,6 +91,18 @@
     - bluetooth
   when: bluetooth_enabled | default(true) | bool
 
+- name: Desktop | Include xdg_user_dirs role
+  ansible.builtin.include_role:
+    name: marcstraube.desktop.xdg_user_dirs
+    apply:
+      tags:
+        - desktop
+        - xdg_user_dirs
+  tags:
+    - desktop
+    - xdg_user_dirs
+  when: xdg_user_dirs_enabled | default(true) | bool
+
 - name: Desktop | Include filemanagers role
   ansible.builtin.include_role:
     name: marcstraube.desktop.filemanagers

--- a/roles/xdg_user_dirs/README.md
+++ b/roles/xdg_user_dirs/README.md
@@ -1,0 +1,182 @@
+# marcstraube.desktop.xdg_user_dirs
+
+Install `xdg-user-dirs` and create the standard user directories per user.
+
+## Description
+
+Manages the per-user XDG base-directory map (`~/.config/user-dirs.dirs`)
+and the directories themselves (`~/Documents`, `~/Downloads`,
+`~/Projects`, …). Names are localized by the user's chosen locale
+through `xdg-user-dirs-update`. A freeze file (`~/.config/user-dirs.conf`
+with `enabled=False`) prevents desktop-environment login hooks from
+silently rewriting the map between Ansible runs.
+
+Works on Arch Linux, Debian Trixie, and EL 9/10 — `xdg-user-dirs` is in
+all three package repositories.
+
+## Requirements
+
+- ansible-core >= 2.17
+- Target host's chosen UTF-8 locale must be generated (`/etc/locale.gen`
+  enabled and `locale-gen` run); the `marcstraube.common.base` role
+  handles this.
+
+## Supported Platforms
+
+| Platform                  | Notes                                    |
+| ------------------------- | ---------------------------------------- |
+| Arch Linux                | `xdg-user-dirs` package, native locale   |
+| Debian Trixie             | same package                             |
+| EL 9 / EL 10              | same package                             |
+
+## Role Variables
+
+### Role Control
+
+| Variable               | Default | Description         |
+| ---------------------- | ------- | ------------------- |
+| `xdg_user_dirs_enabled` | `true`  | Enable/disable role |
+
+### Localization
+
+| Variable                | Default          | Description                              |
+| ----------------------- | ---------------- | ---------------------------------------- |
+| `xdg_user_dirs_locale`  | `'en_US.UTF-8'`  | Locale used when generating directory names |
+
+The locale's `.po` data ships inside the `xdg-user-dirs` package, so
+the role does not need to install separate translation packs.
+
+### Extra (custom) directories
+
+| Variable                | Default | Description                                     |
+| ----------------------- | ------- | ----------------------------------------------- |
+| `xdg_user_dirs_extra`   | `{}`    | Additional XDG entries beyond the package defaults |
+
+Format: dict with the XDG key (without the `XDG_` prefix and `_DIR`
+suffix) as key, relative path under `$HOME` as value:
+
+```yaml
+xdg_user_dirs_extra:
+  MEDIA: 'Medien'
+  BACKUP: 'Sicherungen'
+```
+
+Each entry is added via `lineinfile` with an idempotent regex on
+`XDG_<KEY>_DIR=`. If a future `xdg-user-dirs` release ships the same
+key as a default, the line is replaced in place rather than duplicated.
+
+### Skipping standard entries
+
+| Variable               | Default | Description                                            |
+| ---------------------- | ------- | ------------------------------------------------------ |
+| `xdg_user_dirs_skip`   | `[]`    | XDG keys to remove from `user-dirs.dirs` (no dir created) |
+
+```yaml
+xdg_user_dirs_skip:
+  - TEMPLATES
+  - PUBLICSHARE
+```
+
+Removes those `XDG_<KEY>_DIR=` lines from `~/.config/user-dirs.dirs`
+after `xdg-user-dirs-update` wrote them, and skips directory creation
+for the dropped keys. Locale translation of the kept entries is
+unaffected. Default empty = create everything `xdg-user-dirs` ships,
+including future additions like `PROJECTS` (added in 0.20).
+
+### User configuration
+
+| Variable                          | Default     | Description                                  |
+| --------------------------------- | ----------- | -------------------------------------------- |
+| `xdg_user_dirs_users`             | `[]`        | Users to configure                           |
+| `xdg_user_dirs_user_config_mode`  | `'initial'` | Default mode: `managed` / `initial` / `disabled` |
+| `xdg_user_dirs_mode`              | `'0755'`    | Filesystem mode for created XDG directories. Set to `'0700'` to match a private `$HOME`. |
+
+Per-user entry:
+
+```yaml
+xdg_user_dirs_users:
+  - username: 'johndoe'
+    mode: 'managed'   # optional, overrides the global default
+```
+
+Mode semantics — identical to `marcstraube.desktop.browser` and
+`marcstraube.desktop.development`:
+
+| Mode       | First run                         | Subsequent runs                                       |
+| ---------- | --------------------------------- | ----------------------------------------------------- |
+| `managed`  | deploy                            | re-run `xdg-user-dirs-update --force`, re-apply extras |
+| `initial`  | deploy if user is newly created   | leave existing user-dirs.dirs alone                   |
+| `disabled` | skip                              | skip                                                  |
+
+## What the freeze actually does
+
+`~/.config/user-dirs.conf` with `enabled=False` blocks the
+**auto-triggered** `xdg-user-dirs-update` calls (typical desktop
+environments run it on login). This protects both the Ansible-managed
+state and any manual edits the user makes to `~/.config/user-dirs.dirs`
+between Ansible runs.
+
+It does **not** block:
+
+- Manual edits via text editor.
+- Explicit `xdg-user-dirs-update --set <DIR> <path>` calls (a deliberate
+  user action).
+- `xdg-user-dirs-update --force` (operator override; this is what the
+  role itself uses, so re-runs still work).
+
+So in `mode: initial`, users keep full ownership of the file after the
+initial deploy; the freeze just prevents an external tool from
+clobbering their changes on every login.
+
+## Tags
+
+| Tag                       | Scope                  |
+| ------------------------- | ---------------------- |
+| `xdg_user_dirs`           | All role tasks         |
+| `xdg_user_dirs:install`   | Package installation   |
+| `xdg_user_dirs:users`     | Per-user configuration |
+
+## Example Playbook
+
+```yaml
+- name: Workstation
+  hosts: workstations
+  tasks:
+    - name: Include xdg_user_dirs role
+      ansible.builtin.include_role:
+        name: marcstraube.desktop.xdg_user_dirs
+      tags: [xdg_user_dirs]
+      when: xdg_user_dirs_enabled | default(true) | bool
+```
+
+Inventory example for a German workstation:
+
+```yaml
+xdg_user_dirs_locale: 'de_DE.UTF-8'
+xdg_user_dirs_extra:
+  MEDIA: 'Medien'
+xdg_user_dirs_users:
+  - username: 'marc'
+```
+
+## Testing
+
+```bash
+cd roles/xdg_user_dirs
+molecule test
+```
+
+Driver: Podman. Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10.
+
+## References
+
+- [freedesktop.org xdg-user-dirs](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/) — upstream spec and tool
+- [xdg-user-dirs 0.20 release notes — Projects directory](https://blog.tenstral.net/2026/04/hello-projects-directory.html) — background on the new `PROJECTS` default
+
+## License
+
+MIT
+
+## Author
+
+Marc Straube

--- a/roles/xdg_user_dirs/defaults/main.yml
+++ b/roles/xdg_user_dirs/defaults/main.yml
@@ -1,0 +1,78 @@
+---
+#
+# Role Control
+#
+
+# Enable the xdg_user_dirs role
+xdg_user_dirs_enabled: true
+
+#
+# Localization
+#
+
+# Locale used when generating ~/.config/user-dirs.dirs. The package's
+# translated names (Schreibtisch, Bilder, …) come from the .po files
+# shipped with xdg-user-dirs, so the locale's UTF-8 codeset must be
+# generated on the host (handled by your base role, not here).
+xdg_user_dirs_locale: 'en_US.UTF-8'
+
+#
+# Extra (custom) XDG entries
+#
+# Merged into ~/.config/user-dirs.dirs via lineinfile after the
+# standard set from /etc/xdg/user-dirs.defaults has been written.
+# Format: key (without XDG_ prefix and _DIR suffix) → relative path
+# under $HOME.
+#
+# Example:
+#   xdg_user_dirs_extra:
+#     MEDIA: 'Medien'
+#     BACKUP: 'Sicherungen'
+xdg_user_dirs_extra: {}
+
+#
+# Standard entries to skip
+#
+# Removes the listed XDG_<KEY>_DIR lines from ~/.config/user-dirs.dirs
+# after xdg-user-dirs-update wrote them, and skips directory creation
+# for those keys. Locale translation of the kept entries is unaffected.
+# Use the upstream key name without the XDG_ prefix and _DIR suffix.
+#
+# Common keys: DESKTOP, DOWNLOAD, DOCUMENTS, MUSIC, PICTURES, VIDEOS,
+#              TEMPLATES, PUBLICSHARE, PROJECTS
+#
+# Example:
+#   xdg_user_dirs_skip:
+#     - TEMPLATES
+#     - PUBLICSHARE
+xdg_user_dirs_skip: []
+
+#
+# User Configuration
+#
+# Users for whom XDG user directories should be deployed.
+# Each entry needs at least `username`; an optional `mode` overrides
+# the global default below.
+#
+# Modes:
+#   managed  — overwrite the file on every run (re-runs xdg-user-dirs-update)
+#   initial  — deploy only when the user was created in this run
+#   disabled — skip this user entirely
+xdg_user_dirs_users: []
+# Example:
+#   xdg_user_dirs_users:
+#     - username: 'johndoe'
+#       mode: 'managed'
+
+# Default mode when a user entry omits its own `mode`.
+xdg_user_dirs_user_config_mode: 'initial'
+
+#
+# Directory Permissions
+#
+# Filesystem mode applied to every XDG user directory the role creates
+# or touches. '0755' matches the XDG default (what most file managers
+# create) and keeps the dirs traversable for tools that walk $HOME.
+# Set to '0700' if you keep $HOME at 0700 and want consistent perms;
+# in that case nothing outside $HOME can reach the subdirs anyway.
+xdg_user_dirs_mode: '0755'

--- a/roles/xdg_user_dirs/meta/main.yml
+++ b/roles/xdg_user_dirs/meta/main.yml
@@ -1,0 +1,25 @@
+---
+galaxy_info:
+  author: Marc Straube
+  description: Manage XDG user directories (Documents, Downloads, Projects, …) per user
+  license: MIT
+  min_ansible_version: '2.17'
+
+  platforms:
+    - name: ArchLinux
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - trixie
+    - name: EL
+      versions:
+        - all
+
+  galaxy_tags:
+    - xdg
+    - userdirs
+    - desktop
+    - localization
+
+dependencies: []

--- a/roles/xdg_user_dirs/molecule/default/converge.yml
+++ b/roles/xdg_user_dirs/molecule/default/converge.yml
@@ -1,0 +1,27 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+
+  vars:
+    # Localized output (e.g. de_DE.UTF-8 → 'Schreibtisch') is not tested
+    # here because stock molecule container images strip non-English .mo
+    # files via NoExtract (Arch) / _install_langs (RHEL family). The
+    # translation mechanism is exercised live on real hosts; molecule
+    # tests the deploy/freeze/dir-creation mechanism with C/en_US.
+    xdg_user_dirs_enabled: true
+    xdg_user_dirs_locale: 'en_US.UTF-8'
+    xdg_user_dirs_extra:
+      MEDIA: 'Media'
+    xdg_user_dirs_skip:
+      - TEMPLATES
+      - PUBLICSHARE
+    xdg_user_dirs_mode: '0700'
+    xdg_user_dirs_user_config_mode: 'managed'
+    xdg_user_dirs_users:
+      - username: 'xdg_test_user'
+
+  tasks:
+    - name: Converge | Include xdg_user_dirs role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'

--- a/roles/xdg_user_dirs/molecule/default/molecule.yml
+++ b/roles/xdg_user_dirs/molecule/default/molecule.yml
@@ -1,0 +1,73 @@
+---
+driver:
+  name: podman
+platforms:
+  - name: xdg-user-dirs-archlinux
+    image: docker.io/marcstraube/archlinux-ansible:latest
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      /run: rw,nosuid,nodev,size=65536k
+      /tmp: rw,nosuid,nodev
+  - name: xdg-user-dirs-debian-trixie
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      /run: rw,nosuid,nodev,size=65536k
+      /tmp: rw,nosuid,nodev
+  - name: xdg-user-dirs-rocky-9
+    image: docker.io/geerlingguy/docker-rockylinux9-ansible:latest
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      /run: rw,nosuid,nodev,size=65536k
+      /tmp: rw,nosuid,nodev
+  - name: xdg-user-dirs-rocky-10
+    image: docker.io/geerlingguy/docker-rockylinux10-ansible:latest
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      /run: rw,nosuid,nodev,size=65536k
+      /tmp: rw,nosuid,nodev
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    prepare: prepare.yml
+    verify: verify.yml
+  config_options:
+    defaults:
+      allow_broken_conditionals: true
+  inventory:
+    host_vars:
+      xdg-user-dirs-archlinux:
+        ansible_python_interpreter: /usr/bin/python
+      xdg-user-dirs-debian-trixie:
+        ansible_python_interpreter: /usr/bin/python3
+      xdg-user-dirs-rocky-9:
+        ansible_python_interpreter: /usr/bin/python3
+      xdg-user-dirs-rocky-10:
+        ansible_python_interpreter: /usr/bin/python3
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/roles/xdg_user_dirs/molecule/default/prepare.yml
+++ b/roles/xdg_user_dirs/molecule/default/prepare.yml
@@ -40,8 +40,42 @@
         state: present
       when: ansible_facts['os_family'] in __prepare_packages
 
+    # Sudo PAM bypass — required for tasks using `become_user` on
+    # geerlingguy Rocky containers under GitHub-hosted runners
+    # (test container only).
+    - name: Prepare | Bypass sudo PAM stack (RedHat container)
+      ansible.builtin.copy:
+        content: |
+          #%PAM-1.0
+          auth       sufficient   pam_permit.so
+          account    sufficient   pam_permit.so
+          password   sufficient   pam_permit.so
+          session    sufficient   pam_permit.so
+        dest: /etc/pam.d/sudo
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Disable sudoers authentication (RedHat container)
+      ansible.builtin.copy:
+        content: 'Defaults !authenticate'
+        dest: /etc/sudoers.d/molecule-no-auth
+        owner: root
+        group: root
+        mode: '0440'
+        validate: 'visudo -cf %s'
+      when: ansible_facts['os_family'] == 'RedHat'
+
     - name: Prepare | Create test user
       ansible.builtin.user:
         name: xdg_test_user
         create_home: true
         shell: /bin/bash
+        # Real sha512 password hash. Required so PAM account management
+        # accepts root → xdg_test_user become in containerised Rocky
+        # under GitHub-hosted runners (locked accounts and `*` placeholder
+        # both fail pam_unix account check with "Authentication service
+        # cannot retrieve authentication info").
+        password: "{{ 'molecule-xdg-test-noop' | password_hash('sha512') }}"
+        update_password: 'on_create'

--- a/roles/xdg_user_dirs/molecule/default/prepare.yml
+++ b/roles/xdg_user_dirs/molecule/default/prepare.yml
@@ -1,0 +1,47 @@
+---
+# Note: molecule containers come with aggressive locale-stripping
+# (Arch: NoExtract in pacman.conf; RHEL family: _install_langs=en_US),
+# so only en_US translations are available out-of-the-box. The molecule
+# scenario therefore tests with xdg_user_dirs_locale='en_US.UTF-8'.
+# Localized output (de_DE, fr_FR, …) is verified live on real hosts.
+
+- name: Prepare
+  hosts: all
+  gather_facts: true
+
+  vars:
+    __prepare_packages:
+      Debian:
+        - python3
+        - python3-apt
+        - systemd
+      RedHat:
+        - python3
+
+  tasks:
+    - name: Prepare | Update package cache (Arch)
+      community.general.pacman:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Prepare | Update package cache (Debian)
+      ansible.builtin.apt:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Prepare | Update package cache (RedHat)
+      ansible.builtin.dnf:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
+        state: present
+      when: ansible_facts['os_family'] in __prepare_packages
+
+    - name: Prepare | Create test user
+      ansible.builtin.user:
+        name: xdg_test_user
+        create_home: true
+        shell: /bin/bash

--- a/roles/xdg_user_dirs/molecule/default/verify.yml
+++ b/roles/xdg_user_dirs/molecule/default/verify.yml
@@ -1,0 +1,104 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Verify | Check xdg-user-dirs package installed
+      ansible.builtin.package:
+        name: xdg-user-dirs
+        state: present
+      check_mode: true
+      register: __xdg_verify_pkg
+
+    - name: Verify | Assert xdg-user-dirs installed
+      ansible.builtin.assert:
+        that:
+          - not __xdg_verify_pkg.changed
+        fail_msg: 'xdg-user-dirs is not installed'
+
+    - name: Verify | Read user-dirs.dirs content
+      ansible.builtin.slurp:
+        src: /home/xdg_test_user/.config/user-dirs.dirs
+      register: __xdg_dirs_content
+
+    - name: Verify | Assert user-dirs.dirs has localized names
+      ansible.builtin.assert:
+        that:
+          - "'Desktop' in __dirs_text"
+          - "'Documents' in __dirs_text"
+          - "'Pictures' in __dirs_text"
+        fail_msg: 'user-dirs.dirs does not contain expected standard directory names'
+      vars:
+        __dirs_text: '{{ __xdg_dirs_content.content | b64decode }}'
+
+    - name: Verify | Assert custom MEDIA entry present
+      ansible.builtin.assert:
+        that:
+          - "'XDG_MEDIA_DIR=\"$HOME/Media\"' in __dirs_text"
+        fail_msg: 'Custom XDG_MEDIA_DIR entry missing from user-dirs.dirs'
+      vars:
+        __dirs_text: '{{ __xdg_dirs_content.content | b64decode }}'
+
+    - name: Verify | Read user-dirs.conf (freeze)
+      ansible.builtin.slurp:
+        src: /home/xdg_test_user/.config/user-dirs.conf
+      register: __xdg_conf_content
+
+    - name: Verify | Assert freeze is enabled
+      ansible.builtin.assert:
+        that:
+          - "'enabled=False' in (__xdg_conf_content.content | b64decode)"
+        fail_msg: 'user-dirs.conf does not contain enabled=False'
+
+    - name: Verify | Check Documents directory exists
+      ansible.builtin.stat:
+        path: /home/xdg_test_user/Documents
+      register: __xdg_dokumente
+
+    - name: Verify | Assert Documents directory exists
+      ansible.builtin.assert:
+        that:
+          - __xdg_dokumente.stat.exists
+          - __xdg_dokumente.stat.isdir
+          - __xdg_dokumente.stat.pw_name == 'xdg_test_user'
+        fail_msg: 'Documents directory missing or wrong owner'
+
+    - name: Verify | Check Media custom directory exists
+      ansible.builtin.stat:
+        path: /home/xdg_test_user/Media
+      register: __xdg_medien
+
+    - name: Verify | Assert Media custom directory exists
+      ansible.builtin.assert:
+        that:
+          - __xdg_medien.stat.exists
+          - __xdg_medien.stat.isdir
+          - __xdg_medien.stat.pw_name == 'xdg_test_user'
+        fail_msg: 'Custom Media directory missing or wrong owner'
+
+    - name: Verify | Assert configured mode applied to created dirs
+      ansible.builtin.assert:
+        that:
+          - __xdg_dokumente.stat.mode == '0700'
+          - __xdg_medien.stat.mode == '0700'
+        fail_msg: 'XDG directories do not have configured mode 0700'
+
+    - name: Verify | Assert skipped entries removed from user-dirs.dirs
+      ansible.builtin.assert:
+        that:
+          - "'XDG_TEMPLATES_DIR=' not in __dirs_text"
+          - "'XDG_PUBLICSHARE_DIR=' not in __dirs_text"
+        fail_msg: 'Skipped XDG entries still present in user-dirs.dirs'
+      vars:
+        __dirs_text: '{{ __xdg_dirs_content.content | b64decode }}'
+
+    - name: Verify | Check Templates directory NOT created
+      ansible.builtin.stat:
+        path: /home/xdg_test_user/Templates
+      register: __xdg_templates
+
+    - name: Verify | Assert Templates directory absent
+      ansible.builtin.assert:
+        that:
+          - not __xdg_templates.stat.exists
+        fail_msg: 'Templates directory created despite being in skip list'

--- a/roles/xdg_user_dirs/tasks/main.yml
+++ b/roles/xdg_user_dirs/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Main | Install xdg-user-dirs package
+  ansible.builtin.package:
+    name: xdg-user-dirs
+    state: present
+  retries: 3
+  delay: 5
+  when: xdg_user_dirs_enabled | bool
+  tags:
+    - xdg_user_dirs
+    - xdg_user_dirs:install
+
+- name: Main | Include user-config tasks
+  ansible.builtin.include_tasks:
+    file: users.yml
+    apply:
+      tags:
+        - xdg_user_dirs
+        - xdg_user_dirs:users
+  tags:
+    - xdg_user_dirs
+    - xdg_user_dirs:users
+  when:
+    - xdg_user_dirs_enabled | bool
+    - xdg_user_dirs_users | length > 0

--- a/roles/xdg_user_dirs/tasks/users.yml
+++ b/roles/xdg_user_dirs/tasks/users.yml
@@ -1,0 +1,24 @@
+---
+# Respects mode: managed | initial | disabled.
+# Per-user `mode:` overrides xdg_user_dirs_user_config_mode.
+
+- name: Users | Configure XDG user dirs
+  ansible.builtin.include_tasks:
+    file: users_setup.yml
+    apply:
+      tags:
+        - xdg_user_dirs
+        - xdg_user_dirs:users
+  tags:
+    - xdg_user_dirs
+    - xdg_user_dirs:users
+  loop: '{{ xdg_user_dirs_users }}'
+  loop_control:
+    loop_var: xdg_user
+    label: '{{ xdg_user.username }}'
+  when:
+    - (xdg_user.mode | default(xdg_user_dirs_user_config_mode)) != 'disabled'
+    - >-
+      (xdg_user.mode | default(xdg_user_dirs_user_config_mode)) == 'managed'
+      or ((xdg_user.mode | default(xdg_user_dirs_user_config_mode)) == 'initial'
+          and xdg_user.username in (__users_newly_created | default([])))

--- a/roles/xdg_user_dirs/tasks/users_setup.yml
+++ b/roles/xdg_user_dirs/tasks/users_setup.yml
@@ -1,0 +1,104 @@
+---
+- name: Users Setup | Get user info
+  ansible.builtin.getent:
+    database: passwd
+    key: '{{ xdg_user.username }}'
+
+- name: Users Setup | Set user home fact
+  ansible.builtin.set_fact:
+    __xdg_user_home: "{{ ansible_facts['getent_passwd'][xdg_user.username][4] }}"
+
+- name: Users Setup | Ensure ~/.config directory exists
+  ansible.builtin.file:
+    path: '{{ __xdg_user_home }}/.config'
+    state: directory
+    owner: '{{ xdg_user.username }}'
+    group: '{{ xdg_user.username }}'
+    mode: '0700'
+
+# --dummy-output writes user-dirs.dirs but does NOT create the target
+# directories on its own (which would defeat xdg_user_dirs_skip). The
+# real dir creation is handled by the file task at the end of this
+# file, so we keep full control over which dirs exist. --force still
+# bypasses any enabled=False freeze. Output is deterministic for a
+# given locale, hence changed_when: false; drift is detected by the
+# ownership/mode task that follows.
+- name: Users Setup | Generate user-dirs.dirs with configured locale
+  ansible.builtin.command:
+    cmd: xdg-user-dirs-update --force --dummy-output {{ __xdg_user_home }}/.config/user-dirs.dirs
+  environment:
+    LANG: '{{ xdg_user_dirs_locale }}'
+    LC_ALL: '{{ xdg_user_dirs_locale }}'
+  become: true
+  become_user: '{{ xdg_user.username }}'
+  changed_when: false
+
+- name: Users Setup | Enforce ownership and mode on user-dirs.dirs
+  ansible.builtin.file:
+    path: '{{ __xdg_user_home }}/.config/user-dirs.dirs'
+    owner: '{{ xdg_user.username }}'
+    group: '{{ xdg_user.username }}'
+    mode: '0600'
+
+# Drop standard entries the operator does not want. The line is
+# removed first so the subsequent parse step sees only the kept set
+# and no directory is created for the dropped keys.
+- name: Users Setup | Drop skipped XDG entries
+  ansible.builtin.lineinfile:
+    path: '{{ __xdg_user_home }}/.config/user-dirs.dirs'
+    regexp: '^XDG_{{ item }}_DIR='
+    state: absent
+    owner: '{{ xdg_user.username }}'
+    group: '{{ xdg_user.username }}'
+    mode: '0600'
+  loop: '{{ xdg_user_dirs_skip }}'
+  loop_control:
+    label: '{{ item }}'
+  when: xdg_user_dirs_skip | length > 0
+
+# Custom XDG entries are appended/merged into user-dirs.dirs.
+# lineinfile matches on the XDG_<KEY>_DIR= prefix, so a future
+# xdg-user-dirs upgrade that ships the same key as a default does
+# not produce a duplicate line.
+- name: Users Setup | Apply extra XDG entries
+  ansible.builtin.lineinfile:
+    path: '{{ __xdg_user_home }}/.config/user-dirs.dirs'
+    regexp: '^XDG_{{ item.key }}_DIR='
+    line: 'XDG_{{ item.key }}_DIR="$HOME/{{ item.value }}"'
+    owner: '{{ xdg_user.username }}'
+    group: '{{ xdg_user.username }}'
+    mode: '0600'
+  loop: '{{ xdg_user_dirs_extra | dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
+  when: xdg_user_dirs_extra | length > 0
+
+- name: Users Setup | Freeze user-dirs.dirs against auto-triggered updates
+  ansible.builtin.copy:
+    content: "enabled=False\n"
+    dest: '{{ __xdg_user_home }}/.config/user-dirs.conf'
+    owner: '{{ xdg_user.username }}'
+    group: '{{ xdg_user.username }}'
+    mode: '0644'
+
+- name: Users Setup | Read user-dirs.dirs to learn target paths
+  ansible.builtin.slurp:
+    src: '{{ __xdg_user_home }}/.config/user-dirs.dirs'
+  register: __xdg_dirs_file
+
+- name: Users Setup | Parse XDG_*_DIR entries
+  ansible.builtin.set_fact:
+    __xdg_target_dirs: >-
+      {{ __xdg_dirs_file.content | b64decode
+         | regex_findall('XDG_[A-Z_]+_DIR="[$]HOME/([^"]+)"') }}
+
+- name: Users Setup | Ensure all referenced directories exist
+  ansible.builtin.file:
+    path: '{{ __xdg_user_home }}/{{ item }}'
+    state: directory
+    owner: '{{ xdg_user.username }}'
+    group: '{{ xdg_user.username }}'
+    mode: '{{ xdg_user_dirs_mode }}'
+  loop: '{{ __xdg_target_dirs }}'
+  loop_control:
+    label: '{{ item }}'


### PR DESCRIPTION
Closes #106

## Summary

New distro-agnostic role wrapping `xdg-user-dirs` with per-user configurable locale, custom `XDG_*_DIR` entries, and a skip list for unwanted standard entries (`DESKTOP`, `TEMPLATES`, …). Uses `xdg-user-dirs-update --force --dummy-output` so the binary writes only the file without pre-creating directories — the role's own `file` task materializes only the kept entries. Filesystem mode is configurable (`0755` default, `0700` for private homes). `user-dirs.conf` is frozen with `enabled=False` to prevent auto-updates from clobbering the deployed file.

## Variables

- `xdg_user_dirs_locale` — locale used to translate directory names (default `en_US.UTF-8`)
- `xdg_user_dirs_extra` — additional `XDG_*_DIR` entries beyond the package defaults
- `xdg_user_dirs_skip` — list of standard entries to drop (lines removed, dirs not created)
- `xdg_user_dirs_mode` — filesystem mode for created dirs (default `0755`, set `0700` for private `$HOME`)
- `xdg_user_dirs_users` + `xdg_user_dirs_user_config_mode` — per-user `managed`/`initial`/`disabled` dispatch consistent with other `_users` roles

## Integration

Wired into `playbooks/tasks/desktop_workstation.yml` between `bluetooth` and `filemanagers` with `xdg_user_dirs_enabled` defaulting to `true`.

## Test plan

- [x] Molecule passes on all four supported distros (Arch, Debian Trixie, Rocky 9, Rocky 10) — converge, idempotence, verify
- [x] ansible-lint clean
- [x] Live-tested on real workstation with `de_DE.UTF-8` locale: directories created with localized names (`Schreibtisch`, `Dokumente`, …), `xdg_user_dirs_skip: [DESKTOP]` correctly omits the entry on a re-run, configured mode applied, second run is idempotent
- [ ] Locale translation in CI containers — not covered by molecule because images strip non-English `.mo` files via Arch `NoExtract` and RHEL `_install_langs`; mechanism is verified live instead