### PR TITLE
fix(display_manager): re-enable sddm on EL10

### DIFF
--- a/roles/display_manager/README.md
+++ b/roles/display_manager/README.md
@@ -19,7 +19,7 @@ greeters (gtkgreet, regreet) running under Hyprland, Sway, or Cage.
 | Arch Linux                | Native packages, all DMs supported                     |
 | Debian Trixie             | Native packages (gdm packaged as `gdm3`)               |
 | EL 9 (Rocky, Alma, RHEL)  | EPEL + CRB required, all DMs supported                 |
-| EL 10 (Rocky, Alma, RHEL) | EPEL + CRB required — SDDM unavailable (Qt 6.10 drift) |
+| EL 10 (Rocky, Alma, RHEL) | EPEL + CRB required, all DMs supported                 |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/display_manager/vars/RedHat-9.yml
+++ b/roles/display_manager/vars/RedHat-9.yml
@@ -2,10 +2,10 @@
 #
 # RedHat 9 Variables
 #
-# vars/RedHat.yml targets the newest supported RHEL major (EL10) and
-# turns SDDM into a no-op there. EL9 restores the working values.
-# The remaining keys mirror vars/RedHat.yml because include_vars uses
-# with_first_found and loads only one file per host.
+# Mirrors vars/RedHat.yml because include_vars uses with_first_found
+# and loads only one file per host. Diverges where EL9 needs older
+# package names — currently only the Qt5 virtual keyboard for SDDM
+# (EL10 ships qt6-qtvirtualkeyboard).
 #
 
 # Display manager packages

--- a/roles/display_manager/vars/RedHat.yml
+++ b/roles/display_manager/vars/RedHat.yml
@@ -2,25 +2,19 @@
 #
 # RedHat Variables (targets newest supported RHEL major: EL10)
 #
-# SDDM is unavailable on EL10: EPEL ships sddm-wayland-*, neatvnc, and
-# plasma-keyboard packages that require Qt 6.10 (Rocky 10 base ships
-# Qt 6.8/6.9). The base `sddm` package transitively pulls these in.
-# An empty package name combined with the role's package-list filter
-# turns SDDM installation into a no-op on EL10.
-# EL9 restores working values in vars/RedHat-9.yml.
-# See README "Platform support" section.
+# Older RHEL majors override these in vars/RedHat-<N>.yml when the
+# package names or selections differ. See README "Platform support".
 #
 
 # Display manager packages
 __display_manager_packages:
-  sddm: ''
+  sddm: 'sddm'
   gdm: 'gdm'
   lightdm: 'lightdm'
   greetd: 'greetd'
 
 # SDDM virtual keyboard package
-# Empty on EL10: nothing to add when SDDM itself is a no-op.
-__display_manager_sddm_virtual_keyboard_package: ''
+__display_manager_sddm_virtual_keyboard_package: 'qt6-qtvirtualkeyboard'
 
 # LightDM greeter packages
 __display_manager_lightdm_greeter_packages:


### PR DESCRIPTION
## Summary

- Re-enable `sddm` on EL10 — Qt 6.10 is now available in Rocky 10 / EPEL 10, so the full `sddm` dependency chain (`sddm-wayland-*`, `neatvnc`, `plasma-keyboard`) resolves.
- Restore `sddm` in `__display_manager_packages` and set `__display_manager_sddm_virtual_keyboard_package` to `qt6-qtvirtualkeyboard` on EL10 (EL9 stays on `qt5-qtvirtualkeyboard`).
- Simplify the `vars/RedHat.yml` and `vars/RedHat-9.yml` comment headers.
- Update README "Supported Platforms": EL10 now lists "all DMs supported".

## Test plan

- [x] `molecule test -p display-manager-rocky-10` — converge + idempotence + verify all green
- [x] Verify confirms `rpm -q sddm`, `/etc/sddm.conf.d` directory, and `sddm.service` unit file
- [x] `ansible-lint roles/display_manager/` — passed
- [x] `pre-commit run --files roles/display_manager/vars/RedHat.yml roles/display_manager/vars/RedHat-9.yml roles/display_manager/README.md` — all hooks passed

Closes #141