### PR TITLE
feat(development): add arduino-ide and classic arduino toggles

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -73,13 +73,15 @@ overrides if needed.
 
 ### IDEs and Editors
 
-| Variable                                | Default | Description              |
-|-----------------------------------------|---------|--------------------------|
-| `development_vscode_enabled`            | `false` | Enable VS Code           |
-| `development_vscodium_enabled`          | `true`  | Enable VSCodium          |
-| `development_jetbrains_toolbox_enabled` | `false` | Enable JetBrains Toolbox |
-| `development_phpstorm_enabled`          | `false` | Enable PHPStorm          |
-| `development_zed_enabled`               | `false` | Enable Zed Editor        |
+| Variable                                | Default | Description                     |
+|-----------------------------------------|---------|---------------------------------|
+| `development_vscode_enabled`            | `false` | Enable VS Code                  |
+| `development_vscodium_enabled`          | `true`  | Enable VSCodium                 |
+| `development_jetbrains_toolbox_enabled` | `false` | Enable JetBrains Toolbox        |
+| `development_phpstorm_enabled`          | `false` | Enable PHPStorm                 |
+| `development_zed_enabled`               | `false` | Enable Zed Editor               |
+| `development_arduino_ide_enabled`       | `false` | Enable Arduino IDE 2.x          |
+| `development_arduino_classic_enabled`   | `false` | Enable classic Arduino IDE 1.x  |
 
 #### VSCode / VSCodium settings
 
@@ -99,6 +101,45 @@ Files are deployed under `~/.config/Code/User/settings.json` and
 `.vscode-oss` paths. The role overwrites these files in `managed` mode —
 inventory should populate `development_vscode_settings` with everything
 intended, not just deltas.
+
+#### Arduino
+
+Two independent toggles cover the two IDE generations, since their
+packaging differs per platform:
+
+| IDE                   | Arch                    | Debian Trixie      | EL 9/10 |
+|-----------------------|-------------------------|--------------------|---------|
+| Arduino IDE 2.x       | AUR (`arduino-ide-bin`) | no (Flatpak only)  | no      |
+| Classic Arduino IDE   | AUR (`arduino`)         | yes (`arduino`)    | no      |
+
+Arduino IDE 2.x on Debian/EL is only distributed as Flatpak
+(`cc.arduino.IDE2`) or AppImage; the classic 1.x EPEL package is
+orphaned. Enabling an unavailable combination logs a notice and skips.
+
+When either toggle is enabled, the role adds all `development_users`
+to the OS-specific serial device groups so boards can be flashed over
+USB-serial (`/dev/ttyACM*` / `/dev/ttyUSB*`):
+
+| Platform | Group     | Notes                                                          |
+|----------|-----------|----------------------------------------------------------------|
+| Arch     | `uucp`    | Required for CH340 chips — `uaccess` alone is not sufficient   |
+| Debian   | `dialout` |                                                                |
+| EL 9/10  | `dialout` |                                                                |
+
+Membership is append-only: the groups may be required by other tooling,
+so disabling the Arduino toggles does not remove users from them. Group
+changes take effect at next login.
+
+On Arch the role also deploys a `.desktop` override for Arduino IDE 2.x
+under `/usr/local/share/applications/` that redirects stdout/stderr to
+`/dev/null`. The IDE main process logs to stdout; launched from a
+`.desktop` entry that is a closed pipe, and every write raises an
+uncaught EPIPE exception dialog (upstream:
+[arduino-ide#2340](https://github.com/arduino/arduino-ide/issues/2340)).
+A pacman hook regenerates the override whenever `arduino-ide-bin`
+changes the packaged desktop file, so upstream `.desktop` updates are
+picked up automatically. Disabling the toggle removes the override,
+hook, and generator script.
 
 ### Database Tools
 
@@ -283,6 +324,8 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - [VSCodium](https://vscodium.com/) — Free/libre Code-OSS binaries (telemetry-free VS Code build)
 - [JetBrains Toolbox](https://www.jetbrains.com/toolbox-app/) — Manager for JetBrains IDEs
 - [Zed](https://zed.dev/) — High-performance multiplayer code editor
+- [Arduino IDE 2.x](https://github.com/arduino/arduino-ide) — Arduino IDE, Theia/Electron based
+- [Arduino IDE 1.x](https://github.com/arduino/Arduino) — Classic Arduino IDE, Java/Swing based
 - [shfmt](https://github.com/mvdan/sh) — Shell formatter
 - [shellcheck](https://github.com/koalaman/shellcheck) — Shell script static analysis
 - [bats-core](https://github.com/bats-core/bats-core) — Bash automated testing system

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -152,6 +152,12 @@ development_phpstorm_enabled: false
 # Enable Zed Editor
 development_zed_enabled: false
 
+# Enable Arduino IDE 2.x (Theia/Electron based)
+development_arduino_ide_enabled: false
+
+# Enable classic Arduino IDE 1.x (Java/Swing based)
+development_arduino_classic_enabled: false
+
 #
 # Database Tools
 #

--- a/roles/development/files/arduino-ide-desktop-override
+++ b/roles/development/files/arduino-ide-desktop-override
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Regenerate the Arduino IDE .desktop override that redirects stdout and
+# stderr to /dev/null. The IDE main process logs via console.log; when
+# launched from a .desktop entry stdout is a closed pipe and every write
+# raises an uncaught EPIPE exception dialog on launch and quit.
+# Upstream: https://github.com/arduino/arduino-ide/issues/2340
+#
+# Managed by marcstraube.desktop.development. Also run from a pacman hook
+# on arduino-ide-bin install/upgrade/remove so the override tracks the
+# packaged desktop file.
+
+set -eu
+
+src='/usr/share/applications/arduino-ide-v2.desktop'
+dst='/usr/local/share/applications/arduino-ide-v2.desktop'
+
+if [ ! -f "$src" ]; then
+    if [ -f "$dst" ]; then
+        rm -f "$dst"
+        echo 'changed: override removed (packaged desktop file gone)'
+    else
+        echo 'unchanged'
+    fi
+    exit 0
+fi
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+sed 's|^Exec=.*|Exec=/bin/sh -c '\''exec arduino-ide "$@" >/dev/null 2>&1'\'' arduino-ide %U|' "$src" > "$tmp"
+
+if [ -f "$dst" ] && cmp -s "$tmp" "$dst"; then
+    echo 'unchanged'
+else
+    install -D -m 0644 "$tmp" "$dst"
+    echo 'changed: override regenerated'
+fi

--- a/roles/development/files/arduino-ide-desktop-override.hook
+++ b/roles/development/files/arduino-ide-desktop-override.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = usr/share/applications/arduino-ide-v2.desktop
+
+[Action]
+Description = Regenerating Arduino IDE desktop override (EPIPE workaround)...
+When = PostTransaction
+Exec = /usr/local/bin/arduino-ide-desktop-override

--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -20,6 +20,8 @@
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
+    development_arduino_ide_enabled: false
+    development_arduino_classic_enabled: false
     development_cmake_enabled: true
     development_meson_enabled: false
     development_ninja_enabled: false
@@ -74,6 +76,8 @@
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
+    development_arduino_ide_enabled: false
+    development_arduino_classic_enabled: false
     development_cmake_enabled: true
     development_meson_enabled: false
     development_ninja_enabled: false
@@ -143,6 +147,8 @@
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
+    development_arduino_ide_enabled: false
+    development_arduino_classic_enabled: false
     development_cmake_enabled: true
     development_meson_enabled: false
     development_ninja_enabled: false

--- a/roles/development/tasks/ides.yml
+++ b/roles/development/tasks/ides.yml
@@ -80,6 +80,124 @@
   retries: 3
   delay: 5
 
+# Arduino IDE 2.x (Arch AUR)
+#
+# .desktop override: workaround for
+# https://github.com/arduino/arduino-ide/issues/2340 — the IDE main
+# process logs to stdout, which is a closed pipe when launched from a
+# .desktop entry, and every write raises an uncaught EPIPE exception
+# dialog. The override redirects stdout/stderr to /dev/null. Script and
+# pacman hook deploy BEFORE the AUR install so the hook fires during the
+# install transaction and creates the override automatically; the
+# generate task below only covers hosts where the IDE was installed
+# before the hook existed, and re-runs as a no-op otherwise.
+
+- name: IDEs | Deploy Arduino IDE desktop override script (Arch)
+  ansible.builtin.copy:
+    src: 'arduino-ide-desktop-override'
+    dest: '/usr/local/bin/arduino-ide-desktop-override'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - development_arduino_ide_enabled | bool
+
+- name: IDEs | Deploy pacman hook for Arduino IDE desktop override (Arch)
+  ansible.builtin.copy:
+    src: 'arduino-ide-desktop-override.hook'
+    dest: '/etc/pacman.d/hooks/arduino-ide-desktop-override.hook'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - development_arduino_ide_enabled | bool
+
+- name: IDEs | Manage Arduino IDE from AUR (Arch)
+  become: true
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
+  kewlfft.aur.aur:
+    name: '{{ __development_aur_packages.ides_arduino_ide }}'
+    state: "{{ 'present' if development_arduino_ide_enabled | bool else 'absent' }}"
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - __development_aur_packages.ides_arduino_ide | default([]) | length > 0
+  retries: 3
+  delay: 5
+
+- name: IDEs | Arduino IDE not available notice (non-Arch)
+  ansible.builtin.debug:
+    msg: 'Arduino IDE 2.x requires Flatpak (cc.arduino.IDE2) or AppImage on {{ ansible_facts["os_family"] }}.'
+  when:
+    - ansible_facts['os_family'] != 'Archlinux'
+    - development_arduino_ide_enabled | bool
+
+- name: IDEs | Generate Arduino IDE desktop override (Arch)
+  ansible.builtin.command: '/usr/local/bin/arduino-ide-desktop-override'
+  register: __development_arduino_override
+  changed_when: "'changed' in __development_arduino_override.stdout"
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - development_arduino_ide_enabled | bool
+
+- name: IDEs | Remove Arduino IDE desktop override artefacts (Arch)
+  ansible.builtin.file:
+    path: '{{ item }}'
+    state: absent
+  loop:
+    - '/etc/pacman.d/hooks/arduino-ide-desktop-override.hook'
+    - '/usr/local/bin/arduino-ide-desktop-override'
+    - '/usr/local/share/applications/arduino-ide-v2.desktop'
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - not development_arduino_ide_enabled | bool
+
+# Classic Arduino IDE 1.x (Arch AUR, Debian apt)
+
+- name: IDEs | Manage classic Arduino IDE from AUR (Arch)
+  become: true
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
+  kewlfft.aur.aur:
+    name: '{{ __development_aur_packages.ides_arduino_classic }}'
+    state: "{{ 'present' if development_arduino_classic_enabled | bool else 'absent' }}"
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - __development_aur_packages.ides_arduino_classic | default([]) | length > 0
+  retries: 3
+  delay: 5
+
+- name: IDEs | Manage classic Arduino IDE
+  ansible.builtin.package:
+    name: '{{ __development_arduino_classic_package }}'
+    state: "{{ 'present' if development_arduino_classic_enabled | bool else 'absent' }}"
+  when: __development_arduino_classic_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: IDEs | Classic Arduino IDE not available notice (RedHat)
+  ansible.builtin.debug:
+    msg: 'Classic Arduino IDE is not packaged for {{ ansible_facts["os_family"] }} (EPEL package is orphaned).'
+  when:
+    - ansible_facts['os_family'] != 'Archlinux'
+    - development_arduino_classic_enabled | bool
+    - __development_arduino_classic_package | default('') | length == 0
+
+# Arduino serial device access
+#
+# Membership is append-only: uucp/dialout may be required by other
+# tooling, so disabling the Arduino toggles does not remove users.
+
+- name: IDEs | Add development users to serial device groups (Arduino)
+  ansible.builtin.user:
+    name: '{{ item.0.username }}'
+    groups: '{{ item.1 }}'
+    append: true
+  loop: '{{ development_users | product(__development_serial_groups | default([])) | list }}'
+  loop_control:
+    label: '{{ item.0.username }}:{{ item.1 }}'
+  when: development_arduino_ide_enabled | bool or development_arduino_classic_enabled | bool
+
 # Postman (Arch AUR)
 
 - name: IDEs | Manage Postman from AUR (Arch)

--- a/roles/development/vars/Archlinux.yml
+++ b/roles/development/vars/Archlinux.yml
@@ -68,6 +68,11 @@ __development_lua_busted_package: 'busted'
 # QML tooling (qmllint + qmlformat ship in the same package)
 __development_qml_tools_package: 'qt6-declarative'
 
+# Serial device access for Arduino (uucp required for CH340 USB-serial
+# chips — uaccess from systemd-logind alone is not sufficient)
+__development_serial_groups:
+  - 'uucp'
+
 # AUR packages
 __development_aur_packages:
   ides_vscodium:
@@ -81,6 +86,10 @@ __development_aur_packages:
     - 'phpstorm-jre'
   ides_zed:
     - 'zed-editor'
+  ides_arduino_ide:
+    - 'arduino-ide-bin'
+  ides_arduino_classic:
+    - 'arduino'
   api_tools_postman:
     - 'postman-bin'
   api_tools_insomnia:

--- a/roles/development/vars/Debian.yml
+++ b/roles/development/vars/Debian.yml
@@ -44,6 +44,14 @@ __development_jetbrains_toolbox_package: ''
 __development_phpstorm_packages: []
 __development_zed_package: ''
 
+# Arduino: IDE 2.x is Flatpak/AppImage only (no-op via ides.yml notice);
+# the classic 1.x IDE is packaged officially
+__development_arduino_classic_package: 'arduino'
+
+# Serial device access for Arduino
+__development_serial_groups:
+  - 'dialout'
+
 # Database tools
 __development_dbeaver_package: ''
 __development_pgadmin_package: ''

--- a/roles/development/vars/RedHat-9.yml
+++ b/roles/development/vars/RedHat-9.yml
@@ -51,6 +51,14 @@ __development_jetbrains_toolbox_package: ''
 __development_phpstorm_packages: []
 __development_zed_package: ''
 
+# Arduino: IDE 2.x is Flatpak/AppImage only; the classic 1.x EPEL
+# package is orphaned (last build EPEL 7) — both no-op
+__development_arduino_classic_package: ''
+
+# Serial device access for Arduino
+__development_serial_groups:
+  - 'dialout'
+
 # Database tools
 __development_dbeaver_package: ''
 __development_pgadmin_package: 'pgadmin4'

--- a/roles/development/vars/RedHat.yml
+++ b/roles/development/vars/RedHat.yml
@@ -45,6 +45,14 @@ __development_jetbrains_toolbox_package: ''
 __development_phpstorm_packages: []
 __development_zed_package: ''
 
+# Arduino: IDE 2.x is Flatpak/AppImage only; the classic 1.x EPEL
+# package is orphaned (last build EPEL 7) — both no-op
+__development_arduino_classic_package: ''
+
+# Serial device access for Arduino
+__development_serial_groups:
+  - 'dialout'
+
 # Database tools
 __development_dbeaver_package: ''
 __development_pgadmin_package: 'pgadmin4'


### PR DESCRIPTION
Adds `development_arduino_ide_enabled` (Arduino IDE 2.x) and `development_arduino_classic_enabled` (classic 1.x IDE), both default `false`. Arch installs both via the existing `kewlfft.aur` path (`arduino-ide-bin`, `arduino`); Debian Trixie installs the classic IDE via apt and gets a `debug` notice for 2.x (Flatpak/AppImage only); EL stays a no-op for both (the classic EPEL package is orphaned).

When either toggle is enabled, `development_users` are added to the OS-specific serial device groups (`uucp` on Arch — required for CH340 USB-serial chips, `dialout` on Debian/EL), append-only, following the in-role pattern from `hardware_tokens` and `pipewire`.

On Arch a `.desktop` override redirects Arduino IDE 2.x stdout/stderr to `/dev/null` to suppress the uncaught EPIPE exception dialogs when launching from a desktop entry (arduino/arduino-ide#2340). The generator script and a pacman hook deploy before the AUR install, so the hook creates the override during the install transaction and regenerates it whenever `arduino-ide-bin` changes the packaged desktop file; an Ansible task covers hosts where the IDE predates the hook. Disabling the toggle removes override, hook, and script.

Verified locally: yamllint, ansible-lint (production profile), and shellcheck pass; the desktop override fix was verified on an Arch machine (no more error dialogs). Molecule keeps both toggles disabled like the other AUR-only IDEs.

Closes #143
