### PR TITLE
test(keepassxc): cover initial and disabled modes in molecule

### DIFF
--- a/roles/keepassxc/molecule/default/converge.yml
+++ b/roles/keepassxc/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Converge | Managed mode
   hosts: all
   gather_facts: true
 
@@ -8,9 +8,75 @@
     keepassxc_secret_service_enabled: true
     keepassxc_secret_service_scope: 'global'  # pragma: allowlist secret
     keepassxc_autostart_enabled: true
+    keepassxc_user_config_mode: 'managed'
     keepassxc_users:
       - name: 'testuser'
         mode: 'managed'
+      - name: 'kp_disabled_user'
+        mode: 'disabled'
+
+  tasks:
+    - name: Converge | Include keepassxc role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+# initial mode is gated on keepassxc.ini existence (not __users_newly_created):
+# deploy only when the file is absent, leaving an existing config untouched.
+# autostart / secret_service are independent per-user opt-outs and are
+# disabled here so the play exercises the config-mode path in isolation.
+- name: Converge | Initial mode (existing-file gating)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    keepassxc_enabled: true
+    keepassxc_secret_service_enabled: false
+    keepassxc_autostart_enabled: false
+    keepassxc_user_config_mode: 'initial'
+    keepassxc_users:
+      - name: 'kp_initial_fresh'
+      - name: 'kp_initial_exist'
+
+  pre_tasks:
+    - name: Converge | Ensure existing-user config dir exists
+      ansible.builtin.file:
+        path: /home/kp_initial_exist/.config/keepassxc
+        state: directory
+        owner: kp_initial_exist
+        group: kp_initial_exist
+        mode: '0700'
+
+    - name: Converge | Pre-seed existing keepassxc.ini to prove it is left untouched
+      ansible.builtin.copy:
+        content: |
+          [General]
+          ConfigVersion=99
+
+          [MoleculeFixture]
+          preexisting=true
+        dest: /home/kp_initial_exist/.config/keepassxc/keepassxc.ini
+        owner: kp_initial_exist
+        group: kp_initial_exist
+        mode: '0600'
+
+  tasks:
+    - name: Converge | Include keepassxc role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Disabled mode (global)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    keepassxc_enabled: true
+    keepassxc_secret_service_enabled: false
+    keepassxc_autostart_enabled: false
+    keepassxc_user_config_mode: 'disabled'
+    keepassxc_users:
+      - name: 'kp_global_disabled'
 
   tasks:
     - name: Converge | Include keepassxc role  # noqa: role-name[path]

--- a/roles/keepassxc/molecule/default/prepare.yml
+++ b/roles/keepassxc/molecule/default/prepare.yml
@@ -44,8 +44,19 @@
         validate: 'visudo -cf %s'
       when: ansible_facts['os_family'] == 'Archlinux'
 
-    - name: Prepare | Create test user
+    - name: Prepare | Create test users
       ansible.builtin.user:
-        name: testuser
+        name: '{{ item }}'
         create_home: true
         shell: /bin/bash
+      loop:
+        # Play 1 (managed): reconciled user + per-user disabled override
+        - testuser
+        - kp_disabled_user
+        # Play 2 (initial): no existing ini (deployed) + existing ini (untouched)
+        - kp_initial_fresh
+        - kp_initial_exist
+        # Play 3 (disabled, global): never deployed
+        - kp_global_disabled
+      loop_control:
+        label: '{{ item }}'

--- a/roles/keepassxc/molecule/default/verify.yml
+++ b/roles/keepassxc/molecule/default/verify.yml
@@ -138,3 +138,91 @@
         fail_msg: 'XDG autostart entry missing required Desktop Entry keys or tray-readiness hints'
       vars:
         __autostart_text: '{{ _keepassxc_autostart_content.content | b64decode }}'
+
+    #
+    # Managed Mode — Per-User Disabled Override (kp_disabled_user)
+    #
+    # Entry-level mode=disabled overrides the managed global mode
+    # → role MUST NOT deploy keepassxc.ini for this user.
+    #
+
+    - name: Verify | Check per-user-disabled user has no keepassxc.ini
+      ansible.builtin.stat:
+        path: '/home/kp_disabled_user/.config/keepassxc/keepassxc.ini'
+      register: _keepassxc_disabled_ini
+
+    - name: Verify | Assert per-user-disabled user has no config
+      ansible.builtin.assert:
+        that:
+          - not _keepassxc_disabled_ini.stat.exists
+        fail_msg: 'keepassxc.ini deployed for a per-user-disabled entry'
+
+    #
+    # Initial Mode — No Existing Config (kp_initial_fresh)
+    #
+    # keepassxc_user_config_mode=initial + keepassxc.ini absent
+    # → role MUST deploy the config.
+    #
+
+    - name: Verify | Check initial-fresh user keepassxc.ini exists
+      ansible.builtin.stat:
+        path: '/home/kp_initial_fresh/.config/keepassxc/keepassxc.ini'
+      register: _keepassxc_initialfresh_ini
+
+    - name: Verify | Assert initial-fresh user config is deployed
+      ansible.builtin.assert:
+        that:
+          - _keepassxc_initialfresh_ini.stat.exists
+          - _keepassxc_initialfresh_ini.stat.pw_name == 'kp_initial_fresh'
+          - _keepassxc_initialfresh_ini.stat.mode == '0600'
+        fail_msg: 'keepassxc.ini not deployed for initial-mode user without existing config'
+
+    - name: Verify | Read initial-fresh user keepassxc.ini
+      ansible.builtin.slurp:
+        src: '/home/kp_initial_fresh/.config/keepassxc/keepassxc.ini'
+      register: _keepassxc_initialfresh_content
+
+    - name: Verify | Assert initial-fresh user config has template values
+      ansible.builtin.assert:
+        that:
+          - "'ConfigVersion=2' in (_keepassxc_initialfresh_content.content | b64decode)"
+          - "'[Security]' in (_keepassxc_initialfresh_content.content | b64decode)"
+        fail_msg: 'initial-fresh keepassxc.ini missing expected template values'
+
+    #
+    # Initial Mode — Existing Config (kp_initial_exist)
+    #
+    # keepassxc_user_config_mode=initial + keepassxc.ini already present
+    # → role MUST leave the existing config untouched (no overwrite).
+    #
+
+    - name: Verify | Read initial-exist user keepassxc.ini
+      ansible.builtin.slurp:
+        src: '/home/kp_initial_exist/.config/keepassxc/keepassxc.ini'
+      register: _keepassxc_initialexist_content
+
+    - name: Verify | Assert initial-exist user config is unchanged
+      ansible.builtin.assert:
+        that:
+          - "'ConfigVersion=99' in (_keepassxc_initialexist_content.content | b64decode)"
+          - "'[MoleculeFixture]' in (_keepassxc_initialexist_content.content | b64decode)"
+          - "'preexisting=true' in (_keepassxc_initialexist_content.content | b64decode)"
+        fail_msg: 'pre-existing keepassxc.ini was overwritten for existing initial-mode user'
+
+    #
+    # Disabled Mode — Global (kp_global_disabled)
+    #
+    # keepassxc_user_config_mode=disabled
+    # → role MUST NOT deploy keepassxc.ini for any user.
+    #
+
+    - name: Verify | Check global-disabled user has no keepassxc.ini
+      ansible.builtin.stat:
+        path: '/home/kp_global_disabled/.config/keepassxc/keepassxc.ini'
+      register: _keepassxc_globaldisabled_ini
+
+    - name: Verify | Assert global-disabled user has no config
+      ansible.builtin.assert:
+        that:
+          - not _keepassxc_globaldisabled_ini.stat.exists
+        fail_msg: 'keepassxc.ini deployed despite global disabled mode'


### PR DESCRIPTION
## Summary

Extend the `keepassxc` molecule `default` scenario from managed-only coverage to all three `user_config_mode` paths.

Test-only change: no role logic is modified.

## Coverage added

- **managed:** the reconciled user (existing assertions) plus a new per-user `mode: disabled` override entry, verifying entry-level mode wins over the global mode (no `keepassxc.ini` deployed for that user).
- **initial:** a user without an existing `keepassxc.ini` (config deployed) versus a user with a pre-seeded `keepassxc.ini` (left untouched).
- **disabled (global):** no `keepassxc.ini` deployed for any user.

## Implementation notes

- `keepassxc` gates initial mode on `keepassxc.ini` existence rather than the `__users_newly_created` fact used by the canonical editors pattern; the tests assert that role-specific behaviour.
- `autostart` and `secret_service` are independent per-user opt-outs (not tied to `user_config_mode`) and are disabled in the initial and disabled plays so those plays exercise the config-mode path in isolation.

## Test plan

- [x] `ansible-lint --profile=production --offline` on `roles/keepassxc`: 0 failures, 0 warnings
- [x] `molecule test -p keepassxc-archlinux`: converge (3 plays) + idempotence + verify all successful (24 ok, 0 failed)

References #119