### PR TITLE
fix: replace hardcoded aur_builder with aur_builder_user variable

### DIFF
--- a/roles/ai/tasks/cli.yml
+++ b/roles/ai/tasks/cli.yml
@@ -7,7 +7,7 @@
 
 - name: CLI | Install Claude Code from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.claude_code }}'
     state: present
@@ -40,7 +40,7 @@
 
 - name: CLI | Install Gemini CLI from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.gemini_cli }}'
     state: present
@@ -66,7 +66,7 @@
 
 - name: CLI | Install Antigravity CLI from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.antigravity_cli }}'
     state: present
@@ -117,7 +117,7 @@
 
 - name: CLI | Install OpenCode from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.opencode }}'
     state: present
@@ -141,7 +141,7 @@
 
 - name: CLI | Install OpenCode Claude auth from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.opencode_claude_auth }}'
     state: present
@@ -167,7 +167,7 @@
 
 - name: CLI | Install OpenCode Gemini auth from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.opencode_gemini_auth }}'
     state: present
@@ -195,7 +195,7 @@
 
 - name: CLI | Install Aider from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.aider }}'
     state: present
@@ -220,7 +220,7 @@
 
 - name: CLI | Install Claude Cowork Service from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.claude_cowork_service }}'
     state: present

--- a/roles/ai/tasks/comfyui-archlinux.yml
+++ b/roles/ai/tasks/comfyui-archlinux.yml
@@ -19,7 +19,7 @@
 
 - name: ComfyUI | Install AUR package
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   environment:
     COMFYUI_GPU: "{{ __ai_comfyui_aur_gpu_map[ai_comfyui_gpu] | default('cpu') }}"
   kewlfft.aur.aur:

--- a/roles/ai/tasks/desktop.yml
+++ b/roles/ai/tasks/desktop.yml
@@ -7,7 +7,7 @@
 
 - name: Desktop | Install Claude Desktop from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.claude_desktop }}'
     state: present
@@ -31,7 +31,7 @@
 
 - name: Desktop | Install Antigravity from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.antigravity }}'
     state: present
@@ -56,7 +56,7 @@
 
 - name: Desktop | Install OpenCode Desktop from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.opencode_desktop }}'
     state: present

--- a/roles/ai/tasks/local.yml
+++ b/roles/ai/tasks/local.yml
@@ -71,7 +71,7 @@
 
 - name: Local | Install LM Studio from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __ai_aur_packages.lmstudio }}'
     state: present

--- a/roles/bluetooth/tasks/install.yml
+++ b/roles/bluetooth/tasks/install.yml
@@ -26,7 +26,7 @@
 
 - name: Install | Install AUR audio packages
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __bluetooth_aur_packages.alsa }}'
     state: present

--- a/roles/browser/tasks/install.yml
+++ b/roles/browser/tasks/install.yml
@@ -27,7 +27,7 @@
 
 - name: Install | LibreWolf from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __browser_aur_packages.librewolf }}'
     state: present
@@ -64,7 +64,7 @@
 
 - name: Install | Brave from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __browser_aur_packages.brave }}'
     state: present
@@ -89,7 +89,7 @@
 
 - name: Install | Import Tor Browser GPG key (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   ansible.builtin.shell:
     executable: /bin/bash
     cmd: |
@@ -105,7 +105,7 @@
 
 - name: Install | Tor Browser from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __browser_aur_packages.tor }}'
     state: present
@@ -132,7 +132,7 @@
 
 - name: Install | Zen Browser from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __browser_aur_packages.zen }}'
     state: present

--- a/roles/communication/tasks/install.yml
+++ b/roles/communication/tasks/install.yml
@@ -69,7 +69,7 @@
 
 - name: Install | Slack from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __communication_aur_packages.slack }}'
     state: present
@@ -82,7 +82,7 @@
 
 - name: Install | Slack Wayland from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __communication_aur_packages.slack_wayland }}'
     state: present
@@ -95,7 +95,7 @@
 
 - name: Install | Threema from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __communication_aur_packages.threema }}'
     state: present
@@ -107,7 +107,7 @@
 
 - name: Install | Zoom from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __communication_aur_packages.zoom }}'
     state: present
@@ -119,7 +119,7 @@
 
 - name: Install | Teams from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __communication_aur_packages.teams }}'
     state: present
@@ -131,7 +131,7 @@
 
 - name: Install | Jitsi Meet from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __communication_aur_packages.jitsi }}'
     state: present

--- a/roles/desktop_environment/tasks/hyprland.yml
+++ b/roles/desktop_environment/tasks/hyprland.yml
@@ -78,7 +78,7 @@
 
 - name: Hyprland | Install AUR packages (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __desktop_environment_hyprland_install_aur_packages }}'
     state: present

--- a/roles/desktop_environment/tasks/themes.yml
+++ b/roles/desktop_environment/tasks/themes.yml
@@ -45,7 +45,7 @@
 
 - name: Themes | Install AUR packages (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __desktop_environment_themes_aur_packages }}'
     state: present

--- a/roles/development/tasks/ides.yml
+++ b/roles/development/tasks/ides.yml
@@ -7,7 +7,7 @@
 
 - name: IDEs | Manage VSCodium from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __development_aur_packages.ides_vscodium }}'
     state: "{{ 'present' if development_vscodium_enabled | bool else 'absent' }}"
@@ -28,7 +28,7 @@
 
 - name: IDEs | Manage VS Code from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __development_aur_packages.ides_vscode }}'
     state: "{{ 'present' if development_vscode_enabled | bool else 'absent' }}"
@@ -42,7 +42,7 @@
 
 - name: IDEs | Manage PHPStorm from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __development_aur_packages.ides_phpstorm }}'
     state: "{{ 'present' if development_phpstorm_enabled | bool else 'absent' }}"
@@ -56,7 +56,7 @@
 
 - name: IDEs | Manage Zed from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __development_aur_packages.ides_zed }}'
     state: "{{ 'present' if development_zed_enabled | bool else 'absent' }}"
@@ -70,7 +70,7 @@
 
 - name: IDEs | Manage JetBrains Toolbox from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __development_aur_packages.ides_jetbrains }}'
     state: "{{ 'present' if development_jetbrains_toolbox_enabled | bool else 'absent' }}"
@@ -202,7 +202,7 @@
 
 - name: IDEs | Manage Postman from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __development_aur_packages.api_tools_postman }}'
     state: "{{ 'present' if development_postman_enabled | bool else 'absent' }}"
@@ -216,7 +216,7 @@
 
 - name: IDEs | Manage Insomnia from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __development_aur_packages.api_tools_insomnia }}'
     state: "{{ 'present' if development_insomnia_enabled | bool else 'absent' }}"
@@ -230,7 +230,7 @@
 
 - name: IDEs | Manage Bruno from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __development_aur_packages.api_tools_bruno }}'
     state: "{{ 'present' if development_bruno_enabled | bool else 'absent' }}"

--- a/roles/development/tasks/tools.yml
+++ b/roles/development/tasks/tools.yml
@@ -64,7 +64,7 @@
 
 - name: Tools | Install Socket CLI from AUR (Arch)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __development_aur_packages.security_socket_cli }}'
     state: present

--- a/roles/downloads/tasks/install.yml
+++ b/roles/downloads/tasks/install.yml
@@ -77,7 +77,7 @@
 
 - name: Install | JDownloader from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __downloads_aur_packages.jdownloader }}'
     state: present

--- a/roles/elgato/tasks/install.yml
+++ b/roles/elgato/tasks/install.yml
@@ -9,7 +9,7 @@
 
 - name: Install | StreamController from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __elgato_aur_packages.streamdeck }}'
     state: present
@@ -39,7 +39,7 @@
 
 - name: Install | elgato-keylight from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __elgato_aur_packages.keylight }}'
     state: present

--- a/roles/gaming/tasks/install.yml
+++ b/roles/gaming/tasks/install.yml
@@ -83,7 +83,7 @@
 
 - name: Install | Heroic Games Launcher from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __gaming_aur_packages.heroic }}'
     state: present
@@ -95,7 +95,7 @@
 
 - name: Install | Playback from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __gaming_aur_packages.playback }}'
     state: present
@@ -107,7 +107,7 @@
 
 - name: Install | PCSX2 from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __gaming_aur_packages.pcsx2 }}'
     state: present

--- a/roles/graphics_apps/tasks/install.yml
+++ b/roles/graphics_apps/tasks/install.yml
@@ -41,7 +41,7 @@
 
 - name: Install | XnConvert from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __graphics_apps_aur_packages.xnconvert }}'
     state: present
@@ -53,7 +53,7 @@
 
 - name: Install | XnView from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __graphics_apps_aur_packages.xnview }}'
     state: present

--- a/roles/imaging/tasks/install.yml
+++ b/roles/imaging/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install | VueScan from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __imaging_aur_packages.vuescan }}'
     state: present
@@ -42,7 +42,7 @@
 
 - name: Install | XSane from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __imaging_aur_packages.xsane }}'
     state: present

--- a/roles/multimedia/tasks/install.yml
+++ b/roles/multimedia/tasks/install.yml
@@ -51,7 +51,7 @@
 
 - name: Install | FFMultiConverter from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __multimedia_aur_packages.ffmulticonverter }}'
     state: present

--- a/roles/office/tasks/install.yml
+++ b/roles/office/tasks/install.yml
@@ -25,7 +25,7 @@
 
 - name: Install | OnlyOffice from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __office_aur_packages.onlyoffice }}'
     state: present
@@ -37,7 +37,7 @@
 
 - name: Install | WPS Office from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __office_aur_packages.wps }}'
     state: present
@@ -91,7 +91,7 @@
 
 - name: Install | Betterbird from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __office_betterbird_package }}'
     state: present
@@ -139,7 +139,7 @@
 
 - name: Install | Obsidian from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __office_aur_packages.obsidian }}'
     state: present
@@ -151,7 +151,7 @@
 
 - name: Install | Logseq from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __office_aur_packages.logseq }}'
     state: present
@@ -163,7 +163,7 @@
 
 - name: Install | Joplin from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __office_aur_packages.joplin }}'
     state: present
@@ -175,7 +175,7 @@
 
 - name: Install | Simplenote from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __office_aur_packages.simplenote }}'
     state: present
@@ -191,7 +191,7 @@
 
 - name: Install | Typora from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __office_aur_packages.typora }}'
     state: present

--- a/roles/remote_access/tasks/install.yml
+++ b/roles/remote_access/tasks/install.yml
@@ -39,7 +39,7 @@
 
 - name: Install | RustDesk from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __remote_access_aur_packages.rustdesk }}'
     state: present
@@ -51,7 +51,7 @@
 
 - name: Install | Asbru from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __remote_access_aur_packages.asbru }}'
     state: present
@@ -63,7 +63,7 @@
 
 - name: Install | RealVNC Viewer from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __remote_access_aur_packages.realvnc }}'
     state: present
@@ -75,7 +75,7 @@
 
 - name: Install | AnyDesk from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __remote_access_aur_packages.anydesk }}'
     state: present
@@ -87,7 +87,7 @@
 
 - name: Install | TeamViewer from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __remote_access_aur_packages.teamviewer }}'
     state: present

--- a/roles/security_apps/tasks/install.yml
+++ b/roles/security_apps/tasks/install.yml
@@ -31,7 +31,7 @@
 
 - name: Install | Cypherock CySync from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __security_apps_aur_packages.cypherock }}'
     state: present
@@ -43,7 +43,7 @@
 
 - name: Install | Ledger Live from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __security_apps_aur_packages.ledger }}'
     state: present
@@ -55,7 +55,7 @@
 
 - name: Install | Trezor Suite from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __security_apps_aur_packages.trezor }}'
     state: present

--- a/roles/tuxedo/tasks/install.yml
+++ b/roles/tuxedo/tasks/install.yml
@@ -60,7 +60,7 @@
 
 - name: Install | Tuxedo drivers from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __tuxedo_aur_packages.drivers }}'
     state: present
@@ -74,7 +74,7 @@
 
 - name: Install | Tuxedo Control Center from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __tuxedo_aur_packages.control_center }}'
     state: present
@@ -88,7 +88,7 @@
 
 - name: Install | YT6801 Ethernet driver from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __tuxedo_aur_packages.yt6801 }}'
     state: present

--- a/roles/wayland_utils/tasks/install.yml
+++ b/roles/wayland_utils/tasks/install.yml
@@ -59,7 +59,7 @@
 
 - name: Install | AUR packages (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __wayland_utils_aur_install_list }}'
     state: present


### PR DESCRIPTION
Replaces all 67 hardcoded `become_user: aur_builder` occurrences (quoted and unquoted) across 22 task files with `become_user: "{{ aur_builder_user | default('aur_builder') }}"`, so overriding `aur_builder_user` from inventory works consistently outside `package_management`. The `default()` fallback keeps standalone runs (molecule) working, since role defaults of `marcstraube.common.package_management` are not visible to other roles.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)