### PR TITLE
fix(ai): use native PyTorch for ComfyUI, fail fast on unsupported OS

### DIFF
--- a/roles/ai/README.md
+++ b/roles/ai/README.md
@@ -99,11 +99,18 @@ API keys are managed by the user via environment variables (not by this role).
   systemd unit. Inventory variables marked *(manual path only)* in the
   table above are **not honored** on Arch — they are fixed by the AUR
   PKGBUILD.
-- **Debian / Rocky Linux**: from-source install. The role creates the
-  service user/group, clones the upstream ComfyUI repo to
-  `ai_comfyui_install_dir`, builds a Python virtual environment, and
-  installs PyTorch wheels selected by `ai_comfyui_gpu`. All variables
-  above apply.
+- **Debian** (`ai_comfyui_gpu: nvidia` or `cpu`): from-source install with
+  native PyTorch. The role installs `python3-torch-cuda` (nvidia) or
+  `python3-torch` (cpu) plus `python3-torchvision` and `python3-torchaudio`
+  from Debian's repositories, then builds a `--system-site-packages` venv so
+  ComfyUI sees them. ComfyUI's own requirements are installed into the venv;
+  torch is already satisfied by the native packages. All *(manual path only)*
+  variables above apply.
+- **Debian with `ai_comfyui_gpu: amd`, and all Rocky Linux / EL hosts**:
+  **unsupported**. No complete native PyTorch stack
+  (torch/torchvision/torchaudio) is packaged there, and the upstream pip wheel
+  index is fragile against Python version drift. The role fails fast with a
+  clear message (see issue #122). Use Arch Linux for AMD/ROCm.
 
 **ComfyUI-Manager** is installed via manual git-clone on both paths
 because no upstream package exists yet (see `tasks/comfyui-archlinux.yml`

--- a/roles/ai/defaults/main.yml
+++ b/roles/ai/defaults/main.yml
@@ -80,7 +80,8 @@ ai_lmstudio_enabled: false
 
 # Enable ComfyUI (Stable Diffusion node-based UI)
 ai_comfyui_enabled: false
-# GPU backend (nvidia or amd)
+# GPU backend: 'nvidia', 'amd', or 'cpu' (amd is Arch-only — Debian has no
+# native ROCm PyTorch package; see README)
 ai_comfyui_gpu: 'nvidia'
 # Git branch/tag
 ai_comfyui_version: 'master'

--- a/roles/ai/molecule/comfyui/converge.yml
+++ b/roles/ai/molecule/comfyui/converge.yml
@@ -1,0 +1,30 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+
+  vars:
+    ai_enabled: true
+
+    # Only ComfyUI under test — CPU backend (no CUDA download) with the
+    # service left stopped (we verify the install, not the runtime).
+    ai_claude_code_enabled: false
+    ai_gemini_cli_enabled: false
+    ai_antigravity_cli_enabled: false
+    ai_codex_enabled: false
+    ai_opencode_enabled: false
+    ai_aider_enabled: false
+    ai_claude_cowork_service_enabled: false
+    ai_claude_desktop_enabled: false
+    ai_antigravity_enabled: false
+    ai_opencode_desktop_enabled: false
+    ai_ollama_enabled: false
+    ai_lmstudio_enabled: false
+    ai_comfyui_enabled: true
+    ai_comfyui_gpu: 'cpu'
+    ai_comfyui_service_enabled: false
+
+  tasks:
+    - name: Converge | Include ai role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'

--- a/roles/ai/molecule/comfyui/molecule.yml
+++ b/roles/ai/molecule/comfyui/molecule.yml
@@ -1,0 +1,37 @@
+---
+driver:
+  name: podman
+platforms:
+  - name: comfyui-debian-trixie
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      /run: rw,nosuid,nodev,size=65536k
+      /tmp: rw,nosuid,nodev
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    prepare: prepare.yml
+    verify: verify.yml
+  config_options:
+    defaults:
+      allow_broken_conditionals: true
+  inventory:
+    host_vars:
+      comfyui-debian-trixie:
+        ansible_python_interpreter: /usr/bin/python3
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/roles/ai/molecule/comfyui/prepare.yml
+++ b/roles/ai/molecule/comfyui/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Prepare | Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+      changed_when: false

--- a/roles/ai/molecule/comfyui/verify.yml
+++ b/roles/ai/molecule/comfyui/verify.yml
@@ -1,0 +1,34 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+
+  vars:
+    comfyui_install_dir: /opt/comfyui
+
+  tasks:
+    - name: Verify | Stat venv interpreter and systemd unit
+      ansible.builtin.stat:
+        path: '{{ item }}'
+      loop:
+        - '{{ comfyui_install_dir }}/venv/bin/python'
+        - /etc/systemd/system/comfyui.service
+      register: __verify_paths
+
+    - name: Verify | Import the torch stack from the venv
+      ansible.builtin.command:
+        cmd: >-
+          {{ comfyui_install_dir }}/venv/bin/python
+          -c "import torch, torchvision, torchaudio"
+      changed_when: false
+      register: __verify_import
+
+    - name: Verify | Assert install succeeded
+      ansible.builtin.assert:
+        that:
+          - __verify_paths.results | selectattr('stat.exists') | list | length == 2
+          - __verify_import.rc == 0
+        fail_msg: 'ComfyUI venv, systemd unit, or native torch stack missing'
+        success_msg: >-
+          ComfyUI installed; native torch/torchvision/torchaudio importable
+          from the --system-site-packages venv

--- a/roles/ai/tasks/comfyui-other.yml
+++ b/roles/ai/tasks/comfyui-other.yml
@@ -1,17 +1,50 @@
 ---
 #
-# ComfyUI install — manual flow (Debian, Rocky Linux)
+# ComfyUI install — manual flow (Debian)
 #
 # On Arch, the AUR `comfyui` package is used instead — see
-# `comfyui-archlinux.yml`. This file performs a from-source install:
-# create service user/group, clone repo, build a Python venv, install
-# PyTorch wheels matching `ai_comfyui_gpu`, then deploy a project-owned
+# `comfyui-archlinux.yml`. This manual flow is supported only on Debian with
+# `ai_comfyui_gpu` set to `nvidia` or `cpu`, where PyTorch ships as native
+# `python3-torch{,-cuda}` packages. It creates the service user/group, clones
+# the repo, builds a `--system-site-packages` venv (so the native PyTorch is
+# visible), installs the remaining requirements, and deploys a project-owned
 # systemd unit.
+#
+# Unsupported combinations fail fast: AMD/ROCm on Debian (no ROCm package) and
+# all RedHat-family hosts (no complete native torch/torchvision/torchaudio
+# stack in EPEL). The upstream pip wheel index is intentionally avoided — it is
+# fragile against Python version drift. See issue #122.
+
+- name: ComfyUI | Assert manual install is supported on this platform
+  ansible.builtin.assert:
+    that:
+      - ansible_facts['os_family'] == 'Debian'
+      - ai_comfyui_gpu in ['nvidia', 'cpu']
+    fail_msg: >-
+      Manual ComfyUI install is only supported on Debian with ai_comfyui_gpu
+      'nvidia' or 'cpu' (native python3-torch packages).
+      {{ ansible_facts['distribution'] }} with ai_comfyui_gpu
+      '{{ ai_comfyui_gpu }}' has no complete native PyTorch stack
+      (torch/torchvision/torchaudio), and the upstream pip wheel index is
+      unreliable against Python version drift. See
+      https://github.com/marcstraube/ansible-collection-desktop/issues/122.
+      Arch Linux installs ComfyUI via the AUR comfyui package instead.
+    success_msg: >-
+      Debian / ai_comfyui_gpu '{{ ai_comfyui_gpu }}' — installing PyTorch from
+      native python3-torch packages.
 
 - name: ComfyUI | Install ComfyUI system dependencies
   become: true
   ansible.builtin.package:
     name: '{{ __ai_comfyui_venv_packages }}'
+    state: present
+  retries: 3
+  delay: 5
+
+- name: ComfyUI | Install native PyTorch packages
+  become: true
+  ansible.builtin.package:
+    name: '{{ __ai_comfyui_torch_packages[ai_comfyui_gpu] }}'
     state: present
   retries: 3
   delay: 5
@@ -53,42 +86,19 @@
   retries: 5
   delay: 10
 
+# The venv is built with --system-site-packages so the native PyTorch packages
+# installed above are visible inside it.
 - name: ComfyUI | Create ComfyUI Python virtual environment
   become: true
   become_user: '{{ ai_comfyui_user }}'
   ansible.builtin.command:
-    cmd: '{{ __ai_comfyui_python }} -m venv venv'
+    cmd: '{{ __ai_comfyui_python }} -m venv --system-site-packages venv'
     chdir: '{{ ai_comfyui_install_dir }}'
     creates: '{{ ai_comfyui_install_dir }}/venv/bin/activate'
 
-- name: ComfyUI | Install PyTorch (NVIDIA CUDA)
-  become: true
-  become_user: '{{ ai_comfyui_user }}'
-  ansible.builtin.pip:
-    name:
-      - torch
-      - torchvision
-      - torchaudio
-    extra_args: '--index-url https://download.pytorch.org/whl/cu126'
-    virtualenv: '{{ ai_comfyui_install_dir }}/venv'
-  when: ai_comfyui_gpu == 'nvidia'
-  retries: 3
-  delay: 5
-
-- name: ComfyUI | Install PyTorch (AMD ROCm)
-  become: true
-  become_user: '{{ ai_comfyui_user }}'
-  ansible.builtin.pip:
-    name:
-      - torch
-      - torchvision
-      - torchaudio
-    extra_args: '--index-url https://download.pytorch.org/whl/rocm6.2.4'
-    virtualenv: '{{ ai_comfyui_install_dir }}/venv'
-  when: ai_comfyui_gpu == 'amd'
-  retries: 3
-  delay: 5
-
+# ComfyUI's requirements.txt lists torch/torchvision/torchaudio unpinned. With
+# the native packages visible via --system-site-packages, pip treats them as
+# already satisfied and does not pull wheels from PyPI.
 - name: ComfyUI | Install ComfyUI requirements
   become: true
   become_user: '{{ ai_comfyui_user }}'

--- a/roles/ai/vars/Debian.yml
+++ b/roles/ai/vars/Debian.yml
@@ -30,3 +30,16 @@ __ai_comfyui_venv_packages:
   - 'python3-venv'
   - 'python3-pip'
   - 'git'
+
+# ComfyUI — native PyTorch packages (manual install flow). torchvision and
+# torchaudio are GPU-agnostic; only the base torch package differs by backend.
+# AMD/ROCm has no Debian package, so it is rejected in comfyui-other.yml.
+__ai_comfyui_torch_packages:
+  nvidia:
+    - 'python3-torch-cuda'
+    - 'python3-torchvision'
+    - 'python3-torchaudio'
+  cpu:
+    - 'python3-torch'
+    - 'python3-torchvision'
+    - 'python3-torchaudio'

--- a/roles/ai/vars/RedHat.yml
+++ b/roles/ai/vars/RedHat.yml
@@ -23,9 +23,7 @@ __ai_lmstudio_package: ''
 # Service names
 __ai_ollama_service: 'ollama.service'
 
-# ComfyUI
-__ai_comfyui_python: 'python3'
-__ai_comfyui_venv_packages:
-  - 'python3'
-  - 'python3-pip'
-  - 'git'
+# ComfyUI is not supported on RedHat-family hosts: no complete native PyTorch
+# stack (torch/torchvision/torchaudio) exists in EPEL, and the upstream pip
+# wheel index is fragile against Python version drift. comfyui-other.yml fails
+# fast with a clear message. See issue #122.


### PR DESCRIPTION
## Summary

Fixes the fragile PyTorch wheel selection in the manual ComfyUI install (Debian, RedHat). The role pulled PyTorch from hardcoded pip wheel index URLs (`cu126` / `rocm6.2.4`) that only publish wheels for specific Python versions, so a newer target Python aborted with `No matching distribution found for torch`.

## Changes

- **Debian (`nvidia`/`cpu`)**: install PyTorch from native packages — `python3-torch-cuda` or `python3-torch`, plus `python3-torchvision` and `python3-torchaudio`. The venv is built with `--system-site-packages` so ComfyUI sees them; torch is unpinned in ComfyUI's `requirements.txt` and treated as already satisfied.
- **Fail fast on unsupported combinations**: AMD/ROCm on Debian (no ROCm package) and all RedHat-family hosts (no complete `torch`/`torchvision`/`torchaudio` stack in EPEL) now abort with a clear assertion linking this issue, instead of a cryptic pip error.
- **Arch**: unchanged (AUR `comfyui` package).
- Removed the now-dead ComfyUI vars from `vars/RedHat.yml`.
- Added a `comfyui` molecule scenario covering the Debian `cpu` path. Desktop CI runs only the `default` scenario today; running non-default scenarios is tracked in #169.

## Testing

- `yamllint roles/ai/` — clean.
- `ansible-lint roles/ai/` — passed (`production` profile, 0 failures).
- `markdownlint-cli2 roles/ai/README.md` (v0.22.1) — 0 errors.
- `molecule test -s comfyui` (Debian Trixie, `ai_comfyui_gpu: cpu`) — converge, idempotence, and verify all successful. Verify confirms the venv, the systemd unit, and that `import torch, torchvision, torchaudio` works from the `--system-site-packages` venv.
- `molecule test -p ai-archlinux` (default scenario) — unaffected, passes.

The fail-fast assertion path (RedHat / Debian amd) is not enabled in any scenario and is therefore not exercised in CI; the assertion logic is straightforward.

Closes #122
