### PR TITLE
feat(development): add gb_dev subsection (gbdk-2020 + gb-studio)

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -99,6 +99,27 @@ Enabling an unavailable combination is a no-op (codelldb logs a notice).
 the build-tools section, so its own toggle is a no-op there — it is present
 whenever the build tools are installed.
 
+#### Gameboy Development
+
+Game Boy / Game Boy Color homebrew tooling. Both tools are AUR-only on
+Arch and unpackaged on Debian/RedHat (upstream ships tarball and AppImage
+releases), so enabling them there is a no-op that logs a notice.
+
+| Variable                          | Default | Description                                  |
+|-----------------------------------|---------|----------------------------------------------|
+| `development_gb_gbdk_enabled`     | `false` | Enable the GBDK-2020 cross-compile toolchain |
+| `development_gb_gbstudio_enabled` | `false` | Enable the GB Studio visual game maker       |
+
+Platform support:
+
+| Tool      | Arch      | Debian Trixie | EL 9 | EL 10 |
+|-----------|-----------|---------------|------|-------|
+| GBDK-2020 | yes (AUR) | no            | no   | no    |
+| GB Studio | yes (AUR) | no            | no   | no    |
+
+`GBDK-2020` builds from source via the AUR (SDCC-based); `gb-studio-bin`
+is the AppImage-derived AUR package.
+
 ### Build Tools
 
 | Variable                    | Default | Description                      |
@@ -371,6 +392,8 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - [valgrind](https://valgrind.org/) — Memory and leak debugger
 - [cppcheck](https://cppcheck.sourceforge.io/) — C/C++ static analysis
 - [bear](https://github.com/rizsotto/Bear) — compile_commands.json generator for non-CMake builds
+- [GBDK-2020](https://github.com/gbdk-2020/gbdk-2020) — Game Boy Development Kit (SDCC-based cross-compile toolchain)
+- [GB Studio](https://www.gbstudio.dev/) — Visual Game Boy game maker
 - [shfmt](https://github.com/mvdan/sh) — Shell formatter
 - [shellcheck](https://github.com/koalaman/shellcheck) — Shell script static analysis
 - [bats-core](https://github.com/bats-core/bats-core) — Bash automated testing system

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -95,6 +95,17 @@ development_c_cppcheck_enabled: false
 # Enable bear (generates compile_commands.json for non-CMake projects)
 development_c_bear_enabled: false
 
+# Gameboy development
+#
+# GBDK-2020 and GB Studio are AUR only — no-op on Debian/RedHat.
+
+# Enable the GBDK-2020 toolchain (SDCC-based cross-compiler and
+# libraries for GB / GBC / SGB)
+development_gb_gbdk_enabled: false
+
+# Enable the GB Studio visual game maker
+development_gb_gbstudio_enabled: false
+
 #
 # Language Tooling
 #

--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -18,6 +18,8 @@
     development_go_enabled: false
     development_java_enabled: false
     development_c_enabled: true
+    development_gb_gbdk_enabled: true
+    development_gb_gbstudio_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
@@ -75,6 +77,8 @@
     development_go_enabled: false
     development_java_enabled: false
     development_c_enabled: true
+    development_gb_gbdk_enabled: true
+    development_gb_gbstudio_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
@@ -147,6 +151,8 @@
     development_go_enabled: false
     development_java_enabled: false
     development_c_enabled: true
+    development_gb_gbdk_enabled: true
+    development_gb_gbstudio_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false

--- a/roles/development/tasks/gb_dev.yml
+++ b/roles/development/tasks/gb_dev.yml
@@ -1,0 +1,46 @@
+---
+#
+# Gameboy Development Tools
+#
+# GBDK-2020 (SDCC-based cross-compile toolchain) and GB Studio (visual
+# game maker) are AUR-only on Arch. Upstream ships tarball / AppImage
+# releases on Debian and RedHat, so they are a no-op there (a notice is
+# logged) until the cross-collection alternative-installs strategy lands.
+
+- name: GB Dev | Manage GBDK-2020 from AUR (Arch)
+  become: true
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
+  kewlfft.aur.aur:
+    name: '{{ __development_aur_packages.gb_gbdk }}'
+    state: "{{ 'present' if development_gb_gbdk_enabled | bool else 'absent' }}"
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - __development_aur_packages.gb_gbdk | default([]) | length > 0
+  retries: 3
+  delay: 5
+
+- name: GB Dev | GBDK-2020 not available notice (non-Arch)
+  ansible.builtin.debug:
+    msg: 'GBDK-2020 is not packaged for {{ ansible_facts["os_family"] }} (upstream ships tarball releases only).'
+  when:
+    - ansible_facts['os_family'] != 'Archlinux'
+    - development_gb_gbdk_enabled | bool
+
+- name: GB Dev | Manage GB Studio from AUR (Arch)
+  become: true
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
+  kewlfft.aur.aur:
+    name: '{{ __development_aur_packages.gb_gbstudio }}'
+    state: "{{ 'present' if development_gb_gbstudio_enabled | bool else 'absent' }}"
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - __development_aur_packages.gb_gbstudio | default([]) | length > 0
+  retries: 3
+  delay: 5
+
+- name: GB Dev | GB Studio not available notice (non-Arch)
+  ansible.builtin.debug:
+    msg: 'GB Studio is not packaged for {{ ansible_facts["os_family"] }} (upstream ships an AppImage only).'
+  when:
+    - ansible_facts['os_family'] != 'Archlinux'
+    - development_gb_gbstudio_enabled | bool

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -69,6 +69,13 @@
     - development
     - development:ides
 
+- name: Main | Import Gameboy development tasks
+  ansible.builtin.import_tasks: gb_dev.yml
+  when: development_enabled | bool
+  tags:
+    - development
+    - development:gb-dev
+
 - name: Main | Import misc tools tasks
   ansible.builtin.import_tasks: tools.yml
   when: development_enabled | bool

--- a/roles/development/vars/Archlinux.yml
+++ b/roles/development/vars/Archlinux.yml
@@ -111,3 +111,7 @@ __development_aur_packages:
     - 'socket-cli'
   c_codelldb:
     - 'codelldb-bin'
+  gb_gbdk:
+    - 'gbdk-2020'
+  gb_gbstudio:
+    - 'gb-studio-bin'


### PR DESCRIPTION
## Summary

Adds a Gameboy / Gameboy Color homebrew tooling subsection to the `development` role. Follows the established AUR-only pattern: an entry in the `__development_aur_packages` dict in `vars/Archlinux.yml`, an `os_family` guard, and a non-Arch notice — with no vars entries on Debian/RedHat, per `role-template.md`.

## Changes

- `development_gb_gbdk_enabled` (default `false`) installs GBDK-2020 (SDCC-based cross-compile toolchain for GB/GBC/SGB) via the `gbdk-2020` AUR package.
- `development_gb_gbstudio_enabled` (default `false`) installs GB Studio (visual game maker) via the `gb-studio-bin` AUR package.
- Non-Arch logs a notice (upstream ships tarball / AppImage releases only); no `__pkg: ''` vars on Debian/RedHat.
- New `tasks/gb_dev.yml` imported from `tasks/main.yml` (tag `development:gb-dev`).
- README: Gameboy Development subsection + per-OS coverage matrix + upstream links.
- Molecule converge enables both toggles across all three plays (identical toggle set keeps the sequence idempotent).

## Test plan

- [x] `ansible-lint` (production profile) + `yamllint` — clean
- [x] Molecule Arch: `converge`, `idempotence`, `verify` — all Successful (gbdk-2020 AUR source build + gb-studio-bin installed, idempotent)
- [ ] CI: Debian Trixie / Rocky 9 / Rocky 10 — non-Arch notice path, gating before merge

Closes #151
