### PR TITLE
feat(development): add Socket CLI npm supply-chain scanner toggle

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -12,8 +12,12 @@ Git configuration with signing key setup.
 ## Requirements
 
 - ansible-core >= 2.17
-- `community.general` collection (for git_config, pipx, pacman modules)
+- `community.general` collection (for git_config, pipx, pacman, npm modules)
 - `kewlfft.aur` collection (for AUR packages on Arch Linux)
+- `marcstraube.common.nodejs` role on non-Arch when enabling tools that
+  install via npm (e.g. Socket CLI). The development role itself does
+  not install Node.js; `development_nodejs_enabled` is a marker the
+  inventory uses to gate the common role.
 
 ## Supported Platforms
 
@@ -130,6 +134,8 @@ intended, not just deltas.
 Socket CLI is an npm-native tool. Arch installs the AUR package
 `socket-cli` (which wraps the upstream npm package); Debian and EL
 install the `socket` npm package globally via `community.general.npm`.
+On non-Arch, `marcstraube.common.nodejs` must be applied before this
+role to provide `npm`.
 
 ### Language Tooling
 

--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -121,6 +121,16 @@ intended, not just deltas.
 | `development_direnv_enabled`     | `true`  | Enable direnv directory-based envs |
 | `development_pre_commit_enabled` | `true`  | Enable pre-commit git hooks        |
 
+### Security Tooling
+
+| Variable                         | Default | Description                                          |
+|----------------------------------|---------|------------------------------------------------------|
+| `development_socket_cli_enabled` | `false` | Enable Socket CLI (npm supply-chain scanner)         |
+
+Socket CLI is an npm-native tool. Arch installs the AUR package
+`socket-cli` (which wraps the upstream npm package); Debian and EL
+install the `socket` npm package globally via `community.general.npm`.
+
 ### Language Tooling
 
 Per-tool toggles for distro-packaged linters, formatters, and test frameworks.
@@ -278,6 +288,7 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - [pre-commit](https://pre-commit.com/) — Multi-language git hook framework
 - [direnv](https://direnv.net/) — Per-directory environment variable loader
 - [ShellCheck](https://www.shellcheck.net/) — Shell script static analyser
+- [Socket CLI](https://socket.dev/cli) — npm dependency supply-chain scanner ([source](https://github.com/SocketDev/socket-cli))
 
 ## License
 

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -192,6 +192,17 @@ development_direnv_enabled: true
 development_pre_commit_enabled: true
 
 #
+# Security Tooling
+#
+# Supply-chain / dependency scanners. PM-native tools are installed
+# from their canonical source: AUR on Arch (which wraps the upstream
+# package manager), and the upstream package manager directly on
+# Debian/RedHat.
+
+# Enable Socket CLI (npm dependency supply-chain scanner)
+development_socket_cli_enabled: false
+
+#
 # User Configuration
 #
 

--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -41,6 +41,9 @@
     development_pgadmin_enabled: false
     # httpie disabled — EPEL 9 package has a broken pygments dep
     development_httpie_enabled: false
+    # Socket CLI: AUR on Arch, npm-global on non-Arch (npm/nodejs
+    # provided by prepare.yml)
+    development_socket_cli_enabled: true
     development_users: []
 
   tasks:

--- a/roles/development/molecule/default/prepare.yml
+++ b/roles/development/molecule/default/prepare.yml
@@ -111,3 +111,29 @@
         mode: '0440'
         validate: 'visudo -cf %s'
       when: ansible_facts['os_family'] == 'Archlinux'
+
+    #
+    # Node.js / npm — required by Socket CLI on non-Arch
+    # (the development role itself does not install nodejs; the
+    # inventory normally enables marcstraube.common.nodejs separately).
+    #
+
+    - name: Prepare | Install nodejs and npm (Debian)
+      ansible.builtin.apt:
+        name:
+          - nodejs
+          - npm
+        state: present
+      when: ansible_facts['os_family'] == 'Debian'
+      retries: 3
+      delay: 5
+
+    - name: Prepare | Install nodejs (RedHat)
+      ansible.builtin.dnf:
+        name:
+          - nodejs
+          - npm
+        state: present
+      when: ansible_facts['os_family'] == 'RedHat'
+      retries: 3
+      delay: 5

--- a/roles/development/molecule/default/verify.yml
+++ b/roles/development/molecule/default/verify.yml
@@ -258,3 +258,23 @@
       register: _dev_git_lfs_check
       failed_when: _dev_git_lfs_check.changed
       when: __development_git_lfs_package | default('') | length > 0
+
+    #
+    # Socket CLI (enabled) — AUR on Arch, npm-global on non-Arch
+    #
+
+    - name: Verify | Socket CLI installed from AUR (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q socket-cli'
+      register: _dev_socket_cli_arch
+      changed_when: false
+      failed_when: _dev_socket_cli_arch.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | Socket CLI installed via npm (non-Arch)
+      ansible.builtin.command:
+        cmd: 'npm ls -g --depth=0 socket'
+      register: _dev_socket_cli_npm
+      changed_when: false
+      failed_when: _dev_socket_cli_npm.rc != 0
+      when: ansible_facts['os_family'] != 'Archlinux'

--- a/roles/development/tasks/tools.yml
+++ b/roles/development/tasks/tools.yml
@@ -58,3 +58,30 @@
   when: __development_httpie_package | default('') | length > 0
   retries: 3
   delay: 5
+
+# Socket CLI — npm-native supply-chain scanner. AUR wraps the upstream
+# npm package; non-Arch installs it via npm directly.
+
+- name: Tools | Install Socket CLI from AUR (Arch)
+  become: true
+  become_user: 'aur_builder'
+  kewlfft.aur.aur:
+    name: '{{ __development_aur_packages.security_socket_cli }}'
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - development_socket_cli_enabled | bool
+  retries: 3
+  delay: 5
+
+- name: Tools | Install Socket CLI via npm (non-Arch)
+  become: true
+  community.general.npm:
+    name: 'socket'
+    global: true
+    state: present
+  when:
+    - ansible_facts['os_family'] != 'Archlinux'
+    - development_socket_cli_enabled | bool
+  retries: 3
+  delay: 5

--- a/roles/development/vars/Archlinux.yml
+++ b/roles/development/vars/Archlinux.yml
@@ -86,3 +86,5 @@ __development_aur_packages:
     - 'insomnia-bin'
   api_tools_bruno:
     - 'bruno-bin'
+  security_socket_cli:
+    - 'socket-cli'


### PR DESCRIPTION
## Summary

- Adds opt-in `development_socket_cli_enabled` toggle (default `false`) under a new "Security Tooling" section in the development role.
- Arch installs the AUR package `socket-cli` (wraps upstream npm package) via `kewlfft.aur.aur`.
- Non-Arch installs the `socket` npm package globally via `community.general.npm`.
- Per-OS dispatch mirrors the pattern in `desktop.ai/cli.yml`.
- README documents the `marcstraube.common.nodejs` prerequisite for npm-based tools on non-Arch.

## Implementation notes

Socket CLI is npm-native: the upstream distribution channel is npm, and the AUR package wraps `npm install -g socket`. Pattern matches the existing AI CLI tools (Claude Code, Gemini CLI, OpenAI Codex).

The development role does not install Node.js itself; consumers enable `marcstraube.common.nodejs` separately. `development_nodejs_enabled` is a marker the inventory uses to gate the common role. The molecule `prepare.yml` installs `nodejs`/`npm` on non-Arch so the npm install step has its prerequisites.

## Test plan

- [x] `molecule test -p development-archlinux` — green, AUR install + idempotence + `pacman -Q socket-cli` verify
- [x] `molecule test -p development-debian-trixie` — green, npm global install + idempotence + `npm ls -g socket` verify
- [ ] CI to verify Rocky 9 and Rocky 10 (same non-Arch code path as Debian)
- [x] `ansible-lint` + `yamllint` + `pre-commit` green

Closes #144