### PR TITLE
ci(release-please): port (unreleased) strip step from common

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,3 +29,79 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+
+      # Rewrite the `## vX.Y.Z (unreleased)` heading in MIGRATION.md to
+      # `## vX.Y.Z - YYYY-MM-DD` on the open release PR. release-please
+      # itself does not own MIGRATION.md, so without this step the
+      # heading would have to be dated by hand on every release.
+      #
+      # The step locates the release PR by the `autorelease: pending`
+      # label that release-please applies, rather than via the action's
+      # `pr` output. The action only populates that output when it
+      # creates or updates the PR in *this* run — when the PR already
+      # exists and release-please reports "PR remained the same", the
+      # output is empty and any gating on it would silently skip this
+      # step.
+      #
+      # No-op when no release PR is open, MIGRATION.md is absent, the
+      # heading is already dated, or the version release-please picked
+      # does not have a matching (unreleased) heading. Commit goes
+      # through the contents API so it is attributed to and verified as
+      # the release bot.
+      - name: Date (unreleased) section in MIGRATION.md
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          PR_BRANCH=$(gh pr list -R "$REPO" \
+            --label 'autorelease: pending' --state open \
+            --json headRefName --jq '.[0].headRefName // empty')
+
+          if [ -z "$PR_BRANCH" ]; then
+            echo "No open 'autorelease: pending' PR — nothing to do."
+            exit 0
+          fi
+
+          NEW_VERSION=$(gh api "repos/${REPO}/contents/.release-please-manifest.json?ref=${PR_BRANCH}" \
+            --jq '.content' | base64 -d | jq -r '.["."]')
+          DATE=$(date -u +%Y-%m-%d)
+
+          echo "Release PR branch: ${PR_BRANCH}"
+          echo "Release version:   v${NEW_VERSION}"
+          echo "Date stamp:        ${DATE}"
+
+          # Pull MIGRATION.md from the PR branch (404 here means no
+          # MIGRATION.md at this revision — treat as a no-op).
+          if ! RESP=$(gh api "repos/${REPO}/contents/MIGRATION.md?ref=${PR_BRANCH}" 2>/dev/null); then
+            echo "MIGRATION.md not present on ${PR_BRANCH} — nothing to do."
+            exit 0
+          fi
+
+          OLD_CONTENT=$(jq -r '.content' <<< "$RESP" | base64 -d)
+          FILE_SHA=$(jq -r '.sha' <<< "$RESP")
+
+          PATTERN="## v${NEW_VERSION} (unreleased)"
+          REPLACEMENT="## v${NEW_VERSION} - ${DATE}"
+
+          if ! grep -Fq "$PATTERN" <<< "$OLD_CONTENT"; then
+            echo "No '${PATTERN}' heading in MIGRATION.md — already dated or version mismatch."
+            exit 0
+          fi
+
+          NEW_CONTENT=$(awk -v p="$PATTERN" -v r="$REPLACEMENT" \
+            '{if ($0 == p) print r; else print}' <<< "$OLD_CONTENT")
+
+          if [ "$OLD_CONTENT" = "$NEW_CONTENT" ]; then
+            echo "Rewrite produced identical content — nothing to commit."
+            exit 0
+          fi
+
+          NEW_B64=$(printf '%s\n' "$NEW_CONTENT" | base64 -w 0)
+
+          gh api -X PUT "repos/${REPO}/contents/MIGRATION.md" \
+            -f message="docs: date v${NEW_VERSION} migration section" \
+            -f content="${NEW_B64}" \
+            -f sha="${FILE_SHA}" \
+            -f branch="${PR_BRANCH}"


### PR DESCRIPTION
## Summary

Ports the `Date (unreleased) section in MIGRATION.md` workflow step from `marcstraube.common`'s `release-please.yml` (latest revision, including the label-lookup robustness fix from [common#166](https://github.com/marcstraube/ansible-collection-common/issues/166) / [PR #167](https://github.com/marcstraube/ansible-collection-common/pull/167)).

The step locates the open release PR via `gh pr list --label 'autorelease: pending'`, fetches `MIGRATION.md` from that PR's branch, rewrites `## vX.Y.Z (unreleased)` to `## vX.Y.Z - YYYY-MM-DD`, and commits through the contents API so the change is verified under the release-bot app identity.

No-op when no release PR is open, `MIGRATION.md` is absent, the heading is already dated, or the rewrite produces identical content.

Now that desktop has its own `MIGRATION.md` (#123 / #124), the heading will be dated automatically at tag time without manual intervention.

## Test plan

- [x] `pre-commit run --files .github/workflows/release-please.yml` clean (ansible-lint, yamllint, etc.)
- [ ] Live verification: merging this PR triggers a release-please workflow run on `main`. With the existing release PR #34 carrying the `autorelease: pending` label, the strip step should find it, fetch its `MIGRATION.md`, and rewrite the heading to `## v2.0.0 - <today>`. Verifiable by inspecting PR #34's `MIGRATION.md` after CI completes.

Closes #125