### PR TITLE
feat(ci): add drift-detection workflow for Layer-1-no-op'd packages

### DIFF
--- a/.github/drift-targets.yml
+++ b/.github/drift-targets.yml
@@ -1,0 +1,61 @@
+---
+# Drift-detection targets — packages currently marked as Layer-1 no-ops
+# (empty `__<role>_<pkg>_package` in vars/{distro}.yml). The
+# drift-detection workflow periodically probes each entry and opens an
+# issue when the package becomes installable again, so the
+# corresponding vars file entry can be restored.
+#
+# Schema (per entry):
+#   role:       role directory under roles/
+#   platform:   one of archlinux | debian-trixie | rocky-9 | rocky-10
+#   package:    upstream package name to probe with the platform's PM
+#   source:     'repo' (default) or 'aur' — aur targets attempt a
+#               makepkg build instead of a pacman download
+#   vars_file:  path (relative to the role) to the vars file that
+#               currently holds the no-op; included in the drift issue
+#               so the fix location is obvious
+#
+# Add an entry here when introducing a new Layer-1 no-op; remove the
+# entry when restoring the package.
+
+targets:
+  # EL10 EPEL drift — Qt 6.10 / unpackaged set landed via #129/#131.
+  - role: communication
+    platform: rocky-10
+    package: kmail
+    vars_file: vars/RedHat.yml
+
+  - role: system_apps
+    platform: rocky-10
+    package: gparted
+    vars_file: vars/RedHat.yml
+
+  - role: system_apps
+    platform: rocky-10
+    package: filelight
+    vars_file: vars/RedHat.yml
+
+  - role: system_apps
+    platform: rocky-10
+    package: solaar
+    vars_file: vars/RedHat.yml
+
+  - role: system_apps
+    platform: rocky-10
+    package: plasma-systemmonitor
+    vars_file: vars/RedHat.yml
+
+  - role: system_apps
+    platform: rocky-10
+    package: timeshift
+    vars_file: vars/RedHat.yml
+
+  - role: system_apps
+    platform: rocky-10
+    package: deja-dup
+    vars_file: vars/RedHat.yml
+
+  - role: display_manager
+    platform: rocky-10
+    package: sddm
+    vars_file: vars/RedHat.yml

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -1,0 +1,200 @@
+---
+name: Drift Detection
+
+# Probes Layer-1-no-op'd packages (see .github/drift-targets.yml) for
+# re-availability on their blocked platforms and opens an issue when a
+# package becomes installable again, so the corresponding vars/<OS>.yml
+# entry can be restored.
+
+on:
+  schedule:
+    # Weekly on Monday at 06:00 UTC. The CI matrix also runs weekly
+    # (Sunday 07:00 UTC) — staggered so a runner crunch on one does not
+    # delay the other.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  # =============================================================================
+  # LOAD-TARGETS — parse drift-targets.yml into a matrix
+  # =============================================================================
+  load-targets:
+    name: Load drift targets
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.parse.outputs.matrix }}
+      has_targets: ${{ steps.parse.outputs.has_targets }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      - name: Parse drift-targets.yml
+        id: parse
+        run: |
+          if [ ! -f .github/drift-targets.yml ]; then
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            echo 'has_targets=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          MATRIX=$(python3 -c "
+          import json, yaml
+          with open('.github/drift-targets.yml') as f:
+              data = yaml.safe_load(f) or {}
+          targets = data.get('targets', [])
+          print(json.dumps({'include': targets}))
+          ")
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          if [ "$MATRIX" = '{"include":[]}' ]; then
+            echo 'has_targets=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'has_targets=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  # =============================================================================
+  # PROBE — one job per target (parallel, fail-fast disabled)
+  # =============================================================================
+  probe:
+    name: Probe ${{ matrix.role }}/${{ matrix.package }} on ${{ matrix.platform }}
+    needs: load-targets
+    if: needs.load-targets.outputs.has_targets == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.load-targets.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Resolve image and probe command
+        id: resolve
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          SOURCE: ${{ matrix.source || 'repo' }}
+        run: |
+          case "$PLATFORM" in
+            archlinux)
+              IMAGE='docker.io/marcstraube/archlinux-ansible:latest'
+              if [ "$SOURCE" = "aur" ]; then
+                # AUR probe: clone + makepkg --syncdeps. --skippgpcheck
+                # avoids per-package PGP setup. The build only needs to
+                # *complete* — we discard the artifact.
+                # The Arch image does not ship a build user; provision
+                # one inline (makepkg refuses to run as root). The
+                # wheel-group sudoers entry lets makepkg --syncdeps
+                # install build-time deps via pacman.  # pragma: allowlist secret
+                PROBE='set -euo pipefail
+                pacman -Sy --noconfirm >/dev/null
+                pacman -S --needed --noconfirm git base-devel sudo >/dev/null
+                id aur_builder >/dev/null 2>&1 || useradd -m -G wheel aur_builder
+                printf "%%wheel ALL=(ALL) NOPASSWD: ALL\n" > /etc/sudoers.d/wheel-nopw  # pragma: allowlist secret
+                chmod 0440 /etc/sudoers.d/wheel-nopw
+                rm -rf /tmp/aur-probe
+                sudo -u aur_builder -- bash -c "
+                  git clone --depth=1 https://aur.archlinux.org/$PKG.git /tmp/aur-probe &&
+                  cd /tmp/aur-probe &&
+                  makepkg --syncdeps --noconfirm --skippgpcheck
+                "'
+              else
+                PROBE='set -euo pipefail
+                pacman -Sy --noconfirm >/dev/null
+                pacman -S --downloadonly --noconfirm "$PKG"'
+              fi
+              ;;
+            debian-trixie)
+              IMAGE='docker.io/geerlingguy/docker-debian13-ansible:latest'
+              PROBE='set -euo pipefail
+              apt-get update -qq
+              apt-get install -y --download-only --no-install-recommends "$PKG"'
+              ;;
+            rocky-9)
+              IMAGE='docker.io/geerlingguy/docker-rockylinux9-ansible:latest'
+              PROBE='set -euo pipefail
+              dnf install -y --downloadonly --setopt=install_weak_deps=0 "$PKG"'
+              ;;
+            rocky-10)
+              IMAGE='docker.io/geerlingguy/docker-rockylinux10-ansible:latest'
+              PROBE='set -euo pipefail
+              dnf install -y --downloadonly --setopt=install_weak_deps=0 "$PKG"'
+              ;;
+            *)
+              echo "::error::Unknown platform: $PLATFORM"
+              exit 1
+              ;;
+          esac
+          {
+            echo "image=$IMAGE"
+            echo 'probe<<EOF'
+            echo "$PROBE"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run probe
+        id: probe
+        continue-on-error: true
+        env:
+          PKG: ${{ matrix.package }}
+          IMAGE: ${{ steps.resolve.outputs.image }}
+          PROBE_SCRIPT: ${{ steps.resolve.outputs.probe }}
+        run: |
+          # Pull image once (faster, clearer logs).
+          docker pull --quiet "$IMAGE"
+          # Run probe inside container. Stdout/stderr stream live to logs.
+          if docker run --rm \
+              -e PKG="$PKG" \
+              "$IMAGE" \
+              bash -c "$PROBE_SCRIPT"; then
+            echo 'result=available' >> "$GITHUB_OUTPUT"
+            echo "::notice::Package $PKG is installable on ${{ matrix.platform }} — drift detected"
+          else
+            echo 'result=unavailable' >> "$GITHUB_OUTPUT"
+            echo "::notice::Package $PKG is still unavailable on ${{ matrix.platform }} — no action"
+          fi
+
+      - name: Open drift issue
+        if: steps.probe.outputs.result == 'available'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # pragma: allowlist secret
+          GH_REPO: ${{ github.repository }}
+          TITLE: "Drift detected: re-enable `${{ matrix.package }}` on `${{ matrix.platform }}` in ${{ matrix.vars_file }}"
+        run: |
+          # Dedupe: skip if an open issue with this exact title already exists.
+          EXISTING=$(gh issue list \
+            --state open \
+            --search "in:title \"Drift detected: re-enable\" \"${{ matrix.package }}\" \"${{ matrix.platform }}\"" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" \
+            | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Existing open drift issue #$EXISTING — skipping"
+            exit 0
+          fi
+
+          BODY=$(cat <<EOF
+          The drift-detection workflow successfully probed \`${{ matrix.package }}\` on \`${{ matrix.platform }}\` — the package is installable again.
+
+          To restore: revert the Layer-1 no-op in \`roles/${{ matrix.role }}/${{ matrix.vars_file }}\` (set the package back to its upstream name and drop the explanatory comment), then run the role's molecule to confirm.
+
+          - Role: \`${{ matrix.role }}\`
+          - Package: \`${{ matrix.package }}\`
+          - Platform: \`${{ matrix.platform }}\`
+          - Vars file: \`roles/${{ matrix.role }}/${{ matrix.vars_file }}\`
+          - Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          The probe used a downloadonly / makepkg dry-run, so this issue may still false-positive on packages that install metadata cleanly but fail at use time — verify locally before closing.
+          EOF
+          )
+
+          gh issue create \
+            --title "$TITLE" \
+            --label "bug,enhancement" \
+            --body "$BODY"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -112,6 +112,15 @@
     }
   ],
   "results": {
+    ".github/workflows/drift-detection.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/drift-detection.yml",
+        "hashed_secret": "b91eb3b9b8183ecd9790464b2831fdc42df58b16",
+        "is_verified": false,
+        "line_number": 83
+      }
+    ],
     "molecule/default/prepare.yml": [
       {
         "type": "Secret Keyword",


### PR DESCRIPTION
## Summary

Mirrors the drift-detection workflow established in `marcstraube.common` (common#171, with the aur_builder provisioning fix from common#172, closing common#169). Same two-job design (`load-targets` → probe matrix), same probe semantics (dry-run install via `pacman` / `apt-get` / `dnf` `--downloadonly`), same issue-creation contract. Workflow file is byte-identical to the common version so future fixes can stay in lockstep.

## Files

- `.github/workflows/drift-detection.yml` — verbatim copy of the common workflow (including the post-#172 `aur_builder` provisioning fix). No AUR targets here, but the AUR code path is dormant rather than removed so the two files can stay in sync.
- `.github/drift-targets.yml` — 8 targets covering the EL10 Layer-1 no-ops introduced by #129/#131:
  - `communication`: kmail
  - `system_apps`: gparted, filelight, solaar, plasma-systemmonitor, timeshift, deja-dup
  - `display_manager`: sddm

  All targets probe `rocky-10`; vars file is `vars/RedHat.yml` per the project's "RedHat.yml = newest EL major" convention.
- `.secrets.baseline` — manual entry for the workflow file's line 83 Secret-Keyword match (same hash as common, since file content is byte-identical). The `detect-secrets` pre-commit hook here is still pinned at v1.4.0; a separate follow-up will mirror common's #158 bump to v1.5.0.

## Notes

- `display_manager`'s SDDM probe targets the `sddm` package even though the role uses `__display_manager_packages.sddm` (dict). When SDDM becomes installable again the drift issue will prompt restoring the dict entry plus the sibling `__display_manager_sddm_virtual_keyboard_package` in the same vars file — no separate probe needed.

## Test plan

- [x] yamllint clean
- [x] ansible-lint clean
- [x] detect-secrets clean (baseline entry matches common's hash)
- [ ] manual `workflow_dispatch` run after merge — confirm all 8 probes run against the `rocky-10` image and report "unavailable" (expected — EL10 EPEL drift still in effect), no issues opened

Closes #130