### PR TITLE
ci: enforce MIGRATION.md update on breaking-change PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,16 +309,85 @@ jobs:
           retention-days: 30
 
   # =============================================================================
+  # MIGRATION DOC CHECK (PR only)
+  # Fails any PR whose commits include a Conventional-Commit breaking
+  # marker (`<type>!:` headline or `BREAKING CHANGE:` footer) without a
+  # MIGRATION.md change. No bypass: the `!` marker is reserved for actual
+  # contract violations; if it was set incorrectly the commit message
+  # must be rewritten, not the gate skipped.
+  # =============================================================================
+  migration-doc-check:
+    name: MIGRATION.md doc check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Enforce MIGRATION.md update on breaking-change PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # All commit messages on the PR (headline + body), paginated.
+          COMMITS=$(gh api -X GET "repos/${REPO}/pulls/${PR_NUMBER}/commits" \
+            --paginate --jq '.[].commit.message')
+
+          # Conventional-Commit breaking marker:
+          # - `<type>!:` or `<type>(<scope>)!:` at the start of any line
+          # - `BREAKING CHANGE:` at the start of any line
+          if ! grep -qE '(^[a-z]+(\([^)]+\))?!:|^BREAKING CHANGE:)' <<< "$COMMITS"; then
+            echo "No breaking-change commits in this PR — nothing to enforce."
+            exit 0
+          fi
+
+          echo "Breaking-change commit detected. Checking MIGRATION.md diff…"
+
+          # All changed files on the PR, paginated.
+          FILES=$(gh api -X GET "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[].filename')
+
+          if grep -Fxq 'MIGRATION.md' <<< "$FILES"; then
+            echo "MIGRATION.md is modified — check passes."
+            exit 0
+          fi
+
+          echo "::error::Breaking-change PR must update MIGRATION.md."
+          cat <<'EOF'
+          Detected at least one breaking-change commit (Conventional-Commit
+          `!` marker or BREAKING CHANGE: footer) but MIGRATION.md is not
+          modified by this PR. Pick one of the two paths:
+
+          1. The `!` marker is correct — the change really breaks an
+             inventory contract. Add a sub-section under the persistent
+             `## Unreleased` heading in MIGRATION.md describing the change
+             and the required inventory action. See the Migration Guide
+             intro for the convention.
+
+          2. The `!` marker is wrong — the change is additive, a no-op
+             removal of dead code, or merely implements documented intent.
+             Rewrite the commit message (`git rebase -i`, drop the `!`,
+             remove any `BREAKING CHANGE:` footer) and force-push. The `!`
+             marker is reserved strictly for actual contract violations.
+          EOF
+          exit 1
+
+  # =============================================================================
   # CI GATE (single required check for branch protection)
   # =============================================================================
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
     if: always()
-    needs: [lint, markdown-lint, yaml-lint, build, molecule-compat, molecule-roles]
+    needs: [lint, markdown-lint, yaml-lint, build, molecule-compat, molecule-roles, migration-doc-check]
     steps:
       - name: Check required job results
         run: |
+          # molecule-roles may be skipped when no roles changed;
+          # migration-doc-check is skipped on push to main (PR-only).
           results=(
             "${{ needs.lint.result }}"
             "${{ needs.markdown-lint.result }}"
@@ -326,6 +395,7 @@ jobs:
             "${{ needs.build.result }}"
             "${{ needs.molecule-compat.result }}"
             "${{ needs.molecule-roles.result }}"
+            "${{ needs.migration-doc-check.result }}"
           )
           for r in "${results[@]}"; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
@@ -333,4 +403,4 @@ jobs:
               exit 1
             fi
           done
-          echo "All required jobs passed or were skipped"
+          echo "All required jobs passed (or were skipped)."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,17 @@ Always use generic placeholder data in commented examples:
    - `feat(browser): add Brave browser support`
    - `fix(pipewire): correct low-latency configuration`
    - `refactor(shell): simplify plugin management`
+5. **Breaking changes** — the `!` marker (`<type>!:` headline or
+   `BREAKING CHANGE:` footer) is reserved strictly for actual inventory
+   contract violations. Additive features, no-op removals of dead code,
+   and changes that merely implement documented intent are **not**
+   breaking — they use plain `feat:` / `refactor:` / `fix:`.
+
+   Any PR that does carry the `!` marker must add a sub-section under
+   the persistent `## Unreleased` heading in `MIGRATION.md` describing
+   the change and the required inventory action. CI enforces this; if
+   the marker was set incorrectly, rewrite the commit message rather
+   than working around the gate.
 
 ## License
 


### PR DESCRIPTION
## Summary

Ports the migration-doc-check job from `marcstraube.common` (sibling PR common#204). Every PR whose commits carry a Conventional-Commit breaking marker (`<type>!:` headline or `BREAKING CHANGE:` footer) must touch `MIGRATION.md`, else CI fails with a clear error pointing to two correction paths.

- New PR-only job `migration-doc-check` in `.github/workflows/ci.yml`. Paginated `gh api` over commits + files, regex match for `<type>!:` / `<type>(scope)!:` / `BREAKING CHANGE:`.
- Wired into the existing `ci-gate` aggregator — no separate branch-protection / ruleset edit needed.
- **No bypass label.** The `!` marker is reserved strictly for actual inventory contract violations; if it was set wrong, rewrite the commit message rather than skip the gate. Matches the policy in [feedback_breaking_change_marker] and the choice already made in common.
- `CONTRIBUTING.md` documents the `!`-policy and the breaking-change → MIGRATION.md convention under "Pull Request Process".

## Test plan

- [x] Regex validated against common's matrix (matches `feat!:`, `refactor(scope)!:`, `BREAKING CHANGE:`; ignores plain `feat:`, `fix:`, `docs:`)
- [x] `pre-commit` green (ansible-lint, yamllint, markdownlint)
- [x] This PR itself is non-breaking (`ci:` prefix) — gate should report "no breaking commits" and pass
- [ ] CI to confirm

Closes #128