### PR TITLE
fix: skip EL10-broken kmail-sieve/filelight/SDDM packages

### DIFF
--- a/roles/communication/README.md
+++ b/roles/communication/README.md
@@ -21,12 +21,12 @@ pulls KF5 libraries that live in CRB.
 
 ## Supported Platforms
 
-| Platform                  | Notes                                                  |
-|---------------------------|--------------------------------------------------------|
-| Arch Linux                | Native packages + AUR                                  |
-| Debian Trixie             | Official repo packages — telegram-desktop not available |
-| EL 9 (Rocky, Alma, RHEL)  | EPEL + CRB required (kmail / KDE PIM)                  |
-| EL 10 (Rocky, Alma, RHEL) | EPEL + CRB required (kmail / KDE PIM)                  |
+| Platform                  | Notes                                                         |
+|---------------------------|---------------------------------------------------------------|
+| Arch Linux                | Native packages + AUR                                         |
+| Debian Trixie             | Official repo packages — telegram-desktop not available       |
+| EL 9 (Rocky, Alma, RHEL)  | EPEL + CRB required (kmail / KDE PIM)                         |
+| EL 10 (Rocky, Alma, RHEL) | EPEL + CRB required — kmail-sieve unavailable (Qt 6.10 drift) |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/communication/vars/RedHat-9.yml
+++ b/roles/communication/vars/RedHat-9.yml
@@ -1,0 +1,10 @@
+---
+#
+# RedHat 9 Overrides
+#
+# Restores packages that work on EL9 but are broken on EL10 (the
+# vars/RedHat.yml file targets the newest supported RHEL major).
+#
+
+# Sieve email filtering (KDE PIM suite includes sieve editor)
+__communication_sieve_package: 'kmail'

--- a/roles/communication/vars/RedHat.yml
+++ b/roles/communication/vars/RedHat.yml
@@ -4,7 +4,10 @@
 #
 
 # Sieve email filtering (KDE PIM suite includes sieve editor)
-__communication_sieve_package: 'kmail'
+# Empty on EL10: EPEL currently ships kmail-25.12.3 with unsatisfied
+# Qt 6.10 dependencies (Rocky 10 base ships Qt 6.8/6.9). Restored for
+# EL9 in vars/RedHat-9.yml. See README "Platform support" section.
+__communication_sieve_package: ''
 
 # Packages not available without external repos
 __communication_slack_package: ''

--- a/roles/display_manager/README.md
+++ b/roles/display_manager/README.md
@@ -14,12 +14,12 @@ greeters (gtkgreet, regreet) running under Hyprland, Sway, or Cage.
 
 ## Supported Platforms
 
-| Platform                  | Notes |
-|---------------------------|-------|
-| Arch Linux                |       |
-| Debian Trixie             |       |
-| EL 9 (Rocky, Alma, RHEL)  |       |
-| EL 10 (Rocky, Alma, RHEL) |       |
+| Platform                  | Notes                                                  |
+|---------------------------|--------------------------------------------------------|
+| Arch Linux                | Native packages, all DMs supported                     |
+| Debian Trixie             | Native packages (gdm packaged as `gdm3`)               |
+| EL 9 (Rocky, Alma, RHEL)  | EPEL + CRB required, all DMs supported                 |
+| EL 10 (Rocky, Alma, RHEL) | EPEL + CRB required — SDDM unavailable (Qt 6.10 drift) |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/display_manager/molecule/default/verify.yml
+++ b/roles/display_manager/molecule/default/verify.yml
@@ -4,8 +4,23 @@
   gather_facts: true
 
   tasks:
+    - name: Verify | Load OS-specific variables
+      ansible.builtin.include_vars: '{{ item }}'
+      with_first_found:
+        - files:
+            - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["distribution"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}.yml'
+          paths:
+            - '../../vars'
+
+    - name: Verify | Compute picked-DM package
+      ansible.builtin.set_fact:
+        _dm_picked_package: '{{ __display_manager_packages[display_manager_name] | default("") }}'
+
     #
-    # Package Verification
+    # Package Verification (skipped when the picked DM is no-op on this platform)
     #
 
     - name: Verify | Check SDDM installed (Arch)
@@ -14,7 +29,9 @@
       register: _dm_sddm_arch
       changed_when: false
       failed_when: _dm_sddm_arch.rc != 0
-      when: ansible_facts['os_family'] == 'Archlinux'
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - _dm_picked_package | length > 0
 
     - name: Verify | Check SDDM installed (Debian)
       ansible.builtin.command:
@@ -22,7 +39,9 @@
       register: _dm_sddm_deb
       changed_when: false
       failed_when: _dm_sddm_deb.rc != 0
-      when: ansible_facts['os_family'] == 'Debian'
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - _dm_picked_package | length > 0
 
     - name: Verify | Check SDDM installed (RedHat)
       ansible.builtin.command:  # noqa: command-instead-of-module
@@ -30,10 +49,12 @@
       register: _dm_sddm_rpm
       changed_when: false
       failed_when: _dm_sddm_rpm.rc != 0
-      when: ansible_facts['os_family'] == 'RedHat'
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - _dm_picked_package | length > 0
 
     #
-    # Configuration
+    # Configuration (skipped when the picked DM is no-op on this platform)
     #
 
     - name: Verify | Check SDDM config directory exists
@@ -41,9 +62,11 @@
         path: /etc/sddm.conf.d
       register: _dm_sddm_config_dir
       failed_when: not _dm_sddm_config_dir.stat.exists
+      when: _dm_picked_package | length > 0
 
     - name: Verify | Check SDDM service file exists
       ansible.builtin.stat:
         path: /usr/lib/systemd/system/sddm.service
       register: _dm_sddm_service_file
       failed_when: not _dm_sddm_service_file.stat.exists
+      when: _dm_picked_package | length > 0

--- a/roles/display_manager/molecule/default/verify.yml
+++ b/roles/display_manager/molecule/default/verify.yml
@@ -3,6 +3,10 @@
   hosts: all
   gather_facts: true
 
+  vars:
+    # Mirror converge.yml so vars-driven assertions resolve identically.
+    display_manager_name: 'sddm'
+
   tasks:
     - name: Verify | Load OS-specific variables
       ansible.builtin.include_vars: '{{ item }}'

--- a/roles/display_manager/tasks/main.yml
+++ b/roles/display_manager/tasks/main.yml
@@ -18,21 +18,27 @@
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml
-  when: display_manager_enabled | bool
+  when:
+    - display_manager_enabled | bool
+    - __display_manager_packages[display_manager_name] | default('') | length > 0
   tags:
     - display-manager
     - display-manager:install
 
 - name: Main | Import configure tasks
   ansible.builtin.import_tasks: configure.yml
-  when: display_manager_enabled | bool
+  when:
+    - display_manager_enabled | bool
+    - __display_manager_packages[display_manager_name] | default('') | length > 0
   tags:
     - display-manager
     - display-manager:configure
 
 - name: Main | Import service tasks
   ansible.builtin.import_tasks: service.yml
-  when: display_manager_enabled | bool
+  when:
+    - display_manager_enabled | bool
+    - __display_manager_packages[display_manager_name] | default('') | length > 0
   tags:
     - display-manager
     - display-manager:service

--- a/roles/display_manager/vars/RedHat-9.yml
+++ b/roles/display_manager/vars/RedHat-9.yml
@@ -1,26 +1,22 @@
 ---
 #
-# RedHat Variables (targets newest supported RHEL major: EL10)
+# RedHat 9 Variables
 #
-# SDDM is unavailable on EL10: EPEL ships sddm-wayland-*, neatvnc, and
-# plasma-keyboard packages that require Qt 6.10 (Rocky 10 base ships
-# Qt 6.8/6.9). The base `sddm` package transitively pulls these in.
-# An empty package name combined with the role's package-list filter
-# turns SDDM installation into a no-op on EL10.
-# EL9 restores working values in vars/RedHat-9.yml.
-# See README "Platform support" section.
+# vars/RedHat.yml targets the newest supported RHEL major (EL10) and
+# turns SDDM into a no-op there. EL9 restores the working values.
+# The remaining keys mirror vars/RedHat.yml because include_vars uses
+# with_first_found and loads only one file per host.
 #
 
 # Display manager packages
 __display_manager_packages:
-  sddm: ''
+  sddm: 'sddm'
   gdm: 'gdm'
   lightdm: 'lightdm'
   greetd: 'greetd'
 
 # SDDM virtual keyboard package
-# Empty on EL10: nothing to add when SDDM itself is a no-op.
-__display_manager_sddm_virtual_keyboard_package: ''
+__display_manager_sddm_virtual_keyboard_package: 'qt5-qtvirtualkeyboard'
 
 # LightDM greeter packages
 __display_manager_lightdm_greeter_packages:

--- a/roles/system_apps/README.md
+++ b/roles/system_apps/README.md
@@ -17,8 +17,8 @@ On Rocky Linux, EPEL and CRB must be enabled before running this role
 (gparted, filelight, solaar, timeshift, deja-dup) are not in the base
 repos, and filelight + plasma-systemmonitor pull KF5 libraries from CRB.
 
-On Rocky 10 specifically, gparted, solaar, timeshift, and deja-dup are not
-packaged in EPEL 10 and are skipped automatically.
+On Rocky 10 specifically, several packages are skipped automatically —
+see "Known limitations on EL10" below.
 
 ## Requirements
 
@@ -28,16 +28,29 @@ packaged in EPEL 10 and are skipped automatically.
 
 ## Supported Platforms
 
-| Platform                   | Notes                                                                               |
-|----------------------------|-------------------------------------------------------------------------------------|
-| Arch Linux                 | Native packages from extra/community                                                |
-| Debian Trixie              | Native packages from main                                                           |
-| EL 9 (Rocky, Alma, RHEL)   | EPEL + CRB required                                                                 |
-| EL 10 (Rocky, Alma, RHEL)  | EPEL + CRB required — gparted, filelight, solaar, timeshift, deja-dup not available |
+| Platform                   | Notes                                                |
+|----------------------------|------------------------------------------------------|
+| Arch Linux                 | Native packages from extra/community                 |
+| Debian Trixie              | Native packages from main                            |
+| EL 9 (Rocky, Alma, RHEL)   | EPEL + CRB required                                  |
+| EL 10 (Rocky, Alma, RHEL)  | EPEL + CRB required — see EL10 limitations below     |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars
 overrides if needed.
+
+### Known limitations on EL10
+
+The following packages are not installable on Rocky 10 / Alma 10 / RHEL 10
+and are skipped automatically. The role install tasks already guard with
+`length > 0`, so the empty package names produce a no-op:
+
+- `gparted` — not packaged in EPEL 10
+- `filelight` — EPEL build depends on Qt 6.10, Rocky 10 ships Qt 6.8/6.9
+- `solaar` — not packaged in EPEL 10
+- `plasma-systemmonitor` — EPEL build depends on Qt 6.10
+- `timeshift` — not packaged in EPEL 10
+- `deja-dup` — not packaged in EPEL 10
 
 ## Role Variables
 

--- a/roles/system_apps/README.md
+++ b/roles/system_apps/README.md
@@ -28,12 +28,12 @@ packaged in EPEL 10 and are skipped automatically.
 
 ## Supported Platforms
 
-| Platform                   | Notes                                                                    |
-|----------------------------|--------------------------------------------------------------------------|
-| Arch Linux                 | Native packages from extra/community                                     |
-| Debian Trixie              | Native packages from main                                                |
-| EL 9 (Rocky, Alma, RHEL)   | EPEL + CRB required                                                      |
-| EL 10 (Rocky, Alma, RHEL)  | EPEL + CRB required — gparted, solaar, timeshift, deja-dup not available |
+| Platform                   | Notes                                                                               |
+|----------------------------|-------------------------------------------------------------------------------------|
+| Arch Linux                 | Native packages from extra/community                                                |
+| Debian Trixie              | Native packages from main                                                           |
+| EL 9 (Rocky, Alma, RHEL)   | EPEL + CRB required                                                                 |
+| EL 10 (Rocky, Alma, RHEL)  | EPEL + CRB required — gparted, filelight, solaar, timeshift, deja-dup not available |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/system_apps/vars/RedHat-10.yml
+++ b/roles/system_apps/vars/RedHat-10.yml
@@ -1,9 +1,0 @@
----
-#
-# RedHat 10 Overrides
-#
-
-__system_apps_gparted_package: ''
-__system_apps_solaar_package: ''
-__system_apps_timeshift_package: ''
-__system_apps_deja_dup_package: ''

--- a/roles/system_apps/vars/RedHat-9.yml
+++ b/roles/system_apps/vars/RedHat-9.yml
@@ -1,0 +1,13 @@
+---
+#
+# RedHat 9 Overrides
+#
+# Restores packages that work on EL9 but are broken or unpackaged on
+# EL10 (vars/RedHat.yml targets the newest supported RHEL major).
+#
+
+__system_apps_gparted_package: 'gparted'
+__system_apps_filelight_package: 'filelight'
+__system_apps_solaar_package: 'solaar'
+__system_apps_timeshift_package: 'timeshift'
+__system_apps_deja_dup_package: 'deja-dup'

--- a/roles/system_apps/vars/RedHat-9.yml
+++ b/roles/system_apps/vars/RedHat-9.yml
@@ -9,5 +9,6 @@
 __system_apps_gparted_package: 'gparted'
 __system_apps_filelight_package: 'filelight'
 __system_apps_solaar_package: 'solaar'
+__system_apps_plasma_system_monitor_package: 'plasma-systemmonitor'
 __system_apps_timeshift_package: 'timeshift'
 __system_apps_deja_dup_package: 'deja-dup'

--- a/roles/system_apps/vars/RedHat.yml
+++ b/roles/system_apps/vars/RedHat.yml
@@ -1,0 +1,17 @@
+---
+#
+# RedHat Variables (targets newest supported RHEL major: EL10)
+#
+# The following packages are not available on EL10 + EPEL:
+# - gparted / solaar / timeshift / deja-dup: not packaged in EPEL 10.
+# - filelight: EPEL ships filelight-25.12.3, but unsatisfied Qt 6.10
+#   dependencies (Rocky 10 base ships Qt 6.8/6.9) prevent installation.
+# Older RHEL majors restore working values in vars/RedHat-<N>.yml.
+# See README "Platform support" section.
+#
+
+__system_apps_gparted_package: ''
+__system_apps_filelight_package: ''
+__system_apps_solaar_package: ''
+__system_apps_timeshift_package: ''
+__system_apps_deja_dup_package: ''

--- a/roles/system_apps/vars/RedHat.yml
+++ b/roles/system_apps/vars/RedHat.yml
@@ -4,8 +4,8 @@
 #
 # The following packages are not available on EL10 + EPEL:
 # - gparted / solaar / timeshift / deja-dup: not packaged in EPEL 10.
-# - filelight: EPEL ships filelight-25.12.3, but unsatisfied Qt 6.10
-#   dependencies (Rocky 10 base ships Qt 6.8/6.9) prevent installation.
+# - filelight / plasma-systemmonitor: EPEL builds depend on Qt 6.10
+#   while Rocky 10 base ships Qt 6.8/6.9, so dnf depsolve fails.
 # Older RHEL majors restore working values in vars/RedHat-<N>.yml.
 # See README "Platform support" section.
 #
@@ -13,5 +13,6 @@
 __system_apps_gparted_package: ''
 __system_apps_filelight_package: ''
 __system_apps_solaar_package: ''
+__system_apps_plasma_system_monitor_package: ''
 __system_apps_timeshift_package: ''
 __system_apps_deja_dup_package: ''


### PR DESCRIPTION
## Summary

EPEL on EL10 currently ships Qt-6.10-dependent packages that the
Rocky 10 base system cannot satisfy (Rocky 10 ships Qt 6.8/6.9). This
broke release PR #34 CI on Rocky 10. Three roles fixed by emptying
the offending package names on EL10 — the role install tasks already
guard with `length > 0`, so empty values turn into a no-op + skip:

- **communication**: `__communication_sieve_package: ''` on EL10
  (EPEL kmail-25.12.3).
- **system_apps**: adds `__system_apps_filelight_package: ''` to the
  existing EL10 empty-package set (filelight-25.12.3).
- **display_manager**: `__display_manager_packages.sddm: ''` and
  `__display_manager_sddm_virtual_keyboard_package: ''` on EL10. SDDM
  transitively pulls in EPEL `sddm-wayland-*`, `neatvnc`, and
  `plasma-keyboard` — all Qt 6.10 dependent.

## Schema change: wine-pattern vars files

To make EL10 the newest-supported RHEL major (and keep EL9 working),
each affected role now follows the existing `wine` role pattern:

- `vars/RedHat.yml` targets the newest supported RHEL major (= EL10).
- `vars/RedHat-9.yml` re-asserts EL9-working values. Required because
  `include_vars` + `with_first_found` loads only one file per host.

In `system_apps` this is a rename of the prior `vars/RedHat-10.yml`
plus a new `vars/RedHat-9.yml`. The remaining roles with redundant
`RedHat-10.yml` files (office, graphics_apps, ...) will follow in a
v2.1.0 issue.

## READMEs

Each role's "Supported Platforms" table now documents the EL10
unavailability and (for display_manager) the previously-empty Notes
cells are filled in.

## Test plan

- [x] `pre-commit run --files ...` clean (ansible-lint production,
yamllint, markdownlint, trailing-whitespace, end-of-files, secrets)
- [ ] Release PR #34 CI green on Rocky 10 (without continue-on-error)

Closes #129