### PR TITLE
test(xdg_user_dirs): cover initial and disabled modes in molecule

### DIFF
--- a/roles/xdg_user_dirs/molecule/default/converge.yml
+++ b/roles/xdg_user_dirs/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Converge | Managed mode
   hosts: all
   gather_facts: true
 
@@ -20,6 +20,67 @@
     xdg_user_dirs_user_config_mode: 'managed'
     xdg_user_dirs_users:
       - username: 'xdg_test_user'
+      - username: 'xdg_disabled_user'
+        mode: 'disabled'
+
+  tasks:
+    - name: Converge | Include xdg_user_dirs role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Initial mode (per-user gating)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    xdg_user_dirs_enabled: true
+    xdg_user_dirs_locale: 'en_US.UTF-8'
+    xdg_user_dirs_user_config_mode: 'initial'
+    xdg_user_dirs_users:
+      - username: 'xdg_initial_new'
+      - username: 'xdg_initial_exist'
+
+  pre_tasks:
+    - name: Converge | Ensure existing-user config dir exists
+      ansible.builtin.file:
+        path: /home/xdg_initial_exist/.config
+        state: directory
+        owner: xdg_initial_exist
+        group: xdg_initial_exist
+        mode: '0700'
+
+    - name: Converge | Pre-seed existing user-dirs.dirs to prove it is left untouched
+      ansible.builtin.copy:
+        content: |
+          # molecule-fixture: pre-existing user content
+          XDG_DESKTOP_DIR="$HOME/PreexistingDesktop"
+        dest: /home/xdg_initial_exist/.config/user-dirs.dirs
+        owner: xdg_initial_exist
+        group: xdg_initial_exist
+        mode: '0600'
+
+    - name: Converge | Mark only xdg_initial_new as newly created
+      ansible.builtin.set_fact:
+        __users_newly_created:
+          - 'xdg_initial_new'
+
+  tasks:
+    - name: Converge | Include xdg_user_dirs role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Disabled mode (global)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    xdg_user_dirs_enabled: true
+    xdg_user_dirs_locale: 'en_US.UTF-8'
+    xdg_user_dirs_user_config_mode: 'disabled'
+    xdg_user_dirs_users:
+      - username: 'xdg_global_disabled'
 
   tasks:
     - name: Converge | Include xdg_user_dirs role  # noqa: role-name[path]

--- a/roles/xdg_user_dirs/molecule/default/prepare.yml
+++ b/roles/xdg_user_dirs/molecule/default/prepare.yml
@@ -67,15 +67,26 @@
         validate: 'visudo -cf %s'
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Prepare | Create test user
+    - name: Prepare | Create test users
       ansible.builtin.user:
-        name: xdg_test_user
+        name: '{{ item }}'
         create_home: true
         shell: /bin/bash
         # Real sha512 password hash. Required so PAM account management
-        # accepts root → xdg_test_user become in containerised Rocky
-        # under GitHub-hosted runners (locked accounts and `*` placeholder
-        # both fail pam_unix account check with "Authentication service
-        # cannot retrieve authentication info").
+        # accepts root → user become in containerised Rocky under
+        # GitHub-hosted runners (locked accounts and `*` placeholder both
+        # fail pam_unix account check with "Authentication service cannot
+        # retrieve authentication info").
         password: "{{ 'molecule-xdg-test-noop' | password_hash('sha512') }}"
         update_password: 'on_create'
+      loop:
+        # Play 1 (managed): reconciled user + per-user disabled override
+        - xdg_test_user
+        - xdg_disabled_user
+        # Play 2 (initial): newly-created (touched) + existing (untouched)
+        - xdg_initial_new
+        - xdg_initial_exist
+        # Play 3 (disabled, global): never touched
+        - xdg_global_disabled
+      loop_control:
+        label: '{{ item }}'

--- a/roles/xdg_user_dirs/molecule/default/verify.yml
+++ b/roles/xdg_user_dirs/molecule/default/verify.yml
@@ -102,3 +102,103 @@
         that:
           - not __xdg_templates.stat.exists
         fail_msg: 'Templates directory created despite being in skip list'
+
+    #
+    # Managed Mode — Per-User Disabled Override (xdg_disabled_user)
+    #
+    # Entry-level mode=disabled overrides the managed global mode
+    # → role MUST NOT deploy any config for this user.
+    #
+
+    - name: Verify | Check per-user-disabled user has no user-dirs.dirs
+      ansible.builtin.stat:
+        path: /home/xdg_disabled_user/.config/user-dirs.dirs
+      register: __xdg_disabled_dirs
+
+    - name: Verify | Assert per-user-disabled user has no config
+      ansible.builtin.assert:
+        that:
+          - not __xdg_disabled_dirs.stat.exists
+        fail_msg: 'user-dirs.dirs deployed for a per-user-disabled entry'
+
+    #
+    # Initial Mode — Newly Created User (xdg_initial_new)
+    #
+    # xdg_user_dirs_user_config_mode=initial + user IN __users_newly_created
+    # → role MUST deploy the config (dirs file + freeze file).
+    #
+
+    - name: Verify | Check initial-new user user-dirs.dirs exists
+      ansible.builtin.stat:
+        path: /home/xdg_initial_new/.config/user-dirs.dirs
+      register: __xdg_initialnew_dirs
+
+    - name: Verify | Assert initial-new user config is deployed
+      ansible.builtin.assert:
+        that:
+          - __xdg_initialnew_dirs.stat.exists
+          - __xdg_initialnew_dirs.stat.pw_name == 'xdg_initial_new'
+        fail_msg: 'user-dirs.dirs not deployed for newly-created initial-mode user'
+
+    - name: Verify | Check initial-new user freeze file exists
+      ansible.builtin.stat:
+        path: /home/xdg_initial_new/.config/user-dirs.conf
+      register: __xdg_initialnew_conf
+
+    - name: Verify | Assert initial-new user freeze file is deployed
+      ansible.builtin.assert:
+        that:
+          - __xdg_initialnew_conf.stat.exists
+        fail_msg: 'user-dirs.conf freeze not deployed for newly-created initial-mode user'
+
+    #
+    # Initial Mode — Existing User (xdg_initial_exist)
+    #
+    # xdg_user_dirs_user_config_mode=initial + user NOT IN __users_newly_created
+    # → role MUST leave the pre-existing user-dirs.dirs untouched and MUST
+    #   NOT create the freeze file.
+    #
+
+    - name: Verify | Read initial-exist user user-dirs.dirs
+      ansible.builtin.slurp:
+        src: /home/xdg_initial_exist/.config/user-dirs.dirs
+      register: __xdg_initialexist_dirs
+
+    - name: Verify | Assert initial-exist user config is unchanged
+      ansible.builtin.assert:
+        that:
+          - >-
+            'molecule-fixture: pre-existing user content'
+            in (__xdg_initialexist_dirs.content | b64decode)
+          - "'PreexistingDesktop' in (__xdg_initialexist_dirs.content | b64decode)"
+          - "'XDG_MEDIA_DIR=' not in (__xdg_initialexist_dirs.content | b64decode)"
+        fail_msg: 'pre-existing user-dirs.dirs was modified for existing initial-mode user'
+
+    - name: Verify | Check initial-exist user freeze file absent
+      ansible.builtin.stat:
+        path: /home/xdg_initial_exist/.config/user-dirs.conf
+      register: __xdg_initialexist_conf
+
+    - name: Verify | Assert initial-exist user freeze file absent
+      ansible.builtin.assert:
+        that:
+          - not __xdg_initialexist_conf.stat.exists
+        fail_msg: 'freeze file created for existing initial-mode user (should be untouched)'
+
+    #
+    # Disabled Mode — Global (xdg_global_disabled)
+    #
+    # xdg_user_dirs_user_config_mode=disabled
+    # → role MUST NOT deploy any config for any user.
+    #
+
+    - name: Verify | Check global-disabled user has no user-dirs.dirs
+      ansible.builtin.stat:
+        path: /home/xdg_global_disabled/.config/user-dirs.dirs
+      register: __xdg_globaldisabled_dirs
+
+    - name: Verify | Assert global-disabled user has no config
+      ansible.builtin.assert:
+        that:
+          - not __xdg_globaldisabled_dirs.stat.exists
+        fail_msg: 'user-dirs.dirs deployed despite global disabled mode'


### PR DESCRIPTION
## Summary

Extend the `xdg_user_dirs` molecule `default` scenario from managed-only coverage to all three `user_config_mode` paths, mirroring the canonical editors pattern (marcstraube/ansible-collection-common#209).

Test-only change: no role logic is modified.

## Coverage added

- **managed:** the reconciled user (existing assertions) plus a new per-user `mode: disabled` override entry, verifying entry-level mode wins over the global mode (no config deployed for that user).
- **initial:** a newly-created user (present in `__users_newly_created` → config + freeze file deployed) versus an existing user (pre-seeded `user-dirs.dirs` left untouched, no freeze file created).
- **disabled (global):** no per-user config deployed for any user.

## Implementation notes

- Test users are created in `prepare.yml` (with the sha512 password hash the role's `become_user` needs on the Rocky containers), consistent with the existing `xdg_test_user` fixture.
- The existing-user no-touch case pre-seeds `~/.config/user-dirs.dirs` with a fixture marker and asserts both the marker survives and the role's own markers (`XDG_MEDIA_DIR`, freeze file) are absent.

## Test plan

- [x] `ansible-lint --profile=production --offline` on `roles/xdg_user_dirs`: 0 failures, 0 warnings
- [x] `molecule test -p xdg-user-dirs-archlinux`: converge (3 plays) + idempotence + verify all successful (28 ok, 0 failed)

References #119