### PR TITLE
ci(pre-commit): bump detect-secrets to v1.5.0 to match baseline format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
   # SECRETS DETECTION
   # =============================================================================
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         name: Detect secrets

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"


### PR DESCRIPTION
## Summary

Mirrors marcstraube.common's #159: bumps the `Yelp/detect-secrets` pre-commit hook pin from `v1.4.0` to `v1.5.0` and aligns the baseline header. The desktop baseline's `plugins_used` list is already v1.5.0-compatible (verified by diffing against common's post-bump baseline), so no regeneration is needed.

With the v1.4.0 pin every `pre-commit run` against a baseline-touching change rewrote the baseline's `version` field back to `1.4.0` and exited 3 ("baseline file was updated"), creating spurious follow-up commits. The drift-detection landing (#133) hit exactly this — the manual baseline entry there had to use v1.4.0 formatting to keep the hook happy.

## Changes

- `.pre-commit-config.yaml`: `Yelp/detect-secrets` rev `v1.4.0` → `v1.5.0`
- `.secrets.baseline`: `version` `1.4.0` → `1.5.0` (header only)

## Test plan

- [x] `pre-commit run detect-secrets --files .pre-commit-config.yaml .secrets.baseline` clean, no diff on baseline
- [x] Locally created this commit signed with no false-positive rewrite