### PR TITLE
feat(development): add uv toggle

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -161,9 +161,9 @@ dash, ksh, mksh); `bats-core` is bash-specific.
 
 #### Python Tooling
 
-| Variable                          | Default | Description                              |
-|-----------------------------------|---------|------------------------------------------|
-| `development_python_ruff_enabled` | `false` | Enable ruff Python linter and formatter  |
+| Variable                          | Default | Description                                     |
+|-----------------------------------|---------|-------------------------------------------------|
+| `development_python_ruff_enabled` | `false` | Enable ruff Python linter and formatter         |
 | `development_python_uv_enabled`   | `false` | Enable uv Python package installer and resolver |
 
 #### Lua

--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -164,6 +164,7 @@ dash, ksh, mksh); `bats-core` is bash-specific.
 | Variable                          | Default | Description                              |
 |-----------------------------------|---------|------------------------------------------|
 | `development_python_ruff_enabled` | `false` | Enable ruff Python linter and formatter  |
+| `development_python_uv_enabled`   | `false` | Enable uv Python package installer and resolver |
 
 #### Lua
 
@@ -187,6 +188,7 @@ dash, ksh, mksh); `bats-core` is bash-specific.
 | shellcheck   | yes  | yes           | yes  | yes   |
 | bats         | yes  | yes           | yes  | yes   |
 | ruff         | yes  | no            | no   | yes   |
+| uv           | yes  | no            | no   | yes   |
 | stylua       | yes  | no            | no   | no    |
 | luacheck     | yes  | yes           | no   | no    |
 | busted       | yes  | yes           | no   | no    |
@@ -285,6 +287,7 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - [shellcheck](https://github.com/koalaman/shellcheck) — Shell script static analysis
 - [bats-core](https://github.com/bats-core/bats-core) — Bash automated testing system
 - [ruff](https://github.com/astral-sh/ruff) — Python linter and formatter
+- [uv](https://github.com/astral-sh/uv) — Python package installer and resolver
 - [stylua](https://github.com/JohnnyMorganz/StyLua) — Lua formatter
 - [luacheck](https://github.com/mpeterv/luacheck) — Lua linter
 - [busted](https://github.com/lunarmodules/busted) — Lua test framework

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -98,6 +98,9 @@ development_shell_bats_enabled: false
 # Enable ruff Python linter and formatter
 development_python_ruff_enabled: false
 
+# Enable uv Python package installer and resolver
+development_python_uv_enabled: false
+
 # Lua
 
 # Enable stylua Lua formatter

--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -31,6 +31,7 @@
     development_shell_shellcheck_enabled: true
     development_shell_bats_enabled: true
     development_python_ruff_enabled: true
+    development_python_uv_enabled: true
     development_lua_stylua_enabled: true
     development_lua_luacheck_enabled: true
     development_lua_busted_enabled: true
@@ -84,6 +85,7 @@
     development_shell_shellcheck_enabled: true
     development_shell_bats_enabled: true
     development_python_ruff_enabled: true
+    development_python_uv_enabled: true
     development_lua_stylua_enabled: true
     development_lua_luacheck_enabled: true
     development_lua_busted_enabled: true
@@ -152,6 +154,7 @@
     development_shell_shellcheck_enabled: true
     development_shell_bats_enabled: true
     development_python_ruff_enabled: true
+    development_python_uv_enabled: true
     development_lua_stylua_enabled: true
     development_lua_luacheck_enabled: true
     development_lua_busted_enabled: true

--- a/roles/development/molecule/default/verify.yml
+++ b/roles/development/molecule/default/verify.yml
@@ -188,6 +188,15 @@
       failed_when: _dev_ruff_check.changed
       when: __development_python_ruff_package | default('') | length > 0
 
+    - name: Verify | uv — package installed
+      ansible.builtin.package:
+        name: '{{ __development_python_uv_package }}'
+        state: present
+      check_mode: true
+      register: _dev_uv_check
+      failed_when: _dev_uv_check.changed
+      when: __development_python_uv_package | default('') | length > 0
+
     - name: Verify | stylua — package installed
       ansible.builtin.package:
         name: '{{ __development_lua_stylua_package }}'

--- a/roles/development/tasks/python_tooling.yml
+++ b/roles/development/tasks/python_tooling.yml
@@ -10,3 +10,21 @@
   when: __development_python_ruff_package | default('') | length > 0
   retries: 3
   delay: 5
+
+- name: Python Tooling | Manage uv
+  ansible.builtin.package:
+    name: '{{ __development_python_uv_package }}'
+    state: "{{ 'present' if development_python_uv_enabled | bool else 'absent' }}"
+  when: __development_python_uv_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Python Tooling | uv not available (unpackaged platform)
+  ansible.builtin.debug:
+    msg: >
+      uv is not packaged for {{ ansible_facts['os_family'] }} on this release
+      (Debian Trixie, EL9). Install manually from
+      https://github.com/astral-sh/uv
+  when:
+    - development_python_uv_enabled | bool
+    - __development_python_uv_package | default('') | length == 0

--- a/roles/development/vars/Archlinux.yml
+++ b/roles/development/vars/Archlinux.yml
@@ -58,6 +58,7 @@ __development_shell_bats_package: 'bats'
 
 # Python tooling
 __development_python_ruff_package: 'ruff'
+__development_python_uv_package: 'uv'
 
 # Lua tooling
 __development_lua_stylua_package: 'stylua'

--- a/roles/development/vars/Debian.yml
+++ b/roles/development/vars/Debian.yml
@@ -64,8 +64,9 @@ __development_shell_shfmt_package: 'shfmt'
 __development_shell_shellcheck_package: 'shellcheck'
 __development_shell_bats_package: 'bats'
 
-# Python tooling (ruff not yet in Debian Trixie main)
+# Python tooling (ruff and uv not packaged in Debian Trixie)
 __development_python_ruff_package: ''
+__development_python_uv_package: ''
 
 # Lua tooling (stylua not packaged in Debian)
 __development_lua_stylua_package: ''

--- a/roles/development/vars/RedHat-9.yml
+++ b/roles/development/vars/RedHat-9.yml
@@ -6,6 +6,7 @@
 # mirrors RedHat.yml because include_vars uses with_first_found and
 # loads only one file per host. EL9-specific overrides are:
 # - ruff: not packaged on EL9 (EPEL 10 ships it, EPEL 9 does not).
+# - uv: not packaged on EL9 (EPEL 10 ships it, EPEL 9 does not).
 #
 
 # Version control
@@ -70,8 +71,9 @@ __development_shell_shfmt_package: ''
 __development_shell_shellcheck_package: 'ShellCheck'
 __development_shell_bats_package: 'bats'
 
-# Python tooling (ruff not packaged on EL9)
+# Python tooling (ruff and uv not packaged on EL9)
 __development_python_ruff_package: ''
+__development_python_uv_package: ''
 
 # Lua tooling (none packaged on EL)
 __development_lua_stylua_package: ''

--- a/roles/development/vars/RedHat.yml
+++ b/roles/development/vars/RedHat.yml
@@ -65,8 +65,9 @@ __development_shell_shfmt_package: ''
 __development_shell_shellcheck_package: 'ShellCheck'
 __development_shell_bats_package: 'bats'
 
-# Python tooling (ruff is EL10-only, see vars/RedHat-9.yml)
+# Python tooling (ruff and uv are EL10-only, see vars/RedHat-9.yml)
 __development_python_ruff_package: 'ruff'
+__development_python_uv_package: 'uv'
 
 # Lua tooling (none packaged on EL)
 __development_lua_stylua_package: ''


### PR DESCRIPTION
Adds `development_python_uv_enabled` to install Astral's uv Python package installer and resolver, mirroring the existing `ruff` toggle. Packaged on Arch (extra) and EL10 (EPEL); a no-op with a `debug` notice on Debian Trixie and EL9 where uv is not packaged.

Package availability was verified against upstream repos (2026-07-09), correcting two assumptions in the issue: Debian Trixie ships no `uv` package (no-op), and `uv` is now in EPEL 10 (EL10 installs it, EL9 stays a no-op).

Verified locally: yamllint and ansible-lint (production profile) pass; molecule converge/verify cover the toggle on Arch.

Closes #150