### PR TITLE
fix(wine): Rocky 9 Layer-1 no-op for EPEL mesa-libOSMesa drift

### DIFF
--- a/.github/drift-targets.yml
+++ b/.github/drift-targets.yml
@@ -59,3 +59,10 @@ targets:
     platform: rocky-10
     package: sddm
     vars_file: vars/RedHat.yml
+
+  # EL9 EPEL drift — wine-core depends on mesa-libOSMesa, dropped from
+  # EL9 (#163).
+  - role: wine
+    platform: rocky-9
+    package: wine
+    vars_file: vars/RedHat-9.yml

--- a/roles/wine/README.md
+++ b/roles/wine/README.md
@@ -18,8 +18,13 @@ environment configuration, and per-user Wine prefix initialization.
   `base-system` tag). Required for the `lib32-*` packages and the
   32-bit Vulkan driver. The role asserts this precondition before
   installation.
-- EPEL repository enabled (for Wine on Rocky Linux 9, managed by
-  `marcstraube.common.package_management`)
+- Wine is **currently unavailable** on Rocky Linux 9 / EL 9: EPEL's
+  `wine-8.0-1.el9` requires `mesa-libOSMesa(x86-64)` which is no
+  longer provided on EL 9. The role is a Layer-1 no-op on this
+  platform until the dependency is restored upstream — see
+  [#163](https://github.com/marcstraube/ansible-collection-desktop/issues/163).
+  The drift-detection workflow will open a re-enable issue once the
+  package becomes installable again.
 - Wine is **not available** for EL 10 (no EPEL package exists)
 
 ## Supported Platforms
@@ -28,7 +33,7 @@ environment configuration, and per-user Wine prefix initialization.
 |---------------------------|-----------------------------------------------|
 | Arch Linux                | Stable or staging variant, full lib32 support |
 | Debian Trixie             | Automatic i386 multiarch enablement           |
-| EL 9 (Rocky, Alma, RHEL)  | Via EPEL, 64-bit only (WoW64)                 |
+| EL 9 (Rocky, Alma, RHEL)  | Currently unavailable — EPEL drift (#163)     |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint)
 should work but are not actively tested. Use distro-specific vars overrides if needed.
@@ -64,7 +69,8 @@ Wine is not available for EL 10 — the role warns and skips on unsupported vers
 | `wine_lib32_packages` | `[lib32-mesa, ...]` | lib32 packages for 32-bit support |
 | `wine_vulkan_driver` | `'auto'` | GPU Vulkan driver (`auto`, `amd`, `intel`, `nvidia`, `none`) |
 
-Debian handles 32-bit automatically via multiarch. EL 9 uses WoW64 mode.
+Debian handles 32-bit automatically via multiarch. EL 9 would use
+WoW64 mode when wine is installable again (see #163).
 
 ### Environment
 

--- a/roles/wine/molecule/default/verify.yml
+++ b/roles/wine/molecule/default/verify.yml
@@ -12,16 +12,19 @@
       ansible.builtin.stat:
         path: /usr/bin/wine
       register: __wine_binary
+      when: ansible_facts['os_family'] != 'RedHat'
 
     - name: Verify | Check Wine64 binary exists
       ansible.builtin.stat:
         path: /usr/bin/wine64
       register: __wine64_binary
+      when: ansible_facts['os_family'] != 'RedHat'
 
     - name: Verify | Assert Wine is installed
       ansible.builtin.assert:
         that: __wine_binary.stat.exists or __wine64_binary.stat.exists
         fail_msg: 'Wine binary not found at /usr/bin/wine or /usr/bin/wine64'
+      when: ansible_facts['os_family'] != 'RedHat'
 
     - name: Verify | Check winetricks binary exists
       ansible.builtin.stat:

--- a/roles/wine/tasks/install.yml
+++ b/roles/wine/tasks/install.yml
@@ -30,6 +30,10 @@
   ansible.builtin.package:
     name: '{{ __wine_package_variants[wine_variant] | default(__wine_package_variants["stable"]) }}'
     state: present
+  when: >-
+    (__wine_package_variants[wine_variant]
+      | default(__wine_package_variants["stable"]))
+      | length > 0
   retries: 3
   delay: 5
 

--- a/roles/wine/vars/RedHat-9.yml
+++ b/roles/wine/vars/RedHat-9.yml
@@ -1,6 +1,10 @@
 ---
+# Layer-1 no-op: EPEL 9 wine-8.0-1.el9 pulls wine-core-8.0-1.el9 which
+# requires mesa-libOSMesa(x86-64), no longer provided on Rocky 9 / EL 9.
+# See desktop#163. The drift-detection workflow will open a re-enable
+# issue once the dependency is provided again.
 __wine_package_variants:
-  stable: wine
+  stable: ''
 
 __wine_winetricks_package: ''
 __wine_mono_package: ''


### PR DESCRIPTION
## Summary

Fixes the wine role's Rocky 9 CI failure introduced by upstream EPEL drift: `wine-8.0-1.el9` pulls `wine-core-8.0-1.el9` which requires `mesa-libOSMesa(x86-64)`, no longer provided on EL 9. Turned the schedule matrix red on `main` and blocked release PR #153.

Applies the standard 3-layer upstream-drift pattern:

- **Layer 1** — `roles/wine/vars/RedHat-9.yml`: `__wine_package_variants.stable: ''` + `length > 0` guard on the Wine packages install task.
- **Layer 2** — `roles/wine/README.md`: documents EL 9 unavailability with link to #163; Supported Platforms table updated accordingly.
- **Layer 3** — `.github/drift-targets.yml`: new `wine / rocky-9 / wine` entry so the weekly drift-detection workflow opens a re-enable issue once EPEL restores the dependency.

Molecule verify's Wine-binary asserts get the same `os_family != 'RedHat'` guard already used for the winetricks assertion, so the scenario passes end-to-end on Rocky 9.

## Test plan

- [x] Local `molecule test -p wine-rocky-9` — green (converge no-op, verify skips Wine-binary asserts on RedHat).
- [x] `pre-commit` green (ansible-lint, yamllint, markdownlint).
- [x] Not a breaking change: on Rocky 9 the install was already failing; there is no working prior state that the no-op removes.
- [ ] CI to confirm the wine-rocky-9 matrix entry turns green.

Closes #163