### PR TITLE
chore(claude): remove outdated "Untested Roles" section

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -75,16 +75,6 @@ All `include_tasks` in roles use `apply: tags:` for proper `--tags` filtering:
     - mytag
 ```
 
-## Untested Roles
-
-The following roles are integrated in `playbooks/desktop.yml` with `default(false)` toggles
-but have NOT been verified on a live system yet:
-cad, communication, downloads, filemanagers, gaming, graphics_apps,
-imaging, multimedia, remote_access, security_apps, system_apps, tabletop.
-
-They can be enabled per host via inventory (e.g., `gaming_enabled: true`) but may need
-fixes before production use.
-
 ## Security
 
 - Vault files (`vault.yml`) are never accessed — only `vault.yml.example` templates


### PR DESCRIPTION
## Summary

Remove the "Untested Roles" section from `.claude/CLAUDE.md`. The list was carried over from an earlier phase and is no longer accurate. Per-role README and `defaults/main.yml` remain the canonical source for which roles are stable to enable.

## Test plan

- [x] `pre-commit run markdownlint --files .claude/CLAUDE.md` passes
- [x] Doc-only change, no code or playbook impact