### PR TITLE
chore(pre-commit): bump markdownlint-cli2 hook to v0.23.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
   # MARKDOWN
   # =============================================================================
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.22.1
+    rev: v0.23.0
     hooks:
       - id: markdownlint-cli2
         name: Markdown Lint


### PR DESCRIPTION
Closes #171

Aligns the local pre-commit `markdownlint-cli2` hook with the CI `markdownlint-cli2-action` v24 bump (#167), which bundles markdownlint-cli2 v0.23.0 (markdownlint v0.41.0). Without this, local pre-commit (v0.22.1) and CI (v0.23.0) would lint with different engine versions.

The cli2 v0.23.0 `engines` field still requires `node >=22`, so `language_version` stays at `22.22.0`.

## Test plan

- [x] markdownlint-cli2 v0.23.0 passes on all current Markdown files (verified locally, 31 files, 0 errors)
