### PR TITLE
feat(ai): add Antigravity toggles and deprecate Gemini CLI

### DIFF
--- a/roles/ai/README.md
+++ b/roles/ai/README.md
@@ -5,8 +5,9 @@ Install AI development tools.
 ## Description
 
 Installs AI CLI tools, desktop applications, and local inference engines.
-Supports Claude Code, Gemini CLI, OpenAI Codex, OpenCode, Aider, Ollama,
-LM Studio, Claude Desktop, OpenCode Desktop, and ComfyUI (Stable Diffusion).
+Supports Claude Code, Gemini CLI, Antigravity, OpenAI Codex, OpenCode, Aider,
+Ollama, LM Studio, Claude Desktop, OpenCode Desktop, and ComfyUI (Stable
+Diffusion).
 
 On Arch Linux, tools are installed via native packages (AUR/community/extra).
 On Debian and Rocky Linux, tools are installed via npm, pipx, install scripts,
@@ -44,7 +45,8 @@ API keys are managed by the user via environment variables (not by this role).
 | Variable                           | Default | Description                                    |
 | ---------------------------------- | ------- | ---------------------------------------------- |
 | `ai_claude_code_enabled`           | `true`  | Install Claude Code                            |
-| `ai_gemini_cli_enabled`            | `false` | Install Gemini CLI                             |
+| `ai_gemini_cli_enabled`            | `false` | Install Gemini CLI (deprecated)                |
+| `ai_antigravity_cli_enabled`       | `false` | Install Antigravity CLI (Arch only, AUR)       |
 | `ai_codex_enabled`                 | `false` | Install OpenAI Codex CLI                       |
 | `ai_opencode_enabled`              | `false` | Install OpenCode CLI                           |
 | `ai_opencode_claude_auth_enabled`  | `false` | OpenCode auth plugin for Claude creds          |
@@ -52,11 +54,15 @@ API keys are managed by the user via environment variables (not by this role).
 | `ai_aider_enabled`                 | `false` | Install Aider (pair programming)               |
 | `ai_claude_cowork_service_enabled` | `false` | Install Claude Cowork Service (Arch only, AUR) |
 
+> **Deprecation:** `ai_gemini_cli_enabled` is deprecated and will be removed in
+> v3.0.0. Migrate to Antigravity (`ai_antigravity_cli_enabled`). See #146.
+
 ### Desktop Applications
 
 | Variable                      | Default | Description                                  |
 | ----------------------------- | ------- | -------------------------------------------- |
 | `ai_claude_desktop_enabled`   | `false` | Install Claude Desktop (Arch only)           |
+| `ai_antigravity_enabled`      | `false` | Install Antigravity (Arch only)              |
 | `ai_opencode_desktop_enabled` | `false` | Install OpenCode Desktop (AUR / .deb / .rpm) |
 
 ### Local AI / Inference

--- a/roles/ai/defaults/main.yml
+++ b/roles/ai/defaults/main.yml
@@ -15,7 +15,12 @@ ai_enabled: true
 ai_claude_code_enabled: true
 
 # Enable Gemini CLI (Google)
+# DEPRECATED: Google is moving Gemini CLI behind a paid Pro tier. Superseded by
+# Antigravity (ai_antigravity_cli_enabled). Hard removal in v3.0.0 — see #146.
 ai_gemini_cli_enabled: false
+
+# Enable Antigravity CLI (Google — agentic development platform, CLI companion)
+ai_antigravity_cli_enabled: false
 
 # Enable OpenAI Codex CLI
 ai_codex_enabled: false
@@ -43,6 +48,10 @@ ai_claude_cowork_service_enabled: false
 
 # Enable Claude Desktop (official Anthropic app)
 ai_claude_desktop_enabled: false
+
+# Enable Antigravity (Google — agent-first desktop IDE, Antigravity 2.0
+# multi-agent orchestration platform)
+ai_antigravity_enabled: false
 
 # Enable OpenCode Desktop (Tauri-based GUI)
 ai_opencode_desktop_enabled: false

--- a/roles/ai/molecule/default/converge.yml
+++ b/roles/ai/molecule/default/converge.yml
@@ -9,11 +9,13 @@
     # Skip AUR/external packages in CI containers
     ai_claude_code_enabled: false
     ai_gemini_cli_enabled: false
+    ai_antigravity_cli_enabled: false
     ai_codex_enabled: false
     ai_opencode_enabled: false
     ai_aider_enabled: false
     ai_claude_cowork_service_enabled: false
     ai_claude_desktop_enabled: false
+    ai_antigravity_enabled: false
     ai_opencode_desktop_enabled: false
     ai_ollama_enabled: false
     ai_lmstudio_enabled: false

--- a/roles/ai/tasks/cli.yml
+++ b/roles/ai/tasks/cli.yml
@@ -31,6 +31,13 @@
 
 # Gemini CLI
 
+- name: CLI | Warn about Gemini CLI deprecation
+  ansible.builtin.debug:
+    msg: >
+      ai_gemini_cli_enabled is DEPRECATED and will be removed in v3.0.0.
+      Migrate to Antigravity (ai_antigravity_cli_enabled). See #146.
+  when: ai_gemini_cli_enabled | bool
+
 - name: CLI | Install Gemini CLI from AUR (Arch)
   become: true
   become_user: 'aur_builder'
@@ -54,6 +61,31 @@
     - ai_gemini_cli_enabled | bool
   retries: 3
   delay: 5
+
+# Antigravity CLI
+
+- name: CLI | Install Antigravity CLI from AUR (Arch)
+  become: true
+  become_user: 'aur_builder'
+  kewlfft.aur.aur:
+    name: '{{ __ai_aur_packages.antigravity_cli }}'
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - ai_antigravity_cli_enabled | bool
+  retries: 3
+  delay: 5
+
+- name: CLI | Antigravity CLI not available (non-Arch)
+  ansible.builtin.debug:
+    msg: >
+      Antigravity CLI is only packaged for Arch. Google distributes it as a
+      tarball for {{ ansible_facts['os_family'] }} — download from
+      https://antigravity.google/download/linux
+  when:
+    - ansible_facts['os_family'] != 'Archlinux'
+    - ai_antigravity_cli_enabled | bool
+    - __ai_antigravity_cli_package | default('') | length == 0
 
 # OpenAI Codex
 

--- a/roles/ai/tasks/desktop.yml
+++ b/roles/ai/tasks/desktop.yml
@@ -27,6 +27,31 @@
     - ai_claude_desktop_enabled | bool
     - __ai_claude_desktop_package | length == 0
 
+# Antigravity
+
+- name: Desktop | Install Antigravity from AUR (Arch)
+  become: true
+  become_user: 'aur_builder'
+  kewlfft.aur.aur:
+    name: '{{ __ai_aur_packages.antigravity }}'
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - ai_antigravity_enabled | bool
+  retries: 3
+  delay: 5
+
+- name: Desktop | Antigravity not available (non-Arch)
+  ansible.builtin.debug:
+    msg: >
+      Antigravity is only packaged for Arch. Google distributes it as a tarball
+      for {{ ansible_facts['os_family'] }} — download from
+      https://antigravity.google/download/linux
+  when:
+    - ansible_facts['os_family'] != 'Archlinux'
+    - ai_antigravity_enabled | bool
+    - __ai_antigravity_package | length == 0
+
 # OpenCode Desktop
 
 - name: Desktop | Install OpenCode Desktop from AUR (Arch)

--- a/roles/ai/vars/Archlinux.yml
+++ b/roles/ai/vars/Archlinux.yml
@@ -9,6 +9,8 @@ __ai_aur_packages:
     - claude-code
   gemini_cli:
     - gemini-cli
+  antigravity_cli:
+    - antigravity-cli
   opencode:
     - opencode-bin
   opencode_claude_auth:
@@ -21,6 +23,8 @@ __ai_aur_packages:
     - claude-cowork-service
   claude_desktop:
     - claude-desktop-bin
+  antigravity:
+    - antigravity
   opencode_desktop:
     - opencode-desktop-bin
   lmstudio:

--- a/roles/ai/vars/Debian.yml
+++ b/roles/ai/vars/Debian.yml
@@ -8,9 +8,11 @@ __ai_codex_package: ''
 
 # CLI Tools — AUR-only on Arch, no-op elsewhere
 __ai_claude_cowork_service_package: ''
+__ai_antigravity_cli_package: ''
 
 # Desktop Apps
 __ai_claude_desktop_package: ''
+__ai_antigravity_package: ''
 __ai_opencode_desktop_url: >-
   https://github.com/anomalyco/opencode/releases/latest/download/opencode-desktop-linux-amd64.deb
 

--- a/roles/ai/vars/RedHat.yml
+++ b/roles/ai/vars/RedHat.yml
@@ -8,9 +8,11 @@ __ai_codex_package: ''
 
 # CLI Tools — AUR-only on Arch, no-op elsewhere
 __ai_claude_cowork_service_package: ''
+__ai_antigravity_cli_package: ''
 
 # Desktop Apps
 __ai_claude_desktop_package: ''
+__ai_antigravity_package: ''
 __ai_opencode_desktop_url: >-
   https://github.com/anomalyco/opencode/releases/latest/download/opencode-desktop-linux-x86_64.rpm
 


### PR DESCRIPTION
## Summary

Adds Google Antigravity to the `ai` role as the successor to the soon-to-be subscription-gated Gemini CLI, and marks `ai_gemini_cli_enabled` deprecated ahead of hard removal in v3.0.0.

## Changes

- New toggle `ai_antigravity_cli_enabled` (default `false`) — installs the Antigravity CLI companion.
- New toggle `ai_antigravity_enabled` (default `false`) — installs the Antigravity desktop IDE.
- `ai_gemini_cli_enabled` remains functional but is now surfaced as deprecated in three places: a `defaults/main.yml` comment, a README note, and a runtime debug warning that fires when the toggle is enabled — all pointing to the v3.0.0 removal (#146).
- README CLI and Desktop tables updated; role description mentions Antigravity.
- Molecule `converge.yml` lists both new toggles in the CI-disabled set.

## Install paths

- Arch: AUR `antigravity-cli` and `antigravity` via `kewlfft.aur.aur`.
- Debian / RHEL: no-op package var plus a debug message pointing to the upstream tarball download. Google distributes Antigravity only as tarballs (no apt/dnf repo, no npm package for the CLI), so this follows the existing Arch-only pattern used by Claude Desktop and LM Studio.

## Testing

- `yamllint roles/ai/` — clean.
- `ansible-lint roles/ai/` — passed (`production` profile, 0 failures).
- `markdownlint-cli2 roles/ai/README.md` (v0.22.1, CI engine) — 0 errors.
- `molecule test -p ai-archlinux` (default scenario, toggles off) — converge, idempotence, verify all successful.
- Temporary Arch scenario with both Antigravity toggles enabled — AUR `antigravity` and `antigravity-cli` build and install; `pacman -Q` confirms both packages, `/usr/bin/antigravity` and `/usr/bin/agy` present; idempotent.

Closes #145
