### PR TITLE
chore!: bump ansible-core minimum to 2.19 + forward-compat to 2.21

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,7 +5,7 @@
 Desktop workstation roles for Arch Linux and Debian Trixie — desktop environments,
 display managers, browsers, development tools, multimedia, and productivity software.
 
-## Coding Standards (ansible-core 2.17+)
+## Coding Standards (ansible-core 2.19+)
 
 - **Facts:** `ansible_facts['os_family']` — never `ansible_os_family` (deprecated)
 - **Modules:** Always FQCN (`ansible.builtin.*`, `community.general.*`, `kewlfft.aur.*`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,12 @@ jobs:
         run: yamllint -c .yamllint .
 
   # =============================================================================
-  # MOLECULE FORWARD-COMPATIBILITY (ansible-core 2.20, representative subset)
+  # MOLECULE FORWARD-COMPATIBILITY (ansible-core 2.21, representative subset)
   # Tests a diverse subset of roles on latest ansible-core to catch
   # deprecations and breaking changes early.
   # =============================================================================
   molecule-compat:
-    name: Compat ${{ matrix.role }} (ansible-2.20)
+    name: Compat ${{ matrix.role }} (ansible-2.21)
     runs-on: ubuntu-latest
     needs: [lint, markdown-lint, yaml-lint]
     strategy:
@@ -102,7 +102,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install "ansible-core~=2.20.0" \
+          pip install "ansible-core~=2.21.0" \
                       molecule \
                       molecule-plugins[podman] \
                       passlib
@@ -262,7 +262,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install "ansible-core~=2.17.0" \
+          pip install "ansible-core~=2.19.0" \
                       molecule \
                       molecule-plugins[podman] \
                       passlib

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ and instructions for contributing to this collection.
 ### Prerequisites
 
 - Python 3.13+
-- ansible-core >= 2.17
+- ansible-core >= 2.19
 - Podman (for Molecule tests)
 - Git
 - pre-commit

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,52 @@ snippets. For the full list of changes per release, see
 
 ## v2.0.0 (unreleased)
 
+### Minimum ansible-core bumped from 2.17 to 2.19 (#135)
+
+v2.0.0 unifies and raises the supported ansible-core floor across all
+five (six in CI) surfaces. Aligns with the floor decision in
+`marcstraube.common` v2.0.0 (common#173). The forward-compat CI job
+is bumped from 2.20 to 2.21 (latest stable) to keep coverage above
+the floor.
+
+The floor stops at 2.19 rather than 2.20 because ansible-lint v26.4.0
+(latest at v2.0.0 release time) does not yet accept `>=2.20.0` in
+`meta/runtime.yml` — its `meta-runtime` rule only knows about 2.15
+through 2.19. Once ansible-lint catches up, a follow-up minor release
+will bump the floor to 2.20.
+
+The 2.17 → 2.19 step does not change the install path for users on
+RHEL 9 or Debian Bookworm — those distros' system `ansible-core` is
+older than 2.17 anyway, so a `pip install --user ansible-core` (or
+`pipx`) is the established workflow there. The bump just makes the
+actually-supported floor honest.
+
+#### Required action
+
+Upgrade `ansible-core` to 2.19 or newer before installing this
+collection's v2.0.0 release:
+
+```bash
+# pip (system Python or venv)
+pip install --upgrade 'ansible-core>=2.19,<2.22'
+
+# pipx
+pipx upgrade --pip-args='--upgrade' ansible-core
+```
+
+Distro packages currently shipping `ansible-core >= 2.19`:
+
+- Arch Linux: `extra/ansible-core`
+- Debian Trixie: `main/ansible-core`
+- EPEL 10: `epel/ansible-core`
+- Fedora 41+: `fedora/ansible-core`
+
+If you pin `ansible-core` in a requirements file, set:
+
+```text
+ansible-core>=2.19,<2.22
+```
+
 ### `development_shellcheck_enabled` renamed (#116)
 
 shellcheck moves from "Misc Tools" into the new `# Language Tooling`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Requirements
 
-- ansible-core >= 2.17
+- ansible-core >= 2.19
 - [marcstraube.common](https://github.com/marcstraube/ansible-collection-common) >= 1.0.0
 
 ## Included Roles

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.17.0'
+requires_ansible: '>=2.19.0'
 action_groups:
   marcstraube:
     - community.general.*

--- a/roles/ai/meta/main.yml
+++ b/roles/ai/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure AI development tools
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/bluetooth/meta/main.yml
+++ b/roles/bluetooth/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Bluetooth support
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/browser/meta/main.yml
+++ b/roles/browser/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure web browsers with enterprise policies
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/cad/meta/main.yml
+++ b/roles/cad/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install CAD and 3D modeling applications
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/communication/meta/main.yml
+++ b/roles/communication/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install messaging and communication applications
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/desktop_environment/meta/main.yml
+++ b/roles/desktop_environment/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure desktop environments (Hyprland, Sway, i3, KDE, GNOME, XFCE, LXDE, LXQt)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/development/meta/main.yml
+++ b/roles/development/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   description: Install development tools, IDEs, and programming languages
   license: MIT
 
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/display_manager/meta/main.yml
+++ b/roles/display_manager/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure display managers (SDDM, GDM, LightDM, greetd)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/downloads/meta/main.yml
+++ b/roles/downloads/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install download managers and torrent clients
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/elgato/meta/main.yml
+++ b/roles/elgato/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure tools for Elgato devices
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/filemanagers/meta/main.yml
+++ b/roles/filemanagers/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install terminal and GUI file managers
   license: MIT
 
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/gaming/meta/main.yml
+++ b/roles/gaming/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install gaming platforms and emulators
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/graphics_apps/meta/main.yml
+++ b/roles/graphics_apps/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install graphics and image editing applications
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/imaging/meta/main.yml
+++ b/roles/imaging/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install imaging and scanning applications
   license: MIT
 
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/keepassxc/meta/main.yml
+++ b/roles/keepassxc/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure KeePassXC password manager
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/multimedia/meta/main.yml
+++ b/roles/multimedia/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install multimedia applications for audio and video
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/office/meta/main.yml
+++ b/roles/office/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install office applications and document tools
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/pipewire/meta/main.yml
+++ b/roles/pipewire/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure PipeWire audio server
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/plymouth/meta/main.yml
+++ b/roles/plymouth/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Plymouth boot splash screen
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/remote_access/meta/main.yml
+++ b/roles/remote_access/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install remote desktop and access applications
   license: MIT
 
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/security_apps/meta/main.yml
+++ b/roles/security_apps/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install security and encryption applications
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/system_apps/meta/main.yml
+++ b/roles/system_apps/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install desktop system management applications
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/terminal/meta/main.yml
+++ b/roles/terminal/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install terminal emulators (Ghostty, Alacritty, Kitty, Foot, Wezterm)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/tuxedo/meta/main.yml
+++ b/roles/tuxedo/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install Tuxedo kernel drivers and control center
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/wayland_utils/meta/main.yml
+++ b/roles/wayland_utils/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install common Wayland utilities (clipboard, screenshots, notifications)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/wine/meta/main.yml
+++ b/roles/wine/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Wine Windows compatibility layer
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/xdg_user_dirs/meta/main.yml
+++ b/roles/xdg_user_dirs/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Manage XDG user directories (Documents, Downloads, Projects, …) per user
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux


### PR DESCRIPTION
## Summary

Mirrors common's #173/#174. Unifies and raises the supported ansible-core floor across all five surfaces, plus the CI main and forward-compat matrices. Closes #135.

## Surface coverage

- `meta/runtime.yml`: `'>=2.17.0'` → `'>=2.19.0'`
- `README.md` Requirements: 2.17 → 2.19
- `CONTRIBUTING.md` Prerequisites: 2.17 → 2.19
- `.claude/CLAUDE.md` heading: 2.17+ → 2.19+
- `roles/*/meta/main.yml`: `'2.14'` / `'2.17'` → `'2.19'` (all 28 — one `'2.14'` outlier in `tabletop`, rest were `'2.17'`)
- `.github/workflows/ci.yml`:
    - main molecule-roles job pip pin: 2.17 → 2.19
    - Compat matrix `ansible-2.20` → `ansible-2.21` (one version above the new floor)

## Why floor at 2.19 (not 2.20)

ansible-core 2.20 was released 2026-05-18. ansible-lint v26.4.0 (latest at PR time) still rejects `'>=2.20.0'` in `meta/runtime.yml`. Floor stays at 2.19 for now; bump to 2.20 tracked in follow-up #136 for when upstream tooling catches up.

## Why breaking

ansible-core minimum is a contract change. Inventories that pin `ansible-core==2.17` (or use RHEL 9 / Debian Bookworm system ansible) need to upgrade. The required-action section in `MIGRATION.md` spells out the pip / pipx / distro paths.

## Test plan

- [x] `pre-commit run --all-files` clean
- [ ] Full CI matrix green on the bump branch

Closes #135