### PR TITLE
feat(development)!: add Shell/Python/Lua/QML language tooling toggles

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,28 @@ snippets. For the full list of changes per release, see
 
 ## v2.0.0 (unreleased)
 
+### `development_shellcheck_enabled` renamed (#116)
+
+shellcheck moves from "Misc Tools" into the new `# Language Tooling`
+section under `# Shell`, alongside `shfmt` and `bats`. The toggle is
+renamed accordingly. Hard rename, no fallback.
+
+| Old name                          | New name                                |
+|-----------------------------------|-----------------------------------------|
+| `development_shellcheck_enabled`  | `development_shell_shellcheck_enabled`  |
+
+#### Before
+
+```yaml
+development_shellcheck_enabled: true
+```
+
+#### After
+
+```yaml
+development_shell_shellcheck_enabled: true
+```
+
 ### Boolean toggles renamed to follow `_enabled` convention (#43)
 
 Three logic-gate booleans were renamed to match the project's

--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -79,9 +79,9 @@ overrides if needed.
 
 #### VSCode / VSCodium settings
 
-| Variable                      | Default | Description                                    |
-|-------------------------------|---------|------------------------------------------------|
-| `development_vscode_settings` | `{...}` | Per-user `settings.json` content (dict)        |
+| Variable                      | Default | Description                                   |
+|-------------------------------|---------|-----------------------------------------------|
+| `development_vscode_settings` | `{...}` | Per-user `settings.json` content (dict)       |
 | `development_vscode_argv`     | `{...}` | Per-user `argv.json` (Electron-runtime flags) |
 
 Defaults opt out of editor-core, common Microsoft, and Red Hat extension
@@ -120,7 +120,61 @@ intended, not just deltas.
 | `development_yq_enabled`         | `true`  | Enable yq YAML processor           |
 | `development_direnv_enabled`     | `true`  | Enable direnv directory-based envs |
 | `development_pre_commit_enabled` | `true`  | Enable pre-commit git hooks        |
-| `development_shellcheck_enabled` | `true`  | Enable shellcheck linter           |
+
+### Language Tooling
+
+Per-tool toggles for distro-packaged linters, formatters, and test frameworks.
+Each toggle resolves to a `__development_<tool>_package` variable in
+`vars/{distro}.yml`. Distros without an upstream package map to `''`, in which
+case the install task is a no-op — see "Platform support" below.
+
+For tools installed via a language package manager (`pipx`, `rustup`) the
+role uses the free-form lists `development_python_tools` and
+`development_rust_components` under "Programming Languages" above.
+
+#### Shell
+
+`shfmt` and `shellcheck` cover multiple shell dialects (POSIX sh, bash,
+dash, ksh, mksh); `bats-core` is bash-specific.
+
+| Variable                                 | Default | Description                          |
+|------------------------------------------|---------|--------------------------------------|
+| `development_shell_shfmt_enabled`        | `false` | Enable shfmt shell formatter         |
+| `development_shell_shellcheck_enabled`   | `true`  | Enable shellcheck shell linter       |
+| `development_shell_bats_enabled`         | `false` | Enable bats-core Bash test framework |
+
+#### Python Tooling
+
+| Variable                          | Default | Description                              |
+|-----------------------------------|---------|------------------------------------------|
+| `development_python_ruff_enabled` | `false` | Enable ruff Python linter and formatter  |
+
+#### Lua
+
+| Variable                           | Default | Description                          |
+|------------------------------------|---------|--------------------------------------|
+| `development_lua_stylua_enabled`   | `false` | Enable stylua Lua formatter          |
+| `development_lua_luacheck_enabled` | `false` | Enable luacheck Lua linter           |
+| `development_lua_busted_enabled`   | `false` | Enable busted Lua test framework     |
+
+#### QML
+
+| Variable                        | Default | Description                                          |
+|---------------------------------|---------|------------------------------------------------------|
+| `development_qml_tools_enabled` | `false` | Enable Qt6 QML tools (qmllint + qmlformat, same pkg) |
+
+##### Platform support
+
+| Tool         | Arch | Debian Trixie | EL 9 | EL 10 |
+|--------------|------|---------------|------|-------|
+| shfmt        | yes  | yes           | no   | no    |
+| shellcheck   | yes  | yes           | yes  | yes   |
+| bats         | yes  | yes           | yes  | yes   |
+| ruff         | yes  | no            | no   | yes   |
+| stylua       | yes  | no            | no   | no    |
+| luacheck     | yes  | yes           | no   | no    |
+| busted       | yes  | yes           | no   | no    |
+| qml-tools    | yes  | yes           | yes  | yes   |
 
 ### User Configuration
 
@@ -141,23 +195,27 @@ Each user entry supports:
 
 Mode semantics — analog to `marcstraube.desktop.browser`:
 
-| Mode       | First run                  | Subsequent runs                        |
-|------------|----------------------------|----------------------------------------|
-| `managed`  | deploy                     | overwrite (always reconcile)           |
+| Mode       | First run                       | Subsequent runs                          |
+|------------|---------------------------------|------------------------------------------|
+| `managed`  | deploy                          | overwrite (always reconcile)             |
 | `initial`  | deploy if user is newly created | leave existing user customisations alone |
-| `disabled` | skip                       | skip                                   |
+| `disabled` | skip                            | skip                                     |
 
 ## Tags
 
-| Tag                     | Scope                      |
-|-------------------------|----------------------------|
-| `development`           | All role tasks             |
-| `development:git`       | Version control tasks      |
-| `development:languages` | Programming language tasks |
-| `development:build`     | Build tools tasks          |
-| `development:ides`      | IDE installation tasks     |
-| `development:tools`     | Misc tools tasks           |
-| `development:users`     | User configuration tasks   |
+| Tag                            | Scope                      |
+|--------------------------------|----------------------------|
+| `development`                  | All role tasks             |
+| `development:git`              | Version control tasks      |
+| `development:languages`        | Programming language tasks |
+| `development:build`            | Build tools tasks          |
+| `development:ides`             | IDE installation tasks     |
+| `development:tools`            | Misc tools tasks           |
+| `development:shell`            | Shell tooling tasks        |
+| `development:python-tooling`   | Python tooling tasks       |
+| `development:lua`              | Lua tooling tasks          |
+| `development:qml`              | QML tooling tasks          |
+| `development:users`            | User configuration tasks   |
 
 ## Example Playbook
 
@@ -207,6 +265,15 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - [VSCodium](https://vscodium.com/) — Free/libre Code-OSS binaries (telemetry-free VS Code build)
 - [JetBrains Toolbox](https://www.jetbrains.com/toolbox-app/) — Manager for JetBrains IDEs
 - [Zed](https://zed.dev/) — High-performance multiplayer code editor
+- [shfmt](https://github.com/mvdan/sh) — Shell formatter
+- [shellcheck](https://github.com/koalaman/shellcheck) — Shell script static analysis
+- [bats-core](https://github.com/bats-core/bats-core) — Bash automated testing system
+- [ruff](https://github.com/astral-sh/ruff) — Python linter and formatter
+- [stylua](https://github.com/JohnnyMorganz/StyLua) — Lua formatter
+- [luacheck](https://github.com/mpeterv/luacheck) — Lua linter
+- [busted](https://github.com/lunarmodules/busted) — Lua test framework
+- [Qt qmllint](https://doc.qt.io/qt-6/qtquick-tool-qmllint.html) — QML linter
+- [Qt qmlformat](https://doc.qt.io/qt-6/qtquick-tool-qmlformat.html) — QML formatter
 - [HTTPie](https://httpie.io/) — Modern HTTP CLI client
 - [pre-commit](https://pre-commit.com/) — Multi-language git hook framework
 - [direnv](https://direnv.net/) — Per-directory environment variable loader

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -75,6 +75,46 @@ development_go_enabled: false
 development_java_enabled: false
 
 #
+# Language Tooling
+#
+# Linters, formatters, and test frameworks for shell, Python, Lua, and
+# QML. Each toggle resolves to a `__development_<tool>_package` variable
+# in vars/{distro}.yml — empty on distros without an upstream package,
+# in which case the install task is a no-op.
+
+# Shell
+
+# Enable shfmt shell formatter (POSIX sh, bash, mksh)
+development_shell_shfmt_enabled: false
+
+# Enable shellcheck shell linter (sh, bash, dash, ksh)
+development_shell_shellcheck_enabled: true
+
+# Enable bats-core Bash test framework (bash-only)
+development_shell_bats_enabled: false
+
+# Python Tooling
+
+# Enable ruff Python linter and formatter
+development_python_ruff_enabled: false
+
+# Lua
+
+# Enable stylua Lua formatter
+development_lua_stylua_enabled: false
+
+# Enable luacheck Lua linter
+development_lua_luacheck_enabled: false
+
+# Enable busted Lua test framework
+development_lua_busted_enabled: false
+
+# QML
+
+# Enable Qt6 QML tools (qmllint + qmlformat — single package)
+development_qml_tools_enabled: false
+
+#
 # Build Tools
 #
 
@@ -150,9 +190,6 @@ development_direnv_enabled: true
 
 # Enable pre-commit git hooks
 development_pre_commit_enabled: true
-
-# Enable shellcheck shell script linter
-development_shellcheck_enabled: true
 
 #
 # User Configuration

--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -19,12 +19,23 @@
     development_cmake_enabled: true
     development_meson_enabled: false
     development_ninja_enabled: false
-    # Misc toggles: enable jq + shellcheck (existing verify), disable rest
+    # Misc toggles: enable jq, disable rest
     development_jq_enabled: true
     development_yq_enabled: false
     development_direnv_enabled: false
     development_pre_commit_enabled: false
-    development_shellcheck_enabled: true
+    # Shell tooling: enable all (verify checks present/absent per platform)
+    development_shell_shfmt_enabled: true
+    development_shell_shellcheck_enabled: true
+    development_shell_bats_enabled: true
+    # Python tooling
+    development_python_ruff_enabled: true
+    # Lua tooling
+    development_lua_stylua_enabled: true
+    development_lua_luacheck_enabled: true
+    development_lua_busted_enabled: true
+    # QML tooling
+    development_qml_tools_enabled: true
     # Database tools off
     development_dbeaver_enabled: false
     development_pgadmin_enabled: false

--- a/roles/development/molecule/default/verify.yml
+++ b/roles/development/molecule/default/verify.yml
@@ -8,6 +8,8 @@
       ansible.builtin.include_vars: '{{ item }}'
       with_first_found:
         - files:
+            - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
             - '{{ ansible_facts["distribution"] }}.yml'
             - '{{ ansible_facts["os_family"] }}.yml'
           paths:
@@ -146,33 +148,81 @@
       failed_when: _dev_jq_rpm.rc != 0
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Verify | Check shellcheck installed (Arch)
-      ansible.builtin.command:
-        cmd: 'pacman -Q shellcheck'
-      register: _dev_sc_arch
-      changed_when: false
-      failed_when: _dev_sc_arch.rc != 0
-      when: ansible_facts['os_family'] == 'Archlinux'
+    #
+    # Language Tooling (per-platform availability — skipped when package is '')
+    #
 
-    - name: >-
-        Verify | Check shellcheck installed
-        (Debian)
-      ansible.builtin.command:
-        cmd: 'dpkg -l shellcheck'
-      register: _dev_sc_deb
-      changed_when: false
-      failed_when: _dev_sc_deb.rc != 0
-      when: ansible_facts['os_family'] == 'Debian'
+    - name: Verify | shfmt — package installed
+      ansible.builtin.package:
+        name: '{{ __development_shell_shfmt_package }}'
+        state: present
+      check_mode: true
+      register: _dev_shfmt_check
+      failed_when: _dev_shfmt_check.changed
+      when: __development_shell_shfmt_package | default('') | length > 0
 
-    - name: >-
-        Verify | Check ShellCheck installed
-        (RedHat)
-      ansible.builtin.command:  # noqa: command-instead-of-module
-        cmd: 'rpm -q ShellCheck'
-      register: _dev_sc_rpm
-      changed_when: false
-      failed_when: _dev_sc_rpm.rc != 0
-      when: ansible_facts['os_family'] == 'RedHat'
+    - name: Verify | shellcheck — package installed
+      ansible.builtin.package:
+        name: '{{ __development_shell_shellcheck_package }}'
+        state: present
+      check_mode: true
+      register: _dev_shellcheck_check
+      failed_when: _dev_shellcheck_check.changed
+      when: __development_shell_shellcheck_package | default('') | length > 0
+
+    - name: Verify | bats — package installed
+      ansible.builtin.package:
+        name: '{{ __development_shell_bats_package }}'
+        state: present
+      check_mode: true
+      register: _dev_bats_check
+      failed_when: _dev_bats_check.changed
+      when: __development_shell_bats_package | default('') | length > 0
+
+    - name: Verify | ruff — package installed
+      ansible.builtin.package:
+        name: '{{ __development_python_ruff_package }}'
+        state: present
+      check_mode: true
+      register: _dev_ruff_check
+      failed_when: _dev_ruff_check.changed
+      when: __development_python_ruff_package | default('') | length > 0
+
+    - name: Verify | stylua — package installed
+      ansible.builtin.package:
+        name: '{{ __development_lua_stylua_package }}'
+        state: present
+      check_mode: true
+      register: _dev_stylua_check
+      failed_when: _dev_stylua_check.changed
+      when: __development_lua_stylua_package | default('') | length > 0
+
+    - name: Verify | luacheck — package installed
+      ansible.builtin.package:
+        name: '{{ __development_lua_luacheck_package }}'
+        state: present
+      check_mode: true
+      register: _dev_luacheck_check
+      failed_when: _dev_luacheck_check.changed
+      when: __development_lua_luacheck_package | default('') | length > 0
+
+    - name: Verify | busted — package installed
+      ansible.builtin.package:
+        name: '{{ __development_lua_busted_package }}'
+        state: present
+      check_mode: true
+      register: _dev_busted_check
+      failed_when: _dev_busted_check.changed
+      when: __development_lua_busted_package | default('') | length > 0
+
+    - name: Verify | qml-tools — package installed
+      ansible.builtin.package:
+        name: '{{ __development_qml_tools_package }}'
+        state: present
+      check_mode: true
+      register: _dev_qml_tools_check
+      failed_when: _dev_qml_tools_check.changed
+      when: __development_qml_tools_package | default('') | length > 0
 
     #
     # Toggle verification: cmake enabled, meson disabled

--- a/roles/development/tasks/lua.yml
+++ b/roles/development/tasks/lua.yml
@@ -1,0 +1,28 @@
+---
+#
+# Lua Tooling Installation
+#
+
+- name: Lua | Manage stylua
+  ansible.builtin.package:
+    name: '{{ __development_lua_stylua_package }}'
+    state: "{{ 'present' if development_lua_stylua_enabled | bool else 'absent' }}"
+  when: __development_lua_stylua_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Lua | Manage luacheck
+  ansible.builtin.package:
+    name: '{{ __development_lua_luacheck_package }}'
+    state: "{{ 'present' if development_lua_luacheck_enabled | bool else 'absent' }}"
+  when: __development_lua_luacheck_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Lua | Manage busted
+  ansible.builtin.package:
+    name: '{{ __development_lua_busted_package }}'
+    state: "{{ 'present' if development_lua_busted_enabled | bool else 'absent' }}"
+  when: __development_lua_busted_package | default('') | length > 0
+  retries: 3
+  delay: 5

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -75,6 +75,34 @@
     - development
     - development:tools
 
+- name: Main | Import shell tooling tasks
+  ansible.builtin.import_tasks: shell.yml
+  when: development_enabled | bool
+  tags:
+    - development
+    - development:shell
+
+- name: Main | Import Python tooling tasks
+  ansible.builtin.import_tasks: python_tooling.yml
+  when: development_enabled | bool
+  tags:
+    - development
+    - development:python-tooling
+
+- name: Main | Import Lua tooling tasks
+  ansible.builtin.import_tasks: lua.yml
+  when: development_enabled | bool
+  tags:
+    - development
+    - development:lua
+
+- name: Main | Import QML tooling tasks
+  ansible.builtin.import_tasks: qml.yml
+  when: development_enabled | bool
+  tags:
+    - development
+    - development:qml
+
 - name: Main | Import user configuration tasks
   ansible.builtin.import_tasks: users.yml
   when:

--- a/roles/development/tasks/python_tooling.yml
+++ b/roles/development/tasks/python_tooling.yml
@@ -1,0 +1,12 @@
+---
+#
+# Python Tooling Installation
+#
+
+- name: Python Tooling | Manage ruff
+  ansible.builtin.package:
+    name: '{{ __development_python_ruff_package }}'
+    state: "{{ 'present' if development_python_ruff_enabled | bool else 'absent' }}"
+  when: __development_python_ruff_package | default('') | length > 0
+  retries: 3
+  delay: 5

--- a/roles/development/tasks/qml.yml
+++ b/roles/development/tasks/qml.yml
@@ -1,0 +1,15 @@
+---
+#
+# QML Tooling Installation
+#
+# qmllint and qmlformat ship in the same upstream package across all
+# supported distros. A single toggle covers both binaries.
+#
+
+- name: QML | Manage qml-tools
+  ansible.builtin.package:
+    name: '{{ __development_qml_tools_package }}'
+    state: "{{ 'present' if development_qml_tools_enabled | bool else 'absent' }}"
+  when: __development_qml_tools_package | default('') | length > 0
+  retries: 3
+  delay: 5

--- a/roles/development/tasks/shell.yml
+++ b/roles/development/tasks/shell.yml
@@ -1,0 +1,28 @@
+---
+#
+# Shell Tooling Installation
+#
+
+- name: Shell | Manage shfmt
+  ansible.builtin.package:
+    name: '{{ __development_shell_shfmt_package }}'
+    state: "{{ 'present' if development_shell_shfmt_enabled | bool else 'absent' }}"
+  when: __development_shell_shfmt_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Shell | Manage shellcheck
+  ansible.builtin.package:
+    name: '{{ __development_shell_shellcheck_package }}'
+    state: "{{ 'present' if development_shell_shellcheck_enabled | bool else 'absent' }}"
+  when: __development_shell_shellcheck_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Shell | Manage bats
+  ansible.builtin.package:
+    name: '{{ __development_shell_bats_package }}'
+    state: "{{ 'present' if development_shell_bats_enabled | bool else 'absent' }}"
+  when: __development_shell_bats_package | default('') | length > 0
+  retries: 3
+  delay: 5

--- a/roles/development/tasks/tools.yml
+++ b/roles/development/tasks/tools.yml
@@ -35,14 +35,6 @@
   retries: 3
   delay: 5
 
-- name: Tools | Manage shellcheck
-  ansible.builtin.package:
-    name: '{{ __development_shellcheck_package }}'
-    state: "{{ 'present' if development_shellcheck_enabled | bool else 'absent' }}"
-  when: __development_shellcheck_package | default('') | length > 0
-  retries: 3
-  delay: 5
-
 - name: Tools | Manage DBeaver
   ansible.builtin.package:
     name: '{{ __development_dbeaver_package }}'

--- a/roles/development/vars/Archlinux.yml
+++ b/roles/development/vars/Archlinux.yml
@@ -50,7 +50,22 @@ __development_jq_package: 'jq'
 __development_yq_package: 'yq'
 __development_direnv_package: 'direnv'
 __development_pre_commit_package: 'pre-commit'
-__development_shellcheck_package: 'shellcheck'
+
+# Shell tooling
+__development_shell_shfmt_package: 'shfmt'
+__development_shell_shellcheck_package: 'shellcheck'
+__development_shell_bats_package: 'bats'
+
+# Python tooling
+__development_python_ruff_package: 'ruff'
+
+# Lua tooling
+__development_lua_stylua_package: 'stylua'
+__development_lua_luacheck_package: 'luacheck'
+__development_lua_busted_package: 'busted'
+
+# QML tooling (qmllint + qmlformat ship in the same package)
+__development_qml_tools_package: 'qt6-declarative'
 
 # AUR packages
 __development_aur_packages:

--- a/roles/development/vars/RedHat-9.yml
+++ b/roles/development/vars/RedHat-9.yml
@@ -1,6 +1,11 @@
 ---
 #
-# Debian Variables
+# RedHat 9 Variables
+#
+# vars/RedHat.yml targets the newest supported RHEL major (EL10). EL9
+# mirrors RedHat.yml because include_vars uses with_first_found and
+# loads only one file per host. EL9-specific overrides are:
+# - ruff: not packaged on EL9 (EPEL 10 ships it, EPEL 9 does not).
 #
 
 # Version control
@@ -9,35 +14,36 @@ __development_git_packages:
 
 __development_git_lfs_package: 'git-lfs'
 __development_github_cli_package: 'gh'
-__development_gitlab_cli_package: ''
+__development_gitlab_cli_package: ''  # not in EPEL 9/10
 
 # Python
 __development_python_packages:
   - 'python3'
   - 'python3-pip'
-  - 'python3-venv'
   - 'pipx'
 
 # Rust
-__development_rust_packages: []
+__development_rust_packages:
+  - 'rust'
+  - 'cargo'
 
 # Go
 __development_go_packages:
   - 'golang'
 
 # Java
-__development_java_package: 'openjdk-17-jdk'
+__development_java_package: 'java-21-openjdk-devel'
 
 # Build tools
 __development_build_packages:
-  - 'build-essential'
+  - '@Development Tools'
   - 'make'
 
 __development_cmake_package: 'cmake'
 __development_meson_package: 'meson'
 __development_ninja_package: 'ninja-build'
 
-# IDEs (need external repos or Flatpak)
+# IDEs
 __development_vscodium_package: ''
 __development_vscode_package: ''
 __development_jetbrains_toolbox_package: ''
@@ -46,7 +52,7 @@ __development_zed_package: ''
 
 # Database tools
 __development_dbeaver_package: ''
-__development_pgadmin_package: ''
+__development_pgadmin_package: 'pgadmin4'
 
 # API tools
 __development_httpie_package: 'httpie'
@@ -59,18 +65,18 @@ __development_yq_package: ''
 __development_direnv_package: 'direnv'
 __development_pre_commit_package: 'pre-commit'
 
-# Shell tooling
-__development_shell_shfmt_package: 'shfmt'
-__development_shell_shellcheck_package: 'shellcheck'
+# Shell tooling (shfmt not in EPEL)
+__development_shell_shfmt_package: ''
+__development_shell_shellcheck_package: 'ShellCheck'
 __development_shell_bats_package: 'bats'
 
-# Python tooling (ruff not yet in Debian Trixie main)
+# Python tooling (ruff not packaged on EL9)
 __development_python_ruff_package: ''
 
-# Lua tooling (stylua not packaged in Debian)
+# Lua tooling (none packaged on EL)
 __development_lua_stylua_package: ''
-__development_lua_luacheck_package: 'lua-check'
-__development_lua_busted_package: 'lua-busted'
+__development_lua_luacheck_package: ''
+__development_lua_busted_package: ''
 
-# QML tooling (qmllint + qmlformat ship in the same package)
-__development_qml_tools_package: 'qt6-declarative-dev-tools'
+# QML tooling (qmllint + qmlformat in qt6-qtdeclarative-devel — EPEL on EL9)
+__development_qml_tools_package: 'qt6-qtdeclarative-devel'

--- a/roles/development/vars/RedHat.yml
+++ b/roles/development/vars/RedHat.yml
@@ -59,4 +59,19 @@ __development_jq_package: 'jq'
 __development_yq_package: ''
 __development_direnv_package: 'direnv'
 __development_pre_commit_package: 'pre-commit'
-__development_shellcheck_package: 'ShellCheck'
+
+# Shell tooling (shfmt not in EPEL)
+__development_shell_shfmt_package: ''
+__development_shell_shellcheck_package: 'ShellCheck'
+__development_shell_bats_package: 'bats'
+
+# Python tooling (ruff is EL10-only, see vars/RedHat-9.yml)
+__development_python_ruff_package: 'ruff'
+
+# Lua tooling (none packaged on EL)
+__development_lua_stylua_package: ''
+__development_lua_luacheck_package: ''
+__development_lua_busted_package: ''
+
+# QML tooling (qmllint + qmlformat in qt6-qtdeclarative-devel — appstream on EL10)
+__development_qml_tools_package: 'qt6-qtdeclarative-devel'


### PR DESCRIPTION
## Summary

Adds 8 new per-tool toggles for distro-packaged developer tooling, grouped by language under a new `# Language Tooling` section in `defaults/main.yml`:

- **Shell** (multi-dialect): shfmt, shellcheck, bats-core
- **Python**: ruff
- **Lua**: stylua, luacheck, busted
- **QML**: qmllint + qmlformat (single package)

Each toggle maps to `__development_<group>_<tool>_package` in `vars/{distro}.yml`. Distros without an upstream package map to `''` and the install task no-ops via the existing `length > 0` guard.

Tools installed via language package managers (pipx, rustup) remain on the existing free-form list pattern — see Pattern A vs Pattern B in the project's role-template convention doc (separate PR in the infra repo).

## Breaking change

- `development_shellcheck_enabled` → `development_shell_shellcheck_enabled` (renamed and moved from `# Misc Tools` into the new `# Shell` group)

Migration documented in `MIGRATION.md`.

## RedHat-9.yml

New `vars/RedHat-9.yml` overrides `ruff=''` for EL9 (EPEL 10 ships ruff, EPEL 9 does not). `vars/RedHat.yml` targets the newest supported RHEL major (EL10) per `docs/role-template.md`.

## Platform support matrix

| Tool | Arch | Debian Trixie | EL 9 | EL 10 |
|------|------|---------------|------|-------|
| shfmt | yes | yes | no | no |
| shellcheck | yes | yes | yes | yes |
| bats | yes | yes | yes | yes |
| ruff | yes | no | no | yes |
| stylua | yes | no | no | no |
| luacheck | yes | yes | no | no |
| busted | yes | yes | no | no |
| qml-tools | yes | yes | yes | yes |

## Test plan

- [x] ansible-lint production profile clean
- [x] yamllint clean
- [x] markdownlint clean
- [x] molecule test on Arch local — 18 ok / 0 changed / 0 failed
- [ ] CI green on all 4 platforms (Arch, Debian Trixie, Rocky 9, Rocky 10)

Closes #116