### PR TITLE
feat(roles): add minor-version level to with_first_found vars lookup

### DIFF
--- a/roles/ai/tasks/main.yml
+++ b/roles/ai/tasks/main.yml
@@ -7,6 +7,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/bluetooth/tasks/main.yml
+++ b/roles/bluetooth/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/browser/tasks/main.yml
+++ b/roles/browser/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/cad/tasks/main.yml
+++ b/roles/cad/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/communication/tasks/main.yml
+++ b/roles/communication/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/desktop_environment/tasks/main.yml
+++ b/roles/desktop_environment/tasks/main.yml
@@ -7,6 +7,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -29,6 +29,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/display_manager/tasks/main.yml
+++ b/roles/display_manager/tasks/main.yml
@@ -7,6 +7,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/downloads/tasks/main.yml
+++ b/roles/downloads/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/elgato/tasks/main.yml
+++ b/roles/elgato/tasks/main.yml
@@ -7,6 +7,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/filemanagers/tasks/main.yml
+++ b/roles/filemanagers/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/gaming/tasks/main.yml
+++ b/roles/gaming/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/graphics_apps/tasks/main.yml
+++ b/roles/graphics_apps/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/imaging/tasks/main.yml
+++ b/roles/imaging/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/multimedia/tasks/main.yml
+++ b/roles/multimedia/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/office/tasks/main.yml
+++ b/roles/office/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/pipewire/tasks/main.yml
+++ b/roles/pipewire/tasks/main.yml
@@ -7,6 +7,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/plymouth/tasks/main.yml
+++ b/roles/plymouth/tasks/main.yml
@@ -7,6 +7,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/remote_access/tasks/main.yml
+++ b/roles/remote_access/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/security_apps/tasks/main.yml
+++ b/roles/security_apps/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/system_apps/tasks/main.yml
+++ b/roles/system_apps/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/terminal/tasks/main.yml
+++ b/roles/terminal/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/tuxedo/tasks/main.yml
+++ b/roles/tuxedo/tasks/main.yml
@@ -7,6 +7,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/wayland_utils/tasks/main.yml
+++ b/roles/wayland_utils/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/wine/tasks/main.yml
+++ b/roles/wine/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'


### PR DESCRIPTION
## Summary

Extend the `with_first_found` OS-vars lookup in every role's `tasks/main.yml` with a new minor-version layer (`{distribution}-{distribution_version}.yml`, e.g. `Rocky-10.3.yml`), inserted at the top of the `files:` list. This lets a role ship per-minor-version overrides when EPEL/AppStream package availability changes within a major version.

Mirrors the merged pilot in common: marcstraube/ansible-collection-common#206.

Purely additive: no role in this collection ships a minor-version vars file, so the new lookup falls through to the existing major-version / distribution / os_family files. Behaviour for existing consumers is unchanged.

## Scope

- 25 roles carrying an OS-vars `with_first_found` block in `tasks/main.yml` now include the new lookup line.
- `keepassxc` and `xdg_user_dirs` have no OS-vars lookup and are correctly excluded, matching the common scope.
- No `docs/role-template.md` exists in this collection, so the documentation step does not apply here.

## Test plan

- [x] Audit: grep confirms all 25 affected roles now carry the new lookup line at the top of the `files:` list
- [x] `ansible-lint --profile=production --offline`: 0 failures, 0 warnings across 454 files
- [x] `molecule test -p terminal-archlinux` on `roles/terminal`: converge + idempotence + verify all successful; vars lookup falls through to the existing `Archlinux.yml` (no `Archlinux-*.yml` minor file exists), behaviour unchanged

Closes #117