### PR TITLE
test(browser): cover initial and disabled modes in molecule

### DIFF
--- a/roles/browser/molecule/default/converge.yml
+++ b/roles/browser/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Converge | Managed mode
   hosts: all
   gather_facts: true
 
@@ -28,6 +28,8 @@
     browser_user_config_mode: 'managed'
     browser_users:
       - username: 'browser_test_user'
+      - username: 'browser_disabled_user'
+        mode: 'disabled'
 
     # Minimal extensions for testing
     browser_firefox_extensions:
@@ -38,6 +40,81 @@
     browser_chromium_extensions:
       'cjpalhdlnbpafiamejdnhcphjbkeiagm':
         mode: 'force_installed'
+
+  tasks:
+    - name: Converge | Include browser role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+# initial mode acts only on users present in __users_newly_created (the
+# canonical fact set by marcstraube.common.users). Chromium/policies are
+# system-level (not user_config_mode gated) and are disabled here so the
+# play exercises the per-user Firefox profile path in isolation.
+- name: Converge | Initial mode (per-user gating)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    browser_enabled: true
+    browser_firefox_enabled: true
+    browser_chromium_enabled: false
+    browser_firefox_policies_enabled: false
+    browser_firefox_user_js_enabled: true
+    browser_firefox_preferences:
+      privacy.resistFingerprinting: true
+    browser_default: 'firefox'
+    browser_user_config_mode: 'initial'
+    browser_users:
+      - username: 'browser_initial_new'
+      - username: 'browser_initial_exist'
+
+  pre_tasks:
+    - name: Converge | Ensure existing-user config dir exists
+      ansible.builtin.file:
+        path: /home/browser_initial_exist/.config
+        state: directory
+        owner: browser_initial_exist
+        group: browser_initial_exist
+        mode: '0700'
+
+    - name: Converge | Pre-seed existing mimeapps.list to prove it is left untouched
+      ansible.builtin.copy:
+        content: |
+          [Default Applications]
+          x-scheme-handler/molecule-fixture=preexisting.desktop
+        dest: /home/browser_initial_exist/.config/mimeapps.list
+        owner: browser_initial_exist
+        group: browser_initial_exist
+        mode: '0644'
+
+    - name: Converge | Mark only browser_initial_new as newly created
+      ansible.builtin.set_fact:
+        __users_newly_created:
+          - 'browser_initial_new'
+
+  tasks:
+    - name: Converge | Include browser role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Disabled mode (global)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    browser_enabled: true
+    browser_firefox_enabled: true
+    browser_chromium_enabled: false
+    browser_firefox_policies_enabled: false
+    browser_firefox_user_js_enabled: true
+    browser_firefox_preferences:
+      privacy.resistFingerprinting: true
+    browser_default: 'firefox'
+    browser_user_config_mode: 'disabled'
+    browser_users:
+      - username: 'browser_global_disabled'
 
   tasks:
     - name: Converge | Include browser role  # noqa: role-name[path]

--- a/roles/browser/molecule/default/prepare.yml
+++ b/roles/browser/molecule/default/prepare.yml
@@ -94,8 +94,19 @@
     # Test User (for mimeapps.list handler verification)
     #
 
-    - name: Prepare | Create test user
+    - name: Prepare | Create test users
       ansible.builtin.user:
-        name: browser_test_user
+        name: '{{ item }}'
         create_home: true
         shell: /bin/bash
+      loop:
+        # Play 1 (managed): reconciled user + per-user disabled override
+        - browser_test_user
+        - browser_disabled_user
+        # Play 2 (initial): newly-created (deployed) + existing (untouched)
+        - browser_initial_new
+        - browser_initial_exist
+        # Play 3 (disabled, global): never deployed
+        - browser_global_disabled
+      loop_control:
+        label: '{{ item }}'

--- a/roles/browser/molecule/default/verify.yml
+++ b/roles/browser/molecule/default/verify.yml
@@ -211,3 +211,103 @@
         that:
           - __browser_verify_firefox_user_js.stat.exists
         fail_msg: 'Firefox user.js not deployed into profile'
+
+    #
+    # Managed Mode — Per-User Disabled Override (browser_disabled_user)
+    #
+    # Entry-level mode=disabled overrides the managed global mode → role
+    # MUST NOT bootstrap a Firefox profile or write mimeapps.list.
+    #
+
+    - name: Verify | Check per-user-disabled user has no Firefox profile
+      ansible.builtin.stat:
+        path: /home/browser_disabled_user/.mozilla/firefox/{{ __browser_firefox_profile_dirname }}
+      register: __browser_verify_disabled_profile
+
+    - name: Verify | Check per-user-disabled user has no mimeapps.list
+      ansible.builtin.stat:
+        path: /home/browser_disabled_user/.config/mimeapps.list
+      register: __browser_verify_disabled_mimeapps
+
+    - name: Verify | Assert per-user-disabled user has no config
+      ansible.builtin.assert:
+        that:
+          - not __browser_verify_disabled_profile.stat.exists
+          - not __browser_verify_disabled_mimeapps.stat.exists
+        fail_msg: 'browser config deployed for a per-user-disabled entry'
+
+    #
+    # Initial Mode — Newly Created User (browser_initial_new)
+    #
+    # browser_user_config_mode=initial + user IN __users_newly_created
+    # → role MUST bootstrap the profile, user.js and mimeapps.list.
+    #
+
+    - name: Verify | Check initial-new user Firefox user.js exists
+      ansible.builtin.stat:
+        path: /home/browser_initial_new/.mozilla/firefox/{{ __browser_firefox_profile_dirname }}/user.js
+      register: __browser_verify_initialnew_userjs
+
+    - name: Verify | Check initial-new user mimeapps.list exists
+      ansible.builtin.stat:
+        path: /home/browser_initial_new/.config/mimeapps.list
+      register: __browser_verify_initialnew_mimeapps
+
+    - name: Verify | Assert initial-new user config is deployed
+      ansible.builtin.assert:
+        that:
+          - __browser_verify_initialnew_userjs.stat.exists
+          - __browser_verify_initialnew_userjs.stat.pw_name == 'browser_initial_new'
+          - __browser_verify_initialnew_mimeapps.stat.exists
+        fail_msg: 'browser config not deployed for newly-created initial-mode user'
+
+    #
+    # Initial Mode — Existing User (browser_initial_exist)
+    #
+    # browser_user_config_mode=initial + user NOT IN __users_newly_created
+    # → role MUST leave the pre-existing mimeapps.list untouched and MUST
+    #   NOT bootstrap a Firefox profile.
+    #
+
+    - name: Verify | Read initial-exist user mimeapps.list
+      ansible.builtin.slurp:
+        src: /home/browser_initial_exist/.config/mimeapps.list
+      register: __browser_verify_initialexist_mimeapps
+
+    - name: Verify | Check initial-exist user has no Firefox profile
+      ansible.builtin.stat:
+        path: /home/browser_initial_exist/.mozilla/firefox/{{ __browser_firefox_profile_dirname }}
+      register: __browser_verify_initialexist_profile
+
+    - name: Verify | Assert initial-exist user config is unchanged
+      ansible.builtin.assert:
+        that:
+          - "'x-scheme-handler/molecule-fixture=preexisting.desktop'
+            in (__browser_verify_initialexist_mimeapps.content | b64decode)"
+          - "'firefox.desktop' not in (__browser_verify_initialexist_mimeapps.content | b64decode)"
+          - not __browser_verify_initialexist_profile.stat.exists
+        fail_msg: 'pre-existing config was modified for existing initial-mode user'
+
+    #
+    # Disabled Mode — Global (browser_global_disabled)
+    #
+    # browser_user_config_mode=disabled → role MUST NOT deploy any
+    # per-user config.
+    #
+
+    - name: Verify | Check global-disabled user has no Firefox profile
+      ansible.builtin.stat:
+        path: /home/browser_global_disabled/.mozilla/firefox/{{ __browser_firefox_profile_dirname }}
+      register: __browser_verify_globaldisabled_profile
+
+    - name: Verify | Check global-disabled user has no mimeapps.list
+      ansible.builtin.stat:
+        path: /home/browser_global_disabled/.config/mimeapps.list
+      register: __browser_verify_globaldisabled_mimeapps
+
+    - name: Verify | Assert global-disabled user has no config
+      ansible.builtin.assert:
+        that:
+          - not __browser_verify_globaldisabled_profile.stat.exists
+          - not __browser_verify_globaldisabled_mimeapps.stat.exists
+        fail_msg: 'browser config deployed despite global disabled mode'


### PR DESCRIPTION
## Summary

Extend the `browser` molecule `default` scenario from managed-only coverage to all three `user_config_mode` paths, mirroring the canonical editors pattern (marcstraube/ansible-collection-common#209).

Test-only change: no role logic is modified.

## Coverage added

- **managed:** the reconciled user (existing assertions) plus a new per-user `mode: disabled` override entry (no profile / no `mimeapps.list`).
- **initial:** a newly-created user (present in `__users_newly_created` → Firefox profile + `user.js` + `mimeapps.list` deployed) versus an existing user (pre-seeded `mimeapps.list` left untouched, no profile bootstrapped).
- **disabled (global):** no per-user config deployed for any user.

## Implementation notes

- Firefox/Chromium policies are system-level (not `user_config_mode` gated); the initial and disabled plays disable chromium and policies so they exercise the per-user Firefox profile path in isolation.
- The existing-user no-touch case pre-seeds `~/.config/mimeapps.list` with a fixture marker and asserts both the marker survives and the role's own handler (`firefox.desktop`) / bootstrap profile are absent.

## Test plan

- [x] `ansible-lint --profile=production --offline` on `roles/browser`: 0 failures, 0 warnings
- [x] `molecule test -p browser-archlinux`: 42 ok, 0 failed (converge 3 plays + idempotence + verify)

References #119