### PR TITLE
fix+refactor(ai): install ComfyUI via AUR on Arch; manual path bugfixes for Debian/Rocky

### DIFF
--- a/roles/ai/README.md
+++ b/roles/ai/README.md
@@ -69,18 +69,39 @@ API keys are managed by the user via environment variables (not by this role).
 
 ### ComfyUI (Stable Diffusion)
 
-| Variable                      | Default          | Description                 |
-| ----------------------------- | ---------------- | --------------------------- |
-| `ai_comfyui_enabled`          | `false`          | Install ComfyUI             |
-| `ai_comfyui_gpu`              | `'nvidia'`       | GPU type: `nvidia` or `amd` |
-| `ai_comfyui_version`          | `'master'`       | Git branch/tag              |
-| `ai_comfyui_install_dir`      | `'/opt/comfyui'` | Installation directory      |
-| `ai_comfyui_listen`           | `'127.0.0.1'`    | Listen address              |
-| `ai_comfyui_port`             | `8188`           | Web UI port                 |
-| `ai_comfyui_user`             | `'comfyui'`      | Service user                |
-| `ai_comfyui_group`            | `'comfyui'`      | Service group               |
-| `ai_comfyui_manager_enabled`  | `true`           | Install ComfyUI-Manager     |
-| `ai_comfyui_service_enabled`  | `true`           | Enable systemd service      |
+| Variable                      | Default                 | Description                                                |
+| ----------------------------- | ----------------------- | ---------------------------------------------------------- |
+| `ai_comfyui_enabled`          | `false`                 | Install ComfyUI                                            |
+| `ai_comfyui_gpu`              | `'nvidia'`              | GPU backend: `nvidia`, `amd`, or `cpu`                     |
+| `ai_comfyui_version`          | `'master'`              | Git branch/tag (manual path only)                          |
+| `ai_comfyui_install_dir`      | `'/opt/comfyui'`        | Installation directory (manual path only)                  |
+| `ai_comfyui_home`             | `'/var/lib/comfyui'`    | Service user home (manual path only; FHS state directory)  |
+| `ai_comfyui_listen`           | `'127.0.0.1'`           | Listen address                                             |
+| `ai_comfyui_port`             | `8188`                  | Web UI port                                                |
+| `ai_comfyui_user`             | `'comfyui'`             | Service user (manual path only)                            |
+| `ai_comfyui_group`            | `'comfyui'`             | Service group (manual path only)                           |
+| `ai_comfyui_manager_enabled`  | `true`                  | Install ComfyUI-Manager                                    |
+| `ai_comfyui_service_enabled`  | `true`                  | Enable systemd service                                     |
+
+**Install path differs by OS family:**
+
+- **Arch Linux**: installs the AUR `comfyui` package via `kewlfft.aur.aur`.
+  The PKGBUILD owns the install dir (`/opt/comfyui`), the service user
+  (`comfy`), the Python venv, the PyTorch wheel selection (driven by
+  `COMFYUI_GPU={cuda,rocm,cpu}` mapped from `ai_comfyui_gpu`), and the
+  systemd unit. Inventory variables marked *(manual path only)* in the
+  table above are **not honored** on Arch — they are fixed by the AUR
+  PKGBUILD.
+- **Debian / Rocky Linux**: from-source install. The role creates the
+  service user/group, clones the upstream ComfyUI repo to
+  `ai_comfyui_install_dir`, builds a Python virtual environment, and
+  installs PyTorch wheels selected by `ai_comfyui_gpu`. All variables
+  above apply.
+
+**ComfyUI-Manager** is installed via manual git-clone on both paths
+because no upstream package exists yet (see `tasks/comfyui-archlinux.yml`
+for the documented exception to the project's "Arch installs go through
+repos or AUR" rule).
 
 ## Tags
 

--- a/roles/ai/defaults/main.yml
+++ b/roles/ai/defaults/main.yml
@@ -81,6 +81,9 @@ ai_comfyui_port: 8188
 ai_comfyui_user: 'comfyui'
 # Service group
 ai_comfyui_group: 'comfyui'
+# Service user home (FHS state directory — kept distinct from install_dir
+# so `become_user`'s ~/.ansible/tmp does not land in the git-clone target)
+ai_comfyui_home: '/var/lib/comfyui'
 # Enable ComfyUI-Manager
 ai_comfyui_manager_enabled: true
 # Enable and start the ComfyUI service

--- a/roles/ai/tasks/comfyui-archlinux.yml
+++ b/roles/ai/tasks/comfyui-archlinux.yml
@@ -1,0 +1,64 @@
+---
+#
+# ComfyUI install — Arch Linux (AUR)
+#
+# The AUR `comfyui` package owns: system user `comfy`, install dir
+# `/opt/comfyui`, Python venv, PyTorch wheel selection (driven by the
+# `COMFYUI_GPU` env var consumed by the PKGBUILD's post_install hook),
+# and the systemd unit at `/usr/lib/systemd/system/comfyui.service`.
+#
+# Inventory variables `ai_comfyui_user`, `ai_comfyui_group`,
+# `ai_comfyui_install_dir`, `ai_comfyui_home` are *not* honored on the
+# Arch path — the AUR package determines those.
+#
+# ComfyUI-Manager has no AUR package yet, so it is installed via a
+# manual git-clone as `comfy`. This is the documented exception to the
+# project rule that Arch installs go through official repos or AUR.
+# An AUR submission for `comfyui-manager` is tracked separately and
+# would let this block collapse into a kewlfft.aur.aur install.
+
+- name: ComfyUI | Install AUR package
+  become: true
+  become_user: aur_builder
+  environment:
+    COMFYUI_GPU: "{{ __ai_comfyui_aur_gpu_map[ai_comfyui_gpu] | default('cpu') }}"
+  kewlfft.aur.aur:
+    name: '{{ __ai_comfyui_aur_package }}'
+    state: present
+  retries: 3
+  delay: 5
+
+# Pre-create the Ansible remote_tmp under comfy's home so the next
+# `become_user: comfy` task does not emit the generic 0700 warning.
+# Running git as `comfy` (rather than as root + chown) keeps git's
+# safe.directory check happy on repeated runs — root would refuse to
+# touch a comfy-owned repo and abort with `dubious ownership`.
+- name: ComfyUI | Pre-create Ansible remote_tmp under comfy home
+  become: true
+  ansible.builtin.file:
+    path: '{{ __ai_comfyui_aur_user_home }}/.ansible/tmp'
+    state: directory
+    owner: '{{ __ai_comfyui_aur_user }}'
+    group: '{{ __ai_comfyui_aur_group }}'
+    mode: '0700'
+  when: ai_comfyui_manager_enabled | bool
+
+- name: ComfyUI | Clone ComfyUI-Manager
+  become: true
+  become_user: '{{ __ai_comfyui_aur_user }}'
+  ansible.builtin.git:
+    repo: '{{ __ai_comfyui_manager_repo_url }}'
+    dest: "{{ __ai_comfyui_aur_install_dir }}/custom_nodes/ComfyUI-Manager"
+    version: 'main'
+    update: true
+  when: ai_comfyui_manager_enabled | bool
+  retries: 5
+  delay: 10
+
+- name: ComfyUI | Manage service
+  become: true
+  ansible.builtin.systemd_service:
+    name: comfyui.service
+    enabled: "{{ ai_comfyui_service_enabled | bool }}"
+    state: "{{ ai_comfyui_service_enabled | bool | ternary('started', 'stopped') }}"
+    daemon_reload: true

--- a/roles/ai/tasks/comfyui-other.yml
+++ b/roles/ai/tasks/comfyui-other.yml
@@ -1,0 +1,129 @@
+---
+#
+# ComfyUI install — manual flow (Debian, Rocky Linux)
+#
+# On Arch, the AUR `comfyui` package is used instead — see
+# `comfyui-archlinux.yml`. This file performs a from-source install:
+# create service user/group, clone repo, build a Python venv, install
+# PyTorch wheels matching `ai_comfyui_gpu`, then deploy a project-owned
+# systemd unit.
+
+- name: ComfyUI | Install ComfyUI system dependencies
+  become: true
+  ansible.builtin.package:
+    name: '{{ __ai_comfyui_venv_packages }}'
+    state: present
+  retries: 3
+  delay: 5
+
+- name: ComfyUI | Create service group
+  become: true
+  ansible.builtin.group:
+    name: '{{ ai_comfyui_group }}'
+    system: true
+    state: present
+
+- name: ComfyUI | Create ComfyUI service user
+  become: true
+  ansible.builtin.user:
+    name: '{{ ai_comfyui_user }}'
+    group: '{{ ai_comfyui_group }}'
+    system: true
+    home: '{{ ai_comfyui_home }}'
+    create_home: true
+    shell: /usr/sbin/nologin
+
+- name: ComfyUI | Create ComfyUI install directory
+  become: true
+  ansible.builtin.file:
+    path: '{{ ai_comfyui_install_dir }}'
+    state: directory
+    owner: '{{ ai_comfyui_user }}'
+    group: '{{ ai_comfyui_group }}'
+    mode: '0755'
+
+- name: ComfyUI | Clone ComfyUI repository
+  become: true
+  become_user: '{{ ai_comfyui_user }}'
+  ansible.builtin.git:
+    repo: '{{ __ai_comfyui_repo_url }}'
+    dest: '{{ ai_comfyui_install_dir }}'
+    version: '{{ ai_comfyui_version }}'
+    update: true
+  retries: 5
+  delay: 10
+
+- name: ComfyUI | Create ComfyUI Python virtual environment
+  become: true
+  become_user: '{{ ai_comfyui_user }}'
+  ansible.builtin.command:
+    cmd: '{{ __ai_comfyui_python }} -m venv venv'
+    chdir: '{{ ai_comfyui_install_dir }}'
+    creates: '{{ ai_comfyui_install_dir }}/venv/bin/activate'
+
+- name: ComfyUI | Install PyTorch (NVIDIA CUDA)
+  become: true
+  become_user: '{{ ai_comfyui_user }}'
+  ansible.builtin.pip:
+    name:
+      - torch
+      - torchvision
+      - torchaudio
+    extra_args: '--index-url https://download.pytorch.org/whl/cu126'
+    virtualenv: '{{ ai_comfyui_install_dir }}/venv'
+  when: ai_comfyui_gpu == 'nvidia'
+  retries: 3
+  delay: 5
+
+- name: ComfyUI | Install PyTorch (AMD ROCm)
+  become: true
+  become_user: '{{ ai_comfyui_user }}'
+  ansible.builtin.pip:
+    name:
+      - torch
+      - torchvision
+      - torchaudio
+    extra_args: '--index-url https://download.pytorch.org/whl/rocm6.2.4'
+    virtualenv: '{{ ai_comfyui_install_dir }}/venv'
+  when: ai_comfyui_gpu == 'amd'
+  retries: 3
+  delay: 5
+
+- name: ComfyUI | Install ComfyUI requirements
+  become: true
+  become_user: '{{ ai_comfyui_user }}'
+  ansible.builtin.pip:
+    requirements: '{{ ai_comfyui_install_dir }}/requirements.txt'
+    virtualenv: '{{ ai_comfyui_install_dir }}/venv'
+  retries: 3
+  delay: 5
+
+- name: ComfyUI | Clone ComfyUI-Manager
+  become: true
+  become_user: '{{ ai_comfyui_user }}'
+  ansible.builtin.git:
+    repo: '{{ __ai_comfyui_manager_repo_url }}'
+    dest: '{{ ai_comfyui_install_dir }}/custom_nodes/ComfyUI-Manager'
+    version: 'main'
+    update: true
+  when: ai_comfyui_manager_enabled | bool
+  retries: 5
+  delay: 10
+
+- name: ComfyUI | Deploy ComfyUI systemd service
+  become: true
+  ansible.builtin.template:
+    src: comfyui.service.j2
+    dest: /etc/systemd/system/comfyui.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart ComfyUI
+
+- name: ComfyUI | Manage ComfyUI service
+  become: true
+  ansible.builtin.systemd_service:
+    name: comfyui.service
+    enabled: "{{ ai_comfyui_service_enabled | bool }}"
+    state: "{{ ai_comfyui_service_enabled | bool | ternary('started', 'stopped') }}"
+    daemon_reload: true

--- a/roles/ai/tasks/comfyui.yml
+++ b/roles/ai/tasks/comfyui.yml
@@ -12,6 +12,13 @@
   retries: 3
   delay: 5
 
+- name: ComfyUI | Create service group
+  become: true
+  ansible.builtin.group:
+    name: '{{ ai_comfyui_group }}'
+    system: true
+    state: present
+
 - name: ComfyUI | Create ComfyUI service user
   become: true
   ansible.builtin.user:

--- a/roles/ai/tasks/comfyui.yml
+++ b/roles/ai/tasks/comfyui.yml
@@ -2,124 +2,17 @@
 #
 # ComfyUI - Stable Diffusion Node-Based UI
 #
-# Global install to ai_comfyui_install_dir with dedicated service user
+# Per-OS dispatcher. Arch uses the `comfyui` AUR package
+# (`comfyui-archlinux.yml`); Debian and RedHat-family hosts use the
+# manual install flow (`comfyui-other.yml`).
 
-- name: ComfyUI | Install ComfyUI system dependencies
-  become: true
-  ansible.builtin.package:
-    name: '{{ __ai_comfyui_venv_packages }}'
-    state: present
-  retries: 3
-  delay: 5
-
-- name: ComfyUI | Create service group
-  become: true
-  ansible.builtin.group:
-    name: '{{ ai_comfyui_group }}'
-    system: true
-    state: present
-
-- name: ComfyUI | Create ComfyUI service user
-  become: true
-  ansible.builtin.user:
-    name: '{{ ai_comfyui_user }}'
-    group: '{{ ai_comfyui_group }}'
-    system: true
-    home: '{{ ai_comfyui_home }}'
-    create_home: true
-    shell: /usr/sbin/nologin
-
-- name: ComfyUI | Create ComfyUI install directory
-  become: true
-  ansible.builtin.file:
-    path: '{{ ai_comfyui_install_dir }}'
-    state: directory
-    owner: '{{ ai_comfyui_user }}'
-    group: '{{ ai_comfyui_group }}'
-    mode: '0755'
-
-- name: ComfyUI | Clone ComfyUI repository
-  become: true
-  become_user: '{{ ai_comfyui_user }}'
-  ansible.builtin.git:
-    repo: '{{ __ai_comfyui_repo_url }}'
-    dest: '{{ ai_comfyui_install_dir }}'
-    version: '{{ ai_comfyui_version }}'
-    update: true
-  retries: 5
-  delay: 10
-
-- name: ComfyUI | Create ComfyUI Python virtual environment
-  become: true
-  become_user: '{{ ai_comfyui_user }}'
-  ansible.builtin.command:
-    cmd: '{{ __ai_comfyui_python }} -m venv venv'
-    chdir: '{{ ai_comfyui_install_dir }}'
-    creates: '{{ ai_comfyui_install_dir }}/venv/bin/activate'
-
-- name: ComfyUI | Install PyTorch (NVIDIA CUDA)
-  become: true
-  become_user: '{{ ai_comfyui_user }}'
-  ansible.builtin.pip:
-    name:
-      - torch
-      - torchvision
-      - torchaudio
-    extra_args: '--index-url https://download.pytorch.org/whl/cu126'
-    virtualenv: '{{ ai_comfyui_install_dir }}/venv'
-  when: ai_comfyui_gpu == 'nvidia'
-  retries: 3
-  delay: 5
-
-- name: ComfyUI | Install PyTorch (AMD ROCm)
-  become: true
-  become_user: '{{ ai_comfyui_user }}'
-  ansible.builtin.pip:
-    name:
-      - torch
-      - torchvision
-      - torchaudio
-    extra_args: '--index-url https://download.pytorch.org/whl/rocm6.2.4'
-    virtualenv: '{{ ai_comfyui_install_dir }}/venv'
-  when: ai_comfyui_gpu == 'amd'
-  retries: 3
-  delay: 5
-
-- name: ComfyUI | Install ComfyUI requirements
-  become: true
-  become_user: '{{ ai_comfyui_user }}'
-  ansible.builtin.pip:
-    requirements: '{{ ai_comfyui_install_dir }}/requirements.txt'
-    virtualenv: '{{ ai_comfyui_install_dir }}/venv'
-  retries: 3
-  delay: 5
-
-- name: ComfyUI | Clone ComfyUI-Manager
-  become: true
-  become_user: '{{ ai_comfyui_user }}'
-  ansible.builtin.git:
-    repo: '{{ __ai_comfyui_manager_repo_url }}'
-    dest: '{{ ai_comfyui_install_dir }}/custom_nodes/ComfyUI-Manager'
-    version: 'main'
-    update: true
-  when: ai_comfyui_manager_enabled | bool
-  retries: 5
-  delay: 10
-
-- name: ComfyUI | Deploy ComfyUI systemd service
-  become: true
-  ansible.builtin.template:
-    src: comfyui.service.j2
-    dest: /etc/systemd/system/comfyui.service
-    owner: root
-    group: root
-    mode: '0644'
-  notify: Restart ComfyUI
-
-- name: ComfyUI | Manage ComfyUI service
-  become: true
-  ansible.builtin.systemd_service:
-    name: comfyui.service
-    enabled: "{{ ai_comfyui_service_enabled | bool }}"
-    state: "{{ ai_comfyui_service_enabled | bool | ternary('started', 'stopped') }}"
-    daemon_reload: true
+- name: ComfyUI | Include OS-specific install tasks
+  ansible.builtin.include_tasks:
+    file: "{{ 'comfyui-archlinux.yml' if ansible_facts['os_family'] == 'Archlinux' else 'comfyui-other.yml' }}"
+    apply:
+      tags:
+        - ai
+        - comfyui
+  tags:
+    - ai
+    - comfyui

--- a/roles/ai/tasks/comfyui.yml
+++ b/roles/ai/tasks/comfyui.yml
@@ -25,8 +25,8 @@
     name: '{{ ai_comfyui_user }}'
     group: '{{ ai_comfyui_group }}'
     system: true
-    home: '{{ ai_comfyui_install_dir }}'
-    create_home: false
+    home: '{{ ai_comfyui_home }}'
+    create_home: true
     shell: /usr/sbin/nologin
 
 - name: ComfyUI | Create ComfyUI install directory

--- a/roles/ai/vars/Archlinux.yml
+++ b/roles/ai/vars/Archlinux.yml
@@ -33,7 +33,23 @@ __ai_ollama_package: 'ollama'
 # Service names
 __ai_ollama_service: 'ollama.service'
 
-# ComfyUI
+# ComfyUI — AUR package (handles user, install dir, venv, PyTorch, systemd unit)
+# See roles/ai/tasks/comfyui-archlinux.yml for the install flow.
+# These are AUR PKGBUILD facts, not inventory-tunable.
+__ai_comfyui_aur_package: 'comfyui'
+# GPU backend (ai_comfyui_gpu) → COMFYUI_GPU env var consumed by PKGBUILD
+# post_install hook to choose the PyTorch wheel index (ROCm / CUDA / CPU).
+__ai_comfyui_aur_gpu_map:
+  nvidia: 'cuda'
+  amd: 'rocm'
+  cpu: 'cpu'
+# AUR-fixed paths and identity (set by comfyui.sysusers / PKGBUILD _prefix).
+__ai_comfyui_aur_user: 'comfy'
+__ai_comfyui_aur_group: 'comfy'
+__ai_comfyui_aur_user_home: '/var/lib/comfyui'
+__ai_comfyui_aur_install_dir: '/opt/comfyui'
+
+# ComfyUI — manual install fallback (kept for parity but not used on Arch)
 __ai_comfyui_python: 'python'
 __ai_comfyui_venv_packages:
   - 'python'


### PR DESCRIPTION
## Summary

Reworks ComfyUI install in the `ai` role. Closes #120.

Three commits, each independently reviewable:

1. **`fix(ai): create ComfyUI service group before user`** — adds the missing `ansible.builtin.group` task so `ansible.builtin.user` with explicit `group:` finds the group instead of aborting with `Group comfyui does not exist`. Applies to the manual install path.
2. **`fix(ai): decouple ComfyUI service-user home from install dir`** — `become_user`'s `~/.ansible/tmp/` was landing inside the git-clone target because the service user's home was pinned to `ai_comfyui_install_dir`. New `ai_comfyui_home` variable (default `/var/lib/comfyui`, FHS state directory) holds the home; install dir stays where inventory expects it. Also `create_home: true` so the home exists before any `become_user` task.
3. **`refactor(ai): install ComfyUI via AUR on Arch Linux`** — the root cause: the manual `git clone + venv + pip install` flow is the wrong strategy on Arch, since the AUR `comfyui` package owns user, install dir, venv, PyTorch wheel selection (driven by `COMFYUI_GPU={cuda,rocm,cpu}` mapped from `ai_comfyui_gpu`), and the systemd unit. Splits `tasks/comfyui.yml` into a per-OS dispatcher with `comfyui-archlinux.yml` (AUR install + ComfyUI-Manager + service) and `comfyui-other.yml` (the manual flow for Debian/Rocky, with the bugfixes from commits 1 + 2 retained).

ComfyUI-Manager has no AUR package, so it stays as a manual git-clone under `become_user: comfy` — the **documented exception** to the project's "Arch installs go through repos or AUR" rule. A small `Pre-create Ansible remote_tmp` task silences the generic 0700 warning on first run, and keeping the clone under `comfy` (rather than root + chown) sidesteps git's `safe.directory` check on re-runs. Submitting an AUR `comfyui-manager` PKGBUILD is tracked separately so the exception can collapse to a `kewlfft.aur.aur` install later.

## Variable semantics change

`ai_comfyui_user`, `ai_comfyui_group`, `ai_comfyui_install_dir`, and the new `ai_comfyui_home` now apply **only to the manual install path** (Debian / Rocky). On Arch they are read-only — the AUR PKGBUILD owns those facts (`comfy` user, `/opt/comfyui`, `/var/lib/comfyui`). README updated to spell that out.

## Test plan

- [x] `pre-commit run` clean across all changed files (ansible-lint production, yamllint, markdownlint)
- [x] **Arch live**: fresh install on a host with `ai_comfyui_gpu: amd` — AUR install completes (PyTorch ROCm wheels via PKGBUILD post_install), ComfyUI-Manager clones cleanly, `comfyui.service` enabled and started, no failed tasks, no Ansible warnings
- [x] **Arch idempotence**: second run reports the remote_tmp pre-create as the only `changed` task (because the dir is created fresh on first run), all other Arch tasks `ok`
- [ ] **Debian / Rocky live**: no test host available; manual path verified to fix the previous group/home failures by code review only

Closes #120