### PR TITLE
test(wine): cover initial and disabled modes in molecule

### DIFF
--- a/roles/wine/molecule/default/converge.yml
+++ b/roles/wine/molecule/default/converge.yml
@@ -1,5 +1,9 @@
 ---
-- name: Converge
+# Wine is a documented no-op on Rocky 9 / EL 9 (EPEL wine dependency drift,
+# see desktop#163), so wineboot is unavailable there. The per-user mode test
+# therefore clears wine_users on RedHat: the role still runs (env file), but
+# no prefix initialization is attempted. Mode coverage runs on Arch + Debian.
+- name: Converge | Managed mode
   hosts: all
   gather_facts: true
 
@@ -9,8 +13,89 @@
     wine_vulkan_driver: 'none'
     # Multilib may not be available in containers
     wine_lib32_packages: []
-    # No user prefix initialization in containers
-    wine_users: []
+    wine_user_config_mode: 'managed'
+    wine_users:
+      - username: 'wine_managed_user'
+      - username: 'wine_disabled_user'
+        mode: 'disabled'
+
+  pre_tasks:
+    - name: Converge | Clear test users where wine is unavailable (RedHat)
+      ansible.builtin.set_fact:
+        wine_users: []
+      when: ansible_facts['os_family'] == 'RedHat'
+
+  tasks:
+    - name: Converge | Include wine role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+# initial mode is gated on wine-prefix existence (system.reg) rather than
+# the __users_newly_created fact: wineboot runs only when the prefix is
+# absent, leaving an already-initialized prefix untouched.
+- name: Converge | Initial mode (existing-prefix gating)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    wine_enabled: true
+    wine_vulkan_driver: 'none'
+    wine_lib32_packages: []
+    wine_user_config_mode: 'initial'
+    wine_users:
+      - username: 'wine_initial_fresh'
+      - username: 'wine_initial_exist'
+
+  pre_tasks:
+    - name: Converge | Clear test users where wine is unavailable (RedHat)
+      ansible.builtin.set_fact:
+        wine_users: []
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Converge | Ensure existing-user wine prefix dir exists
+      ansible.builtin.file:
+        path: /home/wine_initial_exist/.wine
+        state: directory
+        owner: wine_initial_exist
+        group: wine_initial_exist
+        mode: '0755'
+      when: ansible_facts['os_family'] != 'RedHat'
+
+    - name: Converge | Pre-seed existing wine prefix to prove it is left untouched
+      ansible.builtin.copy:
+        content: |
+          WINE REGISTRY Version 2
+          ;; molecule-fixture: pre-existing wine prefix
+        dest: /home/wine_initial_exist/.wine/system.reg
+        owner: wine_initial_exist
+        group: wine_initial_exist
+        mode: '0600'
+      when: ansible_facts['os_family'] != 'RedHat'
+
+  tasks:
+    - name: Converge | Include wine role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Disabled mode (global)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    wine_enabled: true
+    wine_vulkan_driver: 'none'
+    wine_lib32_packages: []
+    wine_user_config_mode: 'disabled'
+    wine_users:
+      - username: 'wine_global_disabled'
+
+  pre_tasks:
+    - name: Converge | Clear test users where wine is unavailable (RedHat)
+      ansible.builtin.set_fact:
+        wine_users: []
+      when: ansible_facts['os_family'] == 'RedHat'
 
   tasks:
     - name: Converge | Include wine role  # noqa: role-name[path]

--- a/roles/wine/molecule/default/prepare.yml
+++ b/roles/wine/molecule/default/prepare.yml
@@ -74,3 +74,31 @@
       ansible.builtin.dnf:
         update_cache: true
       when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # Test users for user_config_mode coverage
+    #
+
+    - name: Prepare | Create test users
+      ansible.builtin.user:
+        name: '{{ item }}'
+        create_home: true
+        shell: /bin/bash
+        # Real sha512 password hash. Required so PAM account management
+        # accepts root → user become in containerised Rocky under
+        # GitHub-hosted runners (locked accounts and `*` placeholder both
+        # fail pam_unix account check with "Authentication service cannot
+        # retrieve authentication info").
+        password: "{{ 'molecule-wine-test-noop' | password_hash('sha512') }}"
+        update_password: 'on_create'
+      loop:
+        # Play 1 (managed): reconciled user + per-user disabled override
+        - wine_managed_user
+        - wine_disabled_user
+        # Play 2 (initial): no existing prefix (initialized) + existing prefix (untouched)
+        - wine_initial_fresh
+        - wine_initial_exist
+        # Play 3 (disabled, global): never initialized
+        - wine_global_disabled
+      loop_control:
+        label: '{{ item }}'

--- a/roles/wine/molecule/default/verify.yml
+++ b/roles/wine/molecule/default/verify.yml
@@ -64,3 +64,87 @@
       ansible.builtin.command:
         cmd: grep -q 'WINEDEBUG' /etc/profile.d/wine.sh
       changed_when: false
+
+    #
+    # user_config_mode coverage (Arch + Debian only)
+    #
+    # Wine is a no-op on Rocky 9 / EL 9 (see desktop#163), so wineboot is
+    # unavailable and wine_users is cleared there — these prefix assertions
+    # only run where wine is actually installed.
+    #
+    - name: Verify | user_config_mode prefix assertions
+      when: ansible_facts['os_family'] != 'RedHat'
+      block:
+        #
+        # Managed Mode — Prefix Initialized (wine_managed_user)
+        #
+        - name: Verify | Check managed user wine prefix exists
+          ansible.builtin.stat:
+            path: /home/wine_managed_user/.wine/system.reg
+          register: __wine_managed_prefix
+
+        - name: Verify | Assert managed user prefix is initialized
+          ansible.builtin.assert:
+            that:
+              - __wine_managed_prefix.stat.exists
+              - __wine_managed_prefix.stat.pw_name == 'wine_managed_user'
+            fail_msg: 'wine prefix not initialized for managed-mode user'
+
+        #
+        # Managed Mode — Per-User Disabled Override (wine_disabled_user)
+        #
+        - name: Verify | Check per-user-disabled user has no wine prefix
+          ansible.builtin.stat:
+            path: /home/wine_disabled_user/.wine/system.reg
+          register: __wine_disabled_prefix
+
+        - name: Verify | Assert per-user-disabled user has no prefix
+          ansible.builtin.assert:
+            that:
+              - not __wine_disabled_prefix.stat.exists
+            fail_msg: 'wine prefix initialized for a per-user-disabled entry'
+
+        #
+        # Initial Mode — No Existing Prefix (wine_initial_fresh)
+        #
+        - name: Verify | Check initial-fresh user wine prefix exists
+          ansible.builtin.stat:
+            path: /home/wine_initial_fresh/.wine/system.reg
+          register: __wine_initialfresh_prefix
+
+        - name: Verify | Assert initial-fresh user prefix is initialized
+          ansible.builtin.assert:
+            that:
+              - __wine_initialfresh_prefix.stat.exists
+              - __wine_initialfresh_prefix.stat.pw_name == 'wine_initial_fresh'
+            fail_msg: 'wine prefix not initialized for initial-mode user without existing prefix'
+
+        #
+        # Initial Mode — Existing Prefix (wine_initial_exist)
+        #
+        - name: Verify | Read initial-exist user system.reg
+          ansible.builtin.slurp:
+            src: /home/wine_initial_exist/.wine/system.reg
+          register: __wine_initialexist_reg
+
+        - name: Verify | Assert initial-exist user prefix is unchanged
+          ansible.builtin.assert:
+            that:
+              - >-
+                'molecule-fixture: pre-existing wine prefix'
+                in (__wine_initialexist_reg.content | b64decode)
+            fail_msg: 'pre-existing wine prefix was re-initialized for existing initial-mode user'
+
+        #
+        # Disabled Mode — Global (wine_global_disabled)
+        #
+        - name: Verify | Check global-disabled user has no wine prefix
+          ansible.builtin.stat:
+            path: /home/wine_global_disabled/.wine/system.reg
+          register: __wine_globaldisabled_prefix
+
+        - name: Verify | Assert global-disabled user has no prefix
+          ansible.builtin.assert:
+            that:
+              - not __wine_globaldisabled_prefix.stat.exists
+            fail_msg: 'wine prefix initialized despite global disabled mode'


### PR DESCRIPTION
## Summary

Extend the `wine` molecule `default` scenario from an empty `wine_users` list to all three `user_config_mode` paths.

Test-only change: no role logic is modified.

## Coverage added

- **managed:** prefix initialized for the reconciled user, plus a per-user `mode: disabled` override entry (no prefix for that user).
- **initial:** a user without an existing prefix (`wineboot` runs) versus a user with a pre-seeded prefix (left untouched).
- **disabled (global):** no prefix initialized for any user.

## Implementation notes

- `wine` gates initial mode on wine-prefix (`system.reg`) existence, matching the keepassxc pattern rather than the `__users_newly_created` canonical fact.
- The per-user prefix test runs on **Arch and Debian only**: wine is a documented no-op on Rocky 9 / EL 9 (#163), so `wine_users` is cleared there and the prefix assertions are skipped.

## Test plan

- [x] `ansible-lint --profile=production --offline` on `roles/wine`: 0 failures, 0 warnings
- [x] `molecule test -p wine-archlinux`: 20 ok, 0 failed (converge 3 plays + idempotence + verify)
- [x] `molecule test -p wine-debian-trixie`: 20 ok, 0 failed
- [x] `molecule test -p wine-rocky-9`: 5 ok / 15 skipped, 0 failed (RedHat exclusion verified)

References #119