### PR TITLE
feat(development): add C/C++ toolchain toggles

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -61,6 +61,39 @@ overrides if needed.
 | `development_rust_components` | `[]`    | Rust components via rustup (non-Arch) |
 | `development_go_enabled`      | `false` | Enable Go installation                |
 | `development_java_enabled`    | `false` | Enable Java installation              |
+| `development_c_enabled`       | `false` | Enable C/C++ toolchain installation   |
+
+#### C/C++
+
+`development_c_enabled` installs the core C/C++ tooling block: `clang`
+(with `clang-format`, `clang-tidy` and the `clangd` LSP server), `gdb`
+and `pkgconf`. Fine-grained toggles add optional helpers:
+
+| Variable                          | Default | Description                                            |
+|-----------------------------------|---------|--------------------------------------------------------|
+| `development_c_codelldb_enabled`  | `false` | Enable codelldb LLDB debug adapter (Arch AUR only)     |
+| `development_c_ccache_enabled`    | `false` | Enable ccache compiler cache                           |
+| `development_c_valgrind_enabled`  | `false` | Enable valgrind memory and leak debugger               |
+| `development_c_cppcheck_enabled`  | `false` | Enable cppcheck static analysis                        |
+| `development_c_bear_enabled`      | `false` | Enable bear (`compile_commands.json` for non-CMake)    |
+
+Platform support:
+
+| Tool       | Arch      | Debian Trixie | EL 9       | EL 10      |
+|------------|-----------|---------------|------------|------------|
+| core block | yes       | yes           | yes        | yes        |
+| codelldb   | yes (AUR) | no            | no         | no         |
+| ccache     | yes       | yes           | yes (EPEL) | yes (EPEL) |
+| valgrind   | yes       | yes           | yes        | yes        |
+| cppcheck   | yes       | yes           | yes (EPEL) | yes (EPEL) |
+| bear       | yes       | yes           | yes (EPEL) | no         |
+
+On Debian the core block additionally installs the separate `clangd`,
+`clang-format` and `clang-tidy` packages; on EL they ship in
+`clang-tools-extra`. `codelldb` is the LLDB debug adapter used by
+VS Code/VSCodium/Zed for native debugging; upstream distributes only a
+VSIX archive, so it is AUR-only. `bear` is not packaged in EPEL 10.
+Enabling an unavailable combination is a no-op (codelldb logs a notice).
 
 ### Build Tools
 
@@ -326,6 +359,14 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - [Zed](https://zed.dev/) — High-performance multiplayer code editor
 - [Arduino IDE 2.x](https://github.com/arduino/arduino-ide) — Arduino IDE, Theia/Electron based
 - [Arduino IDE 1.x](https://github.com/arduino/Arduino) — Classic Arduino IDE, Java/Swing based
+- [clang](https://clang.llvm.org/) — C/C++ compiler with clang-format, clang-tidy and clangd
+- [gdb](https://www.sourceware.org/gdb/) — GNU debugger
+- [pkgconf](https://github.com/pkgconf/pkgconf) — Library discovery for build systems
+- [codelldb](https://github.com/vadimcn/codelldb) — LLDB debug adapter for VS Code/VSCodium/Zed
+- [ccache](https://ccache.dev/) — Compiler cache
+- [valgrind](https://valgrind.org/) — Memory and leak debugger
+- [cppcheck](https://cppcheck.sourceforge.io/) — C/C++ static analysis
+- [bear](https://github.com/rizsotto/Bear) — compile_commands.json generator for non-CMake builds
 - [shfmt](https://github.com/mvdan/sh) — Shell formatter
 - [shellcheck](https://github.com/koalaman/shellcheck) — Shell script static analysis
 - [bats-core](https://github.com/bats-core/bats-core) — Bash automated testing system

--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -84,7 +84,7 @@ Platform support:
 | core block | yes       | yes           | yes        | yes        |
 | codelldb   | yes (AUR) | no            | no         | no         |
 | ccache     | yes       | yes           | yes (EPEL) | yes (EPEL) |
-| valgrind   | yes       | yes           | yes        | yes        |
+| valgrind   | yes       | yes           | yes\*      | yes\*      |
 | cppcheck   | yes       | yes           | yes (EPEL) | yes (EPEL) |
 | bear       | yes       | yes           | yes (EPEL) | no         |
 
@@ -94,6 +94,10 @@ On Debian the core block additionally installs the separate `clangd`,
 VS Code/VSCodium/Zed for native debugging; upstream distributes only a
 VSIX archive, so it is AUR-only. `bear` is not packaged in EPEL 10.
 Enabling an unavailable combination is a no-op (codelldb logs a notice).
+
+\* On EL, `valgrind` ships with the `@Development Tools` group pulled in by
+the build-tools section, so its own toggle is a no-op there — it is present
+whenever the build tools are installed.
 
 ### Build Tools
 

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -74,6 +74,27 @@ development_go_enabled: false
 # for per-project version control use mise/sdkman/asdf instead)
 development_java_enabled: false
 
+# C/C++
+
+# Enable the core C/C++ tooling block (clang incl. clang-format,
+# clang-tidy and clangd, gdb, pkgconf)
+development_c_enabled: false
+
+# Enable codelldb LLDB debug adapter (AUR only — no-op on Debian/RedHat)
+development_c_codelldb_enabled: false
+
+# Enable ccache compiler cache
+development_c_ccache_enabled: false
+
+# Enable valgrind memory and leak debugger
+development_c_valgrind_enabled: false
+
+# Enable cppcheck static analysis
+development_c_cppcheck_enabled: false
+
+# Enable bear (generates compile_commands.json for non-CMake projects)
+development_c_bear_enabled: false
+
 #
 # Language Tooling
 #

--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -17,6 +17,7 @@
     development_rust_enabled: false
     development_go_enabled: false
     development_java_enabled: false
+    development_c_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
@@ -73,6 +74,7 @@
     development_rust_enabled: false
     development_go_enabled: false
     development_java_enabled: false
+    development_c_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
@@ -144,6 +146,7 @@
     development_rust_enabled: false
     development_go_enabled: false
     development_java_enabled: false
+    development_c_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false

--- a/roles/development/molecule/default/verify.yml
+++ b/roles/development/molecule/default/verify.yml
@@ -234,6 +234,28 @@
       when: __development_qml_tools_package | default('') | length > 0
 
     #
+    # C/C++ toolchain (umbrella enabled, fine-grained tools disabled)
+    #
+
+    - name: Verify | C/C++ toolchain — packages installed
+      ansible.builtin.package:
+        name: '{{ __development_c_packages }}'
+        state: present
+      check_mode: true
+      register: _dev_c_check
+      failed_when: _dev_c_check.changed
+      when: __development_c_packages | default([]) | length > 0
+
+    - name: Verify | ccache disabled — package not installed
+      ansible.builtin.package:
+        name: '{{ __development_c_ccache_package }}'
+        state: absent
+      check_mode: true
+      register: _dev_ccache_check
+      failed_when: _dev_ccache_check.changed
+      when: __development_c_ccache_package | default('') | length > 0
+
+    #
     # Toggle verification: cmake enabled, meson disabled
     #
 

--- a/roles/development/tasks/languages.yml
+++ b/roles/development/tasks/languages.yml
@@ -77,3 +77,69 @@
   when: development_java_enabled | bool
   retries: 3
   delay: 5
+
+# C/C++
+#
+# The core block (clang, gdb, pkgconf) uses 'when' skip like the other
+# languages above. The fine-grained helper tools below are leaf packages
+# without reverse dependencies and are managed present/absent like the
+# language tooling toggles.
+
+- name: Languages | Install C/C++ toolchain
+  ansible.builtin.package:
+    name: '{{ __development_c_packages }}'
+    state: present
+  when: development_c_enabled | bool
+  retries: 3
+  delay: 5
+
+- name: Languages | Manage codelldb from AUR (Arch)
+  become: true
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
+  kewlfft.aur.aur:
+    name: '{{ __development_aur_packages.c_codelldb }}'
+    state: "{{ 'present' if development_c_codelldb_enabled | bool else 'absent' }}"
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - __development_aur_packages.c_codelldb | default([]) | length > 0
+  retries: 3
+  delay: 5
+
+- name: Languages | codelldb not available notice (non-Arch)
+  ansible.builtin.debug:
+    msg: 'codelldb is not packaged for {{ ansible_facts["os_family"] }} (upstream ships a VSIX archive only).'
+  when:
+    - ansible_facts['os_family'] != 'Archlinux'
+    - development_c_codelldb_enabled | bool
+
+- name: Languages | Manage ccache
+  ansible.builtin.package:
+    name: '{{ __development_c_ccache_package }}'
+    state: "{{ 'present' if development_c_ccache_enabled | bool else 'absent' }}"
+  when: __development_c_ccache_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Languages | Manage valgrind
+  ansible.builtin.package:
+    name: '{{ __development_c_valgrind_package }}'
+    state: "{{ 'present' if development_c_valgrind_enabled | bool else 'absent' }}"
+  when: __development_c_valgrind_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Languages | Manage cppcheck
+  ansible.builtin.package:
+    name: '{{ __development_c_cppcheck_package }}'
+    state: "{{ 'present' if development_c_cppcheck_enabled | bool else 'absent' }}"
+  when: __development_c_cppcheck_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
+- name: Languages | Manage bear
+  ansible.builtin.package:
+    name: '{{ __development_c_bear_package }}'
+    state: "{{ 'present' if development_c_bear_enabled | bool else 'absent' }}"
+  when: __development_c_bear_package | default('') | length > 0
+  retries: 3
+  delay: 5

--- a/roles/development/vars/Archlinux.yml
+++ b/roles/development/vars/Archlinux.yml
@@ -29,6 +29,17 @@ __development_go_packages:
 # Java
 __development_java_package: 'jdk-openjdk'
 
+# C/C++ (clang bundles clang-format, clang-tidy and clangd)
+__development_c_packages:
+  - 'clang'
+  - 'gdb'
+  - 'pkgconf'
+
+__development_c_ccache_package: 'ccache'
+__development_c_valgrind_package: 'valgrind'
+__development_c_cppcheck_package: 'cppcheck'
+__development_c_bear_package: 'bear'
+
 # Build tools
 __development_build_packages:
   - 'base-devel'
@@ -98,3 +109,5 @@ __development_aur_packages:
     - 'bruno-bin'
   security_socket_cli:
     - 'socket-cli'
+  c_codelldb:
+    - 'codelldb-bin'

--- a/roles/development/vars/Debian.yml
+++ b/roles/development/vars/Debian.yml
@@ -28,6 +28,20 @@ __development_go_packages:
 # Java
 __development_java_package: 'openjdk-17-jdk'
 
+# C/C++ (clangd, clang-format and clang-tidy are separate packages on Debian)
+__development_c_packages:
+  - 'clang'
+  - 'clangd'
+  - 'clang-format'
+  - 'clang-tidy'
+  - 'gdb'
+  - 'pkgconf'
+
+__development_c_ccache_package: 'ccache'
+__development_c_valgrind_package: 'valgrind'
+__development_c_cppcheck_package: 'cppcheck'
+__development_c_bear_package: 'bear'
+
 # Build tools
 __development_build_packages:
   - 'build-essential'

--- a/roles/development/vars/RedHat-9.yml
+++ b/roles/development/vars/RedHat-9.yml
@@ -43,9 +43,12 @@ __development_c_packages:
   - 'gdb'
   - 'pkgconf'
 
-# ccache, cppcheck and bear via EPEL (bear ships in EPEL 9 but not EPEL 10)
+# ccache, cppcheck and bear via EPEL (bear ships in EPEL 9 but not EPEL 10).
+# valgrind ships with @Development Tools (build tools) on EL — managing it
+# separately fights that group install and breaks idempotence, so it is a
+# no-op here and comes in with the build tools.
 __development_c_ccache_package: 'ccache'
-__development_c_valgrind_package: 'valgrind'
+__development_c_valgrind_package: ''
 __development_c_cppcheck_package: 'cppcheck'
 __development_c_bear_package: 'bear'
 

--- a/roles/development/vars/RedHat-9.yml
+++ b/roles/development/vars/RedHat-9.yml
@@ -7,6 +7,7 @@
 # loads only one file per host. EL9-specific overrides are:
 # - ruff: not packaged on EL9 (EPEL 10 ships it, EPEL 9 does not).
 # - uv: not packaged on EL9 (EPEL 10 ships it, EPEL 9 does not).
+# - bear: packaged on EL9 (EPEL 9 ships it, EPEL 10 does not).
 #
 
 # Version control
@@ -34,6 +35,19 @@ __development_go_packages:
 
 # Java
 __development_java_package: 'java-21-openjdk-devel'
+
+# C/C++ (clang-tools-extra provides clangd, clang-format and clang-tidy)
+__development_c_packages:
+  - 'clang'
+  - 'clang-tools-extra'
+  - 'gdb'
+  - 'pkgconf'
+
+# ccache, cppcheck and bear via EPEL (bear ships in EPEL 9 but not EPEL 10)
+__development_c_ccache_package: 'ccache'
+__development_c_valgrind_package: 'valgrind'
+__development_c_cppcheck_package: 'cppcheck'
+__development_c_bear_package: 'bear'
 
 # Build tools
 __development_build_packages:

--- a/roles/development/vars/RedHat.yml
+++ b/roles/development/vars/RedHat.yml
@@ -36,9 +36,12 @@ __development_c_packages:
   - 'gdb'
   - 'pkgconf'
 
-# ccache and cppcheck via EPEL; bear is not packaged in EPEL 10
+# ccache and cppcheck via EPEL; bear is not packaged in EPEL 10.
+# valgrind ships with @Development Tools (build tools) on EL — managing it
+# separately fights that group install and breaks idempotence, so it is a
+# no-op here and comes in with the build tools.
 __development_c_ccache_package: 'ccache'
-__development_c_valgrind_package: 'valgrind'
+__development_c_valgrind_package: ''
 __development_c_cppcheck_package: 'cppcheck'
 __development_c_bear_package: ''
 

--- a/roles/development/vars/RedHat.yml
+++ b/roles/development/vars/RedHat.yml
@@ -29,6 +29,19 @@ __development_go_packages:
 # Java
 __development_java_package: 'java-21-openjdk-devel'
 
+# C/C++ (clang-tools-extra provides clangd, clang-format and clang-tidy)
+__development_c_packages:
+  - 'clang'
+  - 'clang-tools-extra'
+  - 'gdb'
+  - 'pkgconf'
+
+# ccache and cppcheck via EPEL; bear is not packaged in EPEL 10
+__development_c_ccache_package: 'ccache'
+__development_c_valgrind_package: 'valgrind'
+__development_c_cppcheck_package: 'cppcheck'
+__development_c_bear_package: ''
+
 # Build tools
 __development_build_packages:
   - '@Development Tools'


### PR DESCRIPTION
## Summary

Adds a C/C++ language-tooling profile to the `development` role, complementing the existing build-tool toggles (`make`/`cmake`/`meson`/`ninja`). Consumers get a single umbrella toggle for the common case plus fine-grained toggles for optional helpers.

## Changes

- `development_c_enabled` (default `false`) installs the core block: `clang` (bundling `clang-format`, `clang-tidy`, `clangd`), `gdb`, `pkgconf`.
- Fine-grained toggles, all default `false`, managed present/absent as leaf packages: `development_c_codelldb_enabled`, `development_c_ccache_enabled`, `development_c_valgrind_enabled`, `development_c_cppcheck_enabled`, `development_c_bear_enabled`.
- `codelldb-bin` via `kewlfft.aur.aur` on Arch only; non-Arch logs a notice (upstream ships a VSIX archive only).
- Per-OS packaging in `vars/*.yml`: Debian splits `clangd`/`clang-format`/`clang-tidy` into separate packages, EL ships them in `clang-tools-extra`.
- README: new toggles documented with a per-OS coverage matrix.
- Molecule `converge` + `verify` exercise the umbrella toggle on the Arch platform.

## Platform note

`bear` is packaged in EPEL 9 but not EPEL 10, so on EL10 it resolves to the `''` no-op (`vars/RedHat.yml`) while EL9 installs it (`vars/RedHat-9.yml`). This refines the issue's availability table, which listed `bear` as EPEL for both EL9 and EL10.

## Test plan

- [x] `ansible-lint` (production profile) + `yamllint` — clean
- [x] Molecule Arch: `converge`, `idempotence` (changed=0), `verify` — passed
- [ ] CI: Debian Trixie / Rocky 9 / Rocky 10 molecule — gating before merge

Closes #148
