### PR TITLE
ci: run all molecule scenarios, not just default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,28 +201,35 @@ jobs:
             fi
           fi
 
-          # Build JSON matrix: one entry per (role, platform) pair.
-          # Platforms are parsed from each role's molecule.yml so roles
-          # with fewer platforms (elgato, tuxedo, wine) get fewer entries.
+          # Build JSON matrix: one entry per (role, scenario, platform).
+          # All molecule scenarios (default plus extras like 'comfyui') are
+          # discovered; platforms come from each scenario's molecule.yml so
+          # roles with fewer platforms (elgato, tuxedo, wine) get fewer
+          # entries. Only podman scenarios run here — others are skipped.
           MATRIX="["
           FIRST=true
           for role in $ROLES; do
             [ -z "$role" ] && continue
-            platforms=$(python3 -c "
+            for scenario_dir in roles/$role/molecule/*/; do
+              scenario=$(basename "$scenario_dir")
+              mol="${scenario_dir}molecule.yml"
+              [ -f "$mol" ] || continue
+              grep -q 'name: podman' "$mol" || continue
+              platforms=$(python3 -c "
           import yaml, sys
           with open(sys.argv[1]) as f:
               data = yaml.safe_load(f)
           for p in data.get('platforms', []):
               print(p['name'])
-          " "roles/$role/molecule/default/molecule.yml")
-
-            for platform in $platforms; do
-              if [ "$FIRST" = "true" ]; then
-                FIRST=false
-              else
-                MATRIX="${MATRIX},"
-              fi
-              MATRIX="${MATRIX}{\"role\":\"${role}\",\"platform\":\"${platform}\"}"
+          " "$mol")
+              for platform in $platforms; do
+                if [ "$FIRST" = "true" ]; then
+                  FIRST=false
+                else
+                  MATRIX="${MATRIX},"
+                fi
+                MATRIX="${MATRIX}{\"role\":\"${role}\",\"scenario\":\"${scenario}\",\"platform\":\"${platform}\"}"
+              done
             done
           done
           MATRIX="${MATRIX}]"
@@ -243,7 +250,7 @@ jobs:
   # full matrix on schedule / workflow_dispatch)
   # =============================================================================
   molecule-roles:
-    name: Molecule ${{ matrix.role }} (${{ matrix.platform }})
+    name: Molecule ${{ matrix.role }} / ${{ matrix.scenario }} (${{ matrix.platform }})
     runs-on: ubuntu-latest
     needs: [lint, markdown-lint, yaml-lint, detect-changes]
     if: needs.detect-changes.outputs.has_roles == 'true'
@@ -273,7 +280,7 @@ jobs:
 
       - name: Run Molecule test
         working-directory: roles/${{ matrix.role }}
-        run: molecule test
+        run: molecule test -s ${{ matrix.scenario }}
         env:
           MOLECULE_PLATFORM_NAME: ${{ matrix.platform }}
           PY_COLORS: '1'


### PR DESCRIPTION
Enumerates every `roles/*/molecule/*/molecule.yml` in `detect-changes` and emits one matrix entry per (role, scenario, platform), running `molecule test -s <scenario>`. Previously only the `default` scenario ran, so `ai/comfyui` (Debian native-PyTorch path) had no CI coverage. Mirrors marcstraube.common #247.

Verified locally: yamllint passes and the matrix simulation for the `ai` role now yields both `default` and `comfyui` scenarios.

Closes #169