### PR TITLE
chore(release-please): adopt persistent Unreleased section in MIGRATION.md

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,10 +30,13 @@ jobs:
           manifest-file: .release-please-manifest.json
           target-branch: main
 
-      # Rewrite the `## vX.Y.Z (unreleased)` heading in MIGRATION.md to
-      # `## vX.Y.Z - YYYY-MM-DD` on the open release PR. release-please
-      # itself does not own MIGRATION.md, so without this step the
-      # heading would have to be dated by hand on every release.
+      # Date the persistent `## Unreleased` heading in MIGRATION.md and
+      # insert a fresh empty `## Unreleased` block above it on the open
+      # release PR. The Keep-a-Changelog-style persistent heading lets
+      # multiple breaking-change PRs in the same cycle append entries
+      # without each having to detect or create the heading, and removes
+      # the version guessing the previous (`## vX.Y.Z (unreleased)`)
+      # convention required.
       #
       # The step locates the release PR by the `autorelease: pending`
       # label that release-please applies, rather than via the action's
@@ -43,12 +46,11 @@ jobs:
       # output is empty and any gating on it would silently skip this
       # step.
       #
-      # No-op when no release PR is open, MIGRATION.md is absent, the
-      # heading is already dated, or the version release-please picked
-      # does not have a matching (unreleased) heading. Commit goes
+      # No-op when no release PR is open, MIGRATION.md is absent, or the
+      # `## Unreleased` heading is missing (already dated). Commit goes
       # through the contents API so it is attributed to and verified as
       # the release bot.
-      - name: Date (unreleased) section in MIGRATION.md
+      - name: Date Unreleased section in MIGRATION.md
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -82,16 +84,41 @@ jobs:
           OLD_CONTENT=$(jq -r '.content' <<< "$RESP" | base64 -d)
           FILE_SHA=$(jq -r '.sha' <<< "$RESP")
 
-          PATTERN="## v${NEW_VERSION} (unreleased)"
+          PATTERN="## Unreleased"
           REPLACEMENT="## v${NEW_VERSION} - ${DATE}"
 
-          if ! grep -Fq "$PATTERN" <<< "$OLD_CONTENT"; then
-            echo "No '${PATTERN}' heading in MIGRATION.md — already dated or version mismatch."
+          if ! grep -Fxq "$PATTERN" <<< "$OLD_CONTENT"; then
+            echo "No '${PATTERN}' heading in MIGRATION.md — already dated or section missing."
             exit 0
           fi
 
-          NEW_CONTENT=$(awk -v p="$PATTERN" -v r="$REPLACEMENT" \
-            '{if ($0 == p) print r; else print}' <<< "$OLD_CONTENT")
+          # Idempotency guard: if the dated heading for this version
+          # already exists in the file, the rewrite has run before.
+          # Skip to avoid stacking duplicate headings on subsequent
+          # main-pushes within the same release cycle (MD024).
+          if grep -Fxq "$REPLACEMENT" <<< "$OLD_CONTENT"; then
+            echo "MIGRATION.md already contains '${REPLACEMENT}' heading — no-op."
+            exit 0
+          fi
+
+          # Rewrite the first `## Unreleased` to two stacked headings:
+          # a fresh empty `## Unreleased` block (for the next cycle) on
+          # top, followed by the dated heading for this release. Any
+          # entries that lived under the original `## Unreleased` now
+          # sit under the dated heading where they belong.
+          NEW_CONTENT=$(awk -v p="$PATTERN" -v r="$REPLACEMENT" '
+            BEGIN { done = 0 }
+            {
+              if ($0 == p && !done) {
+                print p
+                print ""
+                print r
+                done = 1
+              } else {
+                print
+              }
+            }
+          ' <<< "$OLD_CONTENT")
 
           if [ "$OLD_CONTENT" = "$NEW_CONTENT" ]; then
             echo "Rewrite produced identical content — nothing to commit."

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,15 @@ breaking changes adds a section here with before/after inventory
 snippets. For the full list of changes per release, see
 [CHANGELOG.md](CHANGELOG.md).
 
+Following the [Keep a Changelog](https://keepachangelog.com/) convention,
+the file always carries a persistent `## Unreleased` section at the top.
+Breaking-change PRs append their entries under that section; the release
+workflow dates it to `## v<X.Y.Z> - YYYY-MM-DD` at release time and
+inserts a fresh empty `## Unreleased` above it. Do not delete the
+heading or rename it to a concrete version — the workflow handles that.
+
+## Unreleased
+
 ## v2.0.0 - 2026-05-22
 
 ### Minimum ansible-core bumped from 2.17 to 2.19 (#135)


### PR DESCRIPTION
## Summary

- `MIGRATION.md` now carries a persistent `## Unreleased` heading at the top of the v2.0.0+ block, with a short doc paragraph explaining the convention.
- `release-please.yml` Date step ported from `marcstraube.common` (sibling common#162): rewrites `## Unreleased` to two stacked headings (fresh empty `## Unreleased` on top, dated `## v<X.Y.Z> - YYYY-MM-DD` below).
- Idempotency guard skips the rewrite if the dated heading already exists, preventing duplicate-heading stacking on repeated main-pushes within a release cycle.
- Pattern matches `## Unreleased` exactly (`grep -Fxq`), no version-guessing required.

## Test plan

- [x] `pre-commit` green (ansible-lint, yamllint, markdownlint)
- [ ] CI to verify on next release-please run

Closes #127