### PR TITLE
feat(ai): add Claude Cowork Service toggle (AUR-only)

### DIFF
--- a/roles/ai/README.md
+++ b/roles/ai/README.md
@@ -43,13 +43,14 @@ API keys are managed by the user via environment variables (not by this role).
 
 | Variable                          | Default | Description                           |
 | --------------------------------- | ------- | ------------------------------------- |
-| `ai_claude_code_enabled`          | `true`  | Install Claude Code                   |
-| `ai_gemini_cli_enabled`           | `false` | Install Gemini CLI                    |
-| `ai_codex_enabled`                | `false` | Install OpenAI Codex CLI              |
-| `ai_opencode_enabled`             | `false` | Install OpenCode CLI                  |
-| `ai_opencode_claude_auth_enabled` | `false` | OpenCode auth plugin for Claude creds |
-| `ai_opencode_gemini_auth_enabled` | `false` | OpenCode auth plugin for Gemini creds |
-| `ai_aider_enabled`                | `false` | Install Aider (pair programming)      |
+| `ai_claude_code_enabled`            | `true`  | Install Claude Code                                 |
+| `ai_gemini_cli_enabled`             | `false` | Install Gemini CLI                                  |
+| `ai_codex_enabled`                  | `false` | Install OpenAI Codex CLI                            |
+| `ai_opencode_enabled`               | `false` | Install OpenCode CLI                                |
+| `ai_opencode_claude_auth_enabled`   | `false` | OpenCode auth plugin for Claude creds               |
+| `ai_opencode_gemini_auth_enabled`   | `false` | OpenCode auth plugin for Gemini creds               |
+| `ai_aider_enabled`                  | `false` | Install Aider (pair programming)                    |
+| `ai_claude_cowork_service_enabled`  | `false` | Install Claude Cowork Service (Arch only, AUR)      |
 
 ### Desktop Applications
 

--- a/roles/ai/defaults/main.yml
+++ b/roles/ai/defaults/main.yml
@@ -32,6 +32,10 @@ ai_opencode_gemini_auth_enabled: false
 # Enable Aider (AI pair programming)
 ai_aider_enabled: false
 
+# Enable Claude Cowork Service (native backend for Claude Desktop Cowork —
+# Arch only; AUR-packaged)
+ai_claude_cowork_service_enabled: false
+
 #
 # Desktop Applications
 #

--- a/roles/ai/molecule/default/converge.yml
+++ b/roles/ai/molecule/default/converge.yml
@@ -12,6 +12,7 @@
     ai_codex_enabled: false
     ai_opencode_enabled: false
     ai_aider_enabled: false
+    ai_claude_cowork_service_enabled: false
     ai_claude_desktop_enabled: false
     ai_opencode_desktop_enabled: false
     ai_ollama_enabled: false

--- a/roles/ai/tasks/cli.yml
+++ b/roles/ai/tasks/cli.yml
@@ -183,3 +183,27 @@
     - ai_aider_enabled | bool
   retries: 3
   delay: 5
+
+# Claude Cowork Service
+
+- name: CLI | Install Claude Cowork Service from AUR (Arch)
+  become: true
+  become_user: 'aur_builder'
+  kewlfft.aur.aur:
+    name: '{{ __ai_aur_packages.claude_cowork_service }}'
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - ai_claude_cowork_service_enabled | bool
+  retries: 3
+  delay: 5
+
+- name: CLI | Claude Cowork Service not available (non-Arch)
+  ansible.builtin.debug:
+    msg: >
+      Claude Cowork Service is only packaged for Arch
+      ({{ ansible_facts['os_family'] }} has no upstream package).
+  when:
+    - ansible_facts['os_family'] != 'Archlinux'
+    - ai_claude_cowork_service_enabled | bool
+    - __ai_claude_cowork_service_package | default('') | length == 0

--- a/roles/ai/vars/Archlinux.yml
+++ b/roles/ai/vars/Archlinux.yml
@@ -17,6 +17,8 @@ __ai_aur_packages:
     - opencode-gemini-auth
   aider:
     - aider
+  claude_cowork_service:
+    - claude-cowork-service
   claude_desktop:
     - claude-desktop-bin
   opencode_desktop:

--- a/roles/ai/vars/Debian.yml
+++ b/roles/ai/vars/Debian.yml
@@ -6,6 +6,9 @@
 # CLI Tools (via npm/pipx on Debian)
 __ai_codex_package: ''
 
+# CLI Tools — AUR-only on Arch, no-op elsewhere
+__ai_claude_cowork_service_package: ''
+
 # Desktop Apps
 __ai_claude_desktop_package: ''
 __ai_opencode_desktop_url: >-

--- a/roles/ai/vars/RedHat.yml
+++ b/roles/ai/vars/RedHat.yml
@@ -6,6 +6,9 @@
 # CLI Tools (via npm/pipx on RedHat)
 __ai_codex_package: ''
 
+# CLI Tools — AUR-only on Arch, no-op elsewhere
+__ai_claude_cowork_service_package: ''
+
 # Desktop Apps
 __ai_claude_desktop_package: ''
 __ai_opencode_desktop_url: >-


### PR DESCRIPTION
## Summary

- Adds opt-in `ai_claude_cowork_service_enabled` toggle (default `false`).
- Arch installs the `claude-cowork-service` AUR package via `kewlfft.aur.aur` — native Linux backend for Claude Desktop Cowork.
- Non-Arch is a documented no-op (debug message), same pattern as `claude-desktop`.
- Toggle stays `false` in molecule converge — claude-cowork-service requires `claude-desktop-bin`, which is also disabled in CI for the same reason. Enabling it standalone would not test anything meaningful.

## Test plan

- [x] Local molecule run with toggle temporarily `true` on all 4 platforms — Arch installs AUR package (`changed=1`), Debian/Rocky 9/Rocky 10 emit the documented debug no-op. Idempotence green.
- [x] `ansible-lint` + `yamllint` green
- [ ] CI to confirm with toggle in default `false` state

Closes #149