### PR TITLE
fix(system_apps): re-enable filelight and plasma-systemmonitor on EL10

### DIFF
--- a/roles/system_apps/README.md
+++ b/roles/system_apps/README.md
@@ -15,7 +15,7 @@ baseline (GParted, Filelight, Solaar on by default; optional tools off by defaul
 On Rocky Linux, EPEL and CRB must be enabled before running this role
 (typically via `marcstraube.common.package_management`) — several packages
 (gparted, filelight, solaar, timeshift, deja-dup) are not in the base
-repos, and filelight + plasma-systemmonitor pull KF5 libraries from CRB.
+repos, and filelight + plasma-systemmonitor pull KF5/Qt6 libraries from CRB.
 
 On Rocky 10 specifically, several packages are skipped automatically —
 see "Known limitations on EL10" below.
@@ -46,9 +46,7 @@ and are skipped automatically. The role install tasks already guard with
 `length > 0`, so the empty package names produce a no-op:
 
 - `gparted` — not packaged in EPEL 10
-- `filelight` — EPEL build depends on Qt 6.10, Rocky 10 ships Qt 6.8/6.9
 - `solaar` — not packaged in EPEL 10
-- `plasma-systemmonitor` — EPEL build depends on Qt 6.10
 - `timeshift` — not packaged in EPEL 10
 - `deja-dup` — not packaged in EPEL 10
 

--- a/roles/system_apps/vars/RedHat-9.yml
+++ b/roles/system_apps/vars/RedHat-9.yml
@@ -7,8 +7,6 @@
 #
 
 __system_apps_gparted_package: 'gparted'
-__system_apps_filelight_package: 'filelight'
 __system_apps_solaar_package: 'solaar'
-__system_apps_plasma_system_monitor_package: 'plasma-systemmonitor'
 __system_apps_timeshift_package: 'timeshift'
 __system_apps_deja_dup_package: 'deja-dup'

--- a/roles/system_apps/vars/RedHat.yml
+++ b/roles/system_apps/vars/RedHat.yml
@@ -4,15 +4,11 @@
 #
 # The following packages are not available on EL10 + EPEL:
 # - gparted / solaar / timeshift / deja-dup: not packaged in EPEL 10.
-# - filelight / plasma-systemmonitor: EPEL builds depend on Qt 6.10
-#   while Rocky 10 base ships Qt 6.8/6.9, so dnf depsolve fails.
 # Older RHEL majors restore working values in vars/RedHat-<N>.yml.
 # See README "Platform support" section.
 #
 
 __system_apps_gparted_package: ''
-__system_apps_filelight_package: ''
 __system_apps_solaar_package: ''
-__system_apps_plasma_system_monitor_package: ''
 __system_apps_timeshift_package: ''
 __system_apps_deja_dup_package: ''


### PR DESCRIPTION
## Summary

- Re-enable `filelight` and `plasma-systemmonitor` on EL10 — Qt 6.10 is now available in Rocky 10 / EPEL 10 (`qt6-qtbase-gui-6.10.1`, `qt6-qtdeclarative-6.10.1`).
- Drop the Layer-1 no-ops from `roles/system_apps/vars/RedHat.yml` and the matching restores from `roles/system_apps/vars/RedHat-9.yml`.
- Update README "Known limitations on EL10" accordingly.

## Test plan

- [x] `molecule test -p system-apps-rocky-10` — converge + idempotence + verify all green
- [x] `rpm -q filelight` confirmed in verify
- [x] `rpm -q plasma-systemmonitor` confirmed in verify
- [x] `ansible-lint roles/system_apps/` — passed
- [x] `pre-commit run --files roles/system_apps/vars/RedHat.yml roles/system_apps/vars/RedHat-9.yml roles/system_apps/README.md` — all hooks passed

Closes #140
Closes #142