### PR TITLE
test(development): cover initial and disabled modes in molecule

### DIFF
--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -1,5 +1,10 @@
 ---
-- name: Converge
+# All three plays share an identical feature-toggle set so the per-play
+# manage tasks stay idempotent across the sequence (the tool roles remove
+# packages when their toggle flips to false, which would otherwise make
+# play 1 reinstall on every converge). Only development_user_config_mode and
+# development_users differ between the plays.
+- name: Converge | Managed mode
   hosts: all
   gather_facts: true
 
@@ -15,36 +20,151 @@
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
-    # Build-tool toggles: enable cmake, disable meson and ninja
     development_cmake_enabled: true
     development_meson_enabled: false
     development_ninja_enabled: false
-    # Misc toggles: enable jq, disable rest
     development_jq_enabled: true
     development_yq_enabled: false
     development_direnv_enabled: false
     development_pre_commit_enabled: false
-    # Shell tooling: enable all (verify checks present/absent per platform)
     development_shell_shfmt_enabled: true
     development_shell_shellcheck_enabled: true
     development_shell_bats_enabled: true
-    # Python tooling
     development_python_ruff_enabled: true
-    # Lua tooling
     development_lua_stylua_enabled: true
     development_lua_luacheck_enabled: true
     development_lua_busted_enabled: true
-    # QML tooling
     development_qml_tools_enabled: true
-    # Database tools off
     development_dbeaver_enabled: false
     development_pgadmin_enabled: false
-    # httpie disabled — EPEL 9 package has a broken pygments dep
     development_httpie_enabled: false
-    # Socket CLI: AUR on Arch, npm-global on non-Arch (npm/nodejs
-    # provided by prepare.yml)
     development_socket_cli_enabled: true
-    development_users: []
+    development_user_config_mode: 'managed'
+    development_users:
+      - username: 'dev_managed_user'
+        git_name: 'Dev Managed'
+        git_email: 'managed@example.com'
+      - username: 'dev_disabled_user'
+        mode: 'disabled'
+        git_name: 'Dev Disabled'
+        git_email: 'disabled@example.com'
+
+  tasks:
+    - name: Converge | Include development role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+# initial mode acts only on users present in __users_newly_created (the
+# canonical fact set by marcstraube.common.users).
+- name: Converge | Initial mode (per-user gating)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    development_enabled: true
+    development_git_enabled: true
+    development_git_lfs_enabled: true
+    development_python_enabled: true
+    development_nodejs_enabled: false
+    development_rust_enabled: false
+    development_go_enabled: false
+    development_java_enabled: false
+    development_vscodium_enabled: false
+    development_vscode_enabled: false
+    development_zed_enabled: false
+    development_cmake_enabled: true
+    development_meson_enabled: false
+    development_ninja_enabled: false
+    development_jq_enabled: true
+    development_yq_enabled: false
+    development_direnv_enabled: false
+    development_pre_commit_enabled: false
+    development_shell_shfmt_enabled: true
+    development_shell_shellcheck_enabled: true
+    development_shell_bats_enabled: true
+    development_python_ruff_enabled: true
+    development_lua_stylua_enabled: true
+    development_lua_luacheck_enabled: true
+    development_lua_busted_enabled: true
+    development_qml_tools_enabled: true
+    development_dbeaver_enabled: false
+    development_pgadmin_enabled: false
+    development_httpie_enabled: false
+    development_socket_cli_enabled: true
+    development_user_config_mode: 'initial'
+    development_users:
+      - username: 'dev_initial_new'
+        git_name: 'Dev Initial New'
+        git_email: 'new@example.com'
+      - username: 'dev_initial_exist'
+        git_name: 'Dev Initial Exist'
+        git_email: 'exist@example.com'
+
+  pre_tasks:
+    - name: Converge | Pre-seed existing user .gitconfig to prove it is left untouched
+      ansible.builtin.copy:
+        content: |
+          [user]
+          name = Preexisting Fixture
+          [molecule]
+          fixture = preexisting
+        dest: /home/dev_initial_exist/.gitconfig
+        owner: dev_initial_exist
+        group: dev_initial_exist
+        mode: '0644'
+
+    - name: Converge | Mark only dev_initial_new as newly created
+      ansible.builtin.set_fact:
+        __users_newly_created:
+          - 'dev_initial_new'
+
+  tasks:
+    - name: Converge | Include development role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Disabled mode (global)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    development_enabled: true
+    development_git_enabled: true
+    development_git_lfs_enabled: true
+    development_python_enabled: true
+    development_nodejs_enabled: false
+    development_rust_enabled: false
+    development_go_enabled: false
+    development_java_enabled: false
+    development_vscodium_enabled: false
+    development_vscode_enabled: false
+    development_zed_enabled: false
+    development_cmake_enabled: true
+    development_meson_enabled: false
+    development_ninja_enabled: false
+    development_jq_enabled: true
+    development_yq_enabled: false
+    development_direnv_enabled: false
+    development_pre_commit_enabled: false
+    development_shell_shfmt_enabled: true
+    development_shell_shellcheck_enabled: true
+    development_shell_bats_enabled: true
+    development_python_ruff_enabled: true
+    development_lua_stylua_enabled: true
+    development_lua_luacheck_enabled: true
+    development_lua_busted_enabled: true
+    development_qml_tools_enabled: true
+    development_dbeaver_enabled: false
+    development_pgadmin_enabled: false
+    development_httpie_enabled: false
+    development_socket_cli_enabled: true
+    development_user_config_mode: 'disabled'
+    development_users:
+      - username: 'dev_global_disabled'
+        git_name: 'Dev Global Disabled'
+        git_email: 'gd@example.com'
 
   tasks:
     - name: Converge | Include development role  # noqa: role-name[path]

--- a/roles/development/molecule/default/prepare.yml
+++ b/roles/development/molecule/default/prepare.yml
@@ -137,3 +137,31 @@
       when: ansible_facts['os_family'] == 'RedHat'
       retries: 3
       delay: 5
+
+    #
+    # Test users for user_config_mode coverage (git config uses become_user)
+    #
+
+    - name: Prepare | Create test users
+      ansible.builtin.user:
+        name: '{{ item }}'
+        create_home: true
+        shell: /bin/bash
+        # Real sha512 password hash. Required so PAM account management
+        # accepts root → user become in containerised Rocky under
+        # GitHub-hosted runners (locked accounts and `*` placeholder both
+        # fail pam_unix account check with "Authentication service cannot
+        # retrieve authentication info").
+        password: "{{ 'molecule-dev-test-noop' | password_hash('sha512') }}"
+        update_password: 'on_create'
+      loop:
+        # Play 1 (managed): reconciled user + per-user disabled override
+        - dev_managed_user
+        - dev_disabled_user
+        # Play 2 (initial): newly-created (deployed) + existing (untouched)
+        - dev_initial_new
+        - dev_initial_exist
+        # Play 3 (disabled, global): never deployed
+        - dev_global_disabled
+      loop_control:
+        label: '{{ item }}'

--- a/roles/development/molecule/default/verify.yml
+++ b/roles/development/molecule/default/verify.yml
@@ -278,3 +278,85 @@
       changed_when: false
       failed_when: _dev_socket_cli_npm.rc != 0
       when: ansible_facts['os_family'] != 'Archlinux'
+
+    #
+    # user_config_mode coverage — per-user git config (~/.gitconfig)
+    #
+
+    #
+    # Managed Mode — Config Applied (dev_managed_user)
+    #
+    - name: Verify | Read managed user .gitconfig
+      ansible.builtin.slurp:
+        src: /home/dev_managed_user/.gitconfig
+      register: _dev_managed_gitconfig
+
+    - name: Verify | Assert managed user git config is applied
+      ansible.builtin.assert:
+        that:
+          - "'Dev Managed' in (_dev_managed_gitconfig.content | b64decode)"
+          - "'defaultBranch = main' in (_dev_managed_gitconfig.content | b64decode)"
+        fail_msg: 'git config not applied for managed-mode user'
+
+    #
+    # Managed Mode — Per-User Disabled Override (dev_disabled_user)
+    #
+    - name: Verify | Check per-user-disabled user has no .gitconfig
+      ansible.builtin.stat:
+        path: /home/dev_disabled_user/.gitconfig
+      register: _dev_disabled_gitconfig
+
+    - name: Verify | Assert per-user-disabled user has no git config
+      ansible.builtin.assert:
+        that:
+          - not _dev_disabled_gitconfig.stat.exists
+        fail_msg: 'git config applied for a per-user-disabled entry'
+
+    #
+    # Initial Mode — Newly Created User (dev_initial_new)
+    #
+    - name: Verify | Read initial-new user .gitconfig
+      ansible.builtin.slurp:
+        src: /home/dev_initial_new/.gitconfig
+      register: _dev_initialnew_gitconfig
+
+    - name: Verify | Assert initial-new user git config is applied
+      ansible.builtin.assert:
+        that:
+          - "'Dev Initial New' in (_dev_initialnew_gitconfig.content | b64decode)"
+          - "'defaultBranch = main' in (_dev_initialnew_gitconfig.content | b64decode)"
+        fail_msg: 'git config not applied for newly-created initial-mode user'
+
+    #
+    # Initial Mode — Existing User (dev_initial_exist)
+    #
+    # user NOT IN __users_newly_created → role MUST leave the pre-existing
+    # .gitconfig untouched (fixture preserved, no role-managed keys added).
+    #
+    - name: Verify | Read initial-exist user .gitconfig
+      ansible.builtin.slurp:
+        src: /home/dev_initial_exist/.gitconfig
+      register: _dev_initialexist_gitconfig
+
+    - name: Verify | Assert initial-exist user git config is unchanged
+      ansible.builtin.assert:
+        that:
+          - "'Preexisting Fixture' in (_dev_initialexist_gitconfig.content | b64decode)"
+          - "'fixture = preexisting' in (_dev_initialexist_gitconfig.content | b64decode)"
+          - "'Dev Initial Exist' not in (_dev_initialexist_gitconfig.content | b64decode)"
+          - "'defaultBranch = main' not in (_dev_initialexist_gitconfig.content | b64decode)"
+        fail_msg: 'pre-existing .gitconfig was modified for existing initial-mode user'
+
+    #
+    # Disabled Mode — Global (dev_global_disabled)
+    #
+    - name: Verify | Check global-disabled user has no .gitconfig
+      ansible.builtin.stat:
+        path: /home/dev_global_disabled/.gitconfig
+      register: _dev_globaldisabled_gitconfig
+
+    - name: Verify | Assert global-disabled user has no git config
+      ansible.builtin.assert:
+        that:
+          - not _dev_globaldisabled_gitconfig.stat.exists
+        fail_msg: 'git config applied despite global disabled mode'


### PR DESCRIPTION
## Summary

Extend the `development` molecule `default` scenario from an empty `development_users` list to all three `user_config_mode` paths, verified via the per-user `~/.gitconfig`, mirroring the canonical editors pattern (marcstraube/ansible-collection-common#209).

Test-only change: no role logic is modified. This is the final role for the multi-mode coverage effort.

## Coverage added

- **managed:** git config applied for the reconciled user, plus a per-user `mode: disabled` override entry (no `~/.gitconfig`).
- **initial:** a newly-created user (present in `__users_newly_created` → git config applied) versus an existing user (pre-seeded `~/.gitconfig` left untouched).
- **disabled (global):** no git config applied for any user.

## Implementation notes

- All three plays share an identical feature-toggle set so the per-play manage tasks stay idempotent — the language/tool sub-roles remove packages when a toggle flips to false, which would otherwise make play 1 reinstall on every converge. Only `development_user_config_mode` and `development_users` differ between the plays.
- The existing-user no-touch case pre-seeds `~/.gitconfig` with a fixture marker and asserts both the marker survives and the role's own keys (`user.name`, `init.defaultBranch`) are absent.

## Test plan

- [x] `ansible-lint --profile=production --offline` on `roles/development`: 0 failures, 0 warnings
- [x] `molecule test -p development-archlinux`: 29 ok, 0 failed (converge 3 plays + idempotence + verify)

Closes #119