### PR TITLE
ci: unify markdownlint on cli2 with recursive globs

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,6 +1,10 @@
 ---
 config:
   extends: .markdownlint.yml
+globs:
+  - "**/*.{md,markdown}"
 ignores:
-  - ".ansible/**"
   - "CHANGELOG.md"
+  - ".ansible/**"
+  - "**/.venv/**"
+  - "**/node_modules/**"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,14 +29,12 @@ repos:
   # =============================================================================
   # MARKDOWN
   # =============================================================================
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.1
     hooks:
-      - id: markdownlint
+      - id: markdownlint-cli2
         name: Markdown Lint
         language_version: '22.22.0'
-        args: [--config=.markdownlint.yml]
-        exclude: '^CHANGELOG\.md$'
 
   # =============================================================================
   # GENERAL

--- a/roles/ai/README.md
+++ b/roles/ai/README.md
@@ -41,16 +41,16 @@ API keys are managed by the user via environment variables (not by this role).
 
 ### CLI Tools
 
-| Variable                          | Default | Description                           |
-| --------------------------------- | ------- | ------------------------------------- |
-| `ai_claude_code_enabled`            | `true`  | Install Claude Code                                 |
-| `ai_gemini_cli_enabled`             | `false` | Install Gemini CLI                                  |
-| `ai_codex_enabled`                  | `false` | Install OpenAI Codex CLI                            |
-| `ai_opencode_enabled`               | `false` | Install OpenCode CLI                                |
-| `ai_opencode_claude_auth_enabled`   | `false` | OpenCode auth plugin for Claude creds               |
-| `ai_opencode_gemini_auth_enabled`   | `false` | OpenCode auth plugin for Gemini creds               |
-| `ai_aider_enabled`                  | `false` | Install Aider (pair programming)                    |
-| `ai_claude_cowork_service_enabled`  | `false` | Install Claude Cowork Service (Arch only, AUR)      |
+| Variable                           | Default | Description                                    |
+| ---------------------------------- | ------- | ---------------------------------------------- |
+| `ai_claude_code_enabled`           | `true`  | Install Claude Code                            |
+| `ai_gemini_cli_enabled`            | `false` | Install Gemini CLI                             |
+| `ai_codex_enabled`                 | `false` | Install OpenAI Codex CLI                       |
+| `ai_opencode_enabled`              | `false` | Install OpenCode CLI                           |
+| `ai_opencode_claude_auth_enabled`  | `false` | OpenCode auth plugin for Claude creds          |
+| `ai_opencode_gemini_auth_enabled`  | `false` | OpenCode auth plugin for Gemini creds          |
+| `ai_aider_enabled`                 | `false` | Install Aider (pair programming)               |
+| `ai_claude_cowork_service_enabled` | `false` | Install Claude Cowork Service (Arch only, AUR) |
 
 ### Desktop Applications
 

--- a/roles/browser/README.md
+++ b/roles/browser/README.md
@@ -69,19 +69,19 @@ Chromium on Rocky Linux requires EPEL.
 
 ### LibreWolf Options
 
-| Variable                                      | Default     | Description                       |
-| --------------------------------------------- | ----------- | --------------------------------- |
-| `browser_librewolf_policies_enabled`          | `true`      | Deploy policies.json              |
-| `browser_librewolf_user_js_enabled`           | `true`      | Deploy per-user user.js           |
-| `browser_librewolf_extensions`                | `{...}`     | Extensions (defaults to Firefox)  |
-| `browser_librewolf_preferences`               | `{}`        | Additional preferences           |
-| `browser_librewolf_disable_telemetry`         | `true`      | Disable telemetry                |
-| `browser_librewolf_disable_pocket`            | `true`      | Disable Pocket                   |
-| `browser_librewolf_disable_firefox_studies`   | `true`      | Disable Firefox studies          |
-| `browser_librewolf_homepage`                  | `''`        | Homepage URL (empty = default)   |
-| `browser_librewolf_no_default_bookmarks`      | `true`      | Remove default bookmarks         |
-| `browser_librewolf_offer_to_save_logins`      | `false`     | Offer to save logins             |
-| `browser_librewolf_password_manager`          | `false`     | Built-in password manager        |
+| Variable                                    | Default | Description                      |
+| ------------------------------------------- | ------- | -------------------------------- |
+| `browser_librewolf_policies_enabled`        | `true`  | Deploy policies.json             |
+| `browser_librewolf_user_js_enabled`         | `true`  | Deploy per-user user.js          |
+| `browser_librewolf_extensions`              | `{...}` | Extensions (defaults to Firefox) |
+| `browser_librewolf_preferences`             | `{}`    | Additional preferences           |
+| `browser_librewolf_disable_telemetry`       | `true`  | Disable telemetry                |
+| `browser_librewolf_disable_pocket`          | `true`  | Disable Pocket                   |
+| `browser_librewolf_disable_firefox_studies` | `true`  | Disable Firefox studies          |
+| `browser_librewolf_homepage`                | `''`    | Homepage URL (empty = default)   |
+| `browser_librewolf_no_default_bookmarks`    | `true`  | Remove default bookmarks         |
+| `browser_librewolf_offer_to_save_logins`    | `false` | Offer to save logins             |
+| `browser_librewolf_password_manager`        | `false` | Built-in password manager        |
 
 ### Chromium Options
 
@@ -136,7 +136,10 @@ users, leaving subsequent manual changes intact.
 
 Two mechanisms, two variables, distinct semantics:
 
-- **`browser_firefox_policy_settings.Preferences`** (and `_librewolf_…`) deploy via `policies.json` as **system-wide locked** prefs. Only the [Mozilla whitelist of allowed prefixes](https://github.com/mozilla/gecko-dev/blob/master/browser/components/enterprisepolicies/Policies.sys.mjs) is honored — non-whitelisted entries are silently ignored by Mozilla. Format:
+- **`browser_firefox_policy_settings.Preferences`** (and `_librewolf_…`) deploy via `policies.json` as
+  **system-wide locked** prefs. Only the
+  [Mozilla whitelist of allowed prefixes](https://github.com/mozilla/gecko-dev/blob/master/browser/components/enterprisepolicies/Policies.sys.mjs)
+  is honored — non-whitelisted entries are silently ignored by Mozilla. Format:
 
   ```yaml
   browser_firefox_policy_settings:
@@ -146,9 +149,14 @@ Two mechanisms, two variables, distinct semantics:
         Status: locked
   ```
 
-- **`browser_firefox_preferences`** (and `_librewolf_…`) deploy as `user_pref()` in `<profile>/user.js` — **per-user, overridable in `about:config`** until the next managed-mode run reconciles. Use this for prefs that aren't on the policy whitelist, or for defaults the user should be able to change.
+- **`browser_firefox_preferences`** (and `_librewolf_…`) deploy as `user_pref()` in `<profile>/user.js` —
+  **per-user, overridable in `about:config`** until the next managed-mode run reconciles. Use this for
+  prefs that aren't on the policy whitelist, or for defaults the user should be able to change.
 
-The role's defaults intentionally leave `browser_firefox_preferences` empty: every soft-hardening pref worth defaulting is either already covered by another policy (e.g. `DisableTelemetry` covers all telemetry prefs) or by recent Firefox built-in defaults. The two non-trivial leftovers (`network.prefetch-next`, `network.dns.disablePrefetch`) live in `Preferences` policy.
+The role's defaults intentionally leave `browser_firefox_preferences` empty: every soft-hardening pref
+worth defaulting is either already covered by another policy (e.g. `DisableTelemetry` covers all
+telemetry prefs) or by recent Firefox built-in defaults. The two non-trivial leftovers
+(`network.prefetch-next`, `network.dns.disablePrefetch`) live in `Preferences` policy.
 
 ### Firefox / LibreWolf profile bootstrap
 
@@ -217,10 +225,13 @@ molecule test
 ## References
 
 - [Firefox](https://www.mozilla.org/firefox/) — Open-source web browser
-- [Mozilla Policy Templates](https://mozilla.github.io/policy-templates/) — Reference for `policies.json` keys deployed by this role
-- [arkenfox/user.js](https://github.com/arkenfox/user.js) — Hardened Firefox `user.js` template the role's defaults derive from
+- [Mozilla Policy Templates](https://mozilla.github.io/policy-templates/) —
+  Reference for `policies.json` keys deployed by this role
+- [arkenfox/user.js](https://github.com/arkenfox/user.js) —
+  Hardened Firefox `user.js` template the role's defaults derive from
 - [Chromium](https://www.chromium.org/) — Open-source browser project
-- [Chromium Enterprise Policy List](https://chromeenterprise.google/policies/) — Reference for Chromium/Brave policy keys
+- [Chromium Enterprise Policy List](https://chromeenterprise.google/policies/) —
+  Reference for Chromium/Brave policy keys
 - [LibreWolf](https://librewolf.net/) — Privacy-focused Firefox fork
 - [Brave](https://brave.com/) — Privacy-focused Chromium fork
 - [Tor Browser](https://www.torproject.org/) — Anonymity-focused Firefox fork

--- a/roles/desktop_environment/README.md
+++ b/roles/desktop_environment/README.md
@@ -201,7 +201,9 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - [LXDE](https://lxde.org/) — Lightweight X11 desktop environment
 - [LXQt](https://lxqt-project.org/) — Lightweight Qt desktop environment
 - [UWSM](https://github.com/Vladimir-csp/uwsm) — Universal Wayland Session Manager
-- [hyprland-qt-support](https://github.com/hyprwm/hyprland-qt-support) and the Hypr* ecosystem (hypridle, hyprlock, hyprpaper, hyprpicker, hyprshot, hyprsunset, hyprlauncher) — Companion utilities to Hyprland
+- [hyprland-qt-support](https://github.com/hyprwm/hyprland-qt-support) and the Hypr* ecosystem
+  (hypridle, hyprlock, hyprpaper, hyprpicker, hyprshot, hyprsunset, hyprlauncher) —
+  Companion utilities to Hyprland
 
 ## License
 

--- a/roles/terminal/README.md
+++ b/roles/terminal/README.md
@@ -37,10 +37,10 @@ overrides if needed.
 
 ### Terminal Emulators
 
-| Variable             | Default                               | Description                                              |
-|----------------------|---------------------------------------|----------------------------------------------------------|
-| `terminal_emulators` | `['ghostty']`                         | List of terminal emulators to install                    |
-| `terminal_default`   | `'{{ terminal_emulators \| first }}'` | Default `$TERMINAL` (empty disables env file deployment) |
+| Variable             | Default                               | Description                                   |
+|----------------------|---------------------------------------|-----------------------------------------------|
+| `terminal_emulators` | `['ghostty']`                         | List of terminal emulators to install         |
+| `terminal_default`   | `'{{ terminal_emulators \| first }}'` | Default `$TERMINAL` (empty disables env file) |
 
 When `terminal_default` is non-empty, the role writes
 `/etc/environment.d/terminal.conf` containing `TERMINAL=<value>`,
@@ -91,7 +91,8 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - [Kitty](https://sw.kovidgoyal.net/kitty/) — Fast, feature-rich, GPU-based terminal with image support
 - [Foot](https://codeberg.org/dnkl/foot) — Fast, lightweight, minimalist Wayland terminal emulator
 - [WezTerm](https://wezterm.org/) — GPU-accelerated cross-platform terminal emulator and multiplexer
-- [systemd.environment-generators(7)](https://www.freedesktop.org/software/systemd/man/latest/environment.d.html) — `/etc/environment.d/` reference
+- [systemd.environment-generators(7)](https://www.freedesktop.org/software/systemd/man/latest/environment.d.html) —
+  `/etc/environment.d/` reference
 
 ## License
 

--- a/roles/wayland_utils/README.md
+++ b/roles/wayland_utils/README.md
@@ -85,10 +85,10 @@ overrides if needed.
 
 ### Wallpaper
 
-| Variable                         | Default  | Description                                                                 |
-|----------------------------------|----------|-----------------------------------------------------------------------------|
-| `wayland_utils_wallpaper`        | `'none'` | Wallpaper tool: awww, swaybg, hyprpaper, wpaperd, none                      |
-| `wayland_utils_matugen_enabled`  | `false`  | Install matugen (Material You color generation, pairs well with awww)       |
+| Variable                        | Default  | Description                                                           |
+|---------------------------------|----------|-----------------------------------------------------------------------|
+| `wayland_utils_wallpaper`       | `'none'` | Wallpaper tool: awww, swaybg, hyprpaper, wpaperd, none                |
+| `wayland_utils_matugen_enabled` | `false`  | Install matugen (Material You color generation, pairs well with awww) |
 
 ### Display Management
 


### PR DESCRIPTION
## Summary

Unifies markdownlint tooling so local `pre-commit` and CI use the same engine, config, and file coverage.

- **pre-commit**: swap `igorshubovych/markdownlint-cli` for the `DavidAnson/markdownlint-cli2` hook, pinned `v0.22.1` — the cli2 version bundled in `markdownlint-cli2-action@v23`.
- **`.markdownlint-cli2.yaml`**: add `globs: ["**/*.{md,markdown}"]` (recursive) and ignore `.ansible/**`, `**/.venv/**`, `**/node_modules/**`.
- **CI**: the action already runs with no `with:` overrides, so it now lints every role README via the shared config — previously it only checked the root-level markdown files.

Recursive linting surfaced 40 pre-existing violations, fixed here:

- `roles/ai/README.md` — CLI Tools table re-aligned (header and data rows were mismatched)
- `roles/browser/README.md` — LibreWolf options table re-aligned; three long explanatory bullets and three reference-link lines wrapped to ≤120
- `roles/terminal/README.md` — Terminal Emulators table narrowed to ≤120; one reference link wrapped
- `roles/wayland_utils/README.md` — Wallpaper table re-aligned (was padded past 120)
- `roles/desktop_environment/README.md` — one long ecosystem bullet wrapped

## Test plan

- [x] `pre-commit run markdownlint-cli2 --all-files` passes with cli2 v0.22.1 (the CI engine).
- [x] Full pre-commit suite passes on the changed files.
- [x] All fixed tables re-measured to equal column widths; wrapped lines verified ≤120 characters.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
