### PR TITLE
feat(development): add devkitPro subsection for Nintendo homebrew toolchains

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -120,6 +120,49 @@ Platform support:
 `GBDK-2020` builds from source via the AUR (SDCC-based); `gb-studio-bin`
 is the AppImage-derived AUR package.
 
+#### devkitPro (Nintendo Homebrew)
+
+devkitARM / devkitPPC / devkitA64 cross-compiler toolchains for Nintendo
+consoles, distributed via devkitPro's own pacman repositories. A master
+toggle enables the repo tooling; per-platform toggles select the package
+groups to install.
+
+| Variable                                     | Default | Description                            |
+|----------------------------------------------|---------|----------------------------------------|
+| `development_devkitpro_enabled`              | `false` | Master toggle (keyring + environment)  |
+| `development_devkitpro_gba_dev_enabled`      | `false` | Game Boy Advance toolchain (`gba-dev`) |
+| `development_devkitpro_nds_dev_enabled`      | `false` | Nintendo DS toolchain (`nds-dev`)      |
+| `development_devkitpro_3ds_dev_enabled`      | `false` | Nintendo 3DS toolchain (`3ds-dev`)     |
+| `development_devkitpro_gamecube_dev_enabled` | `false` | GameCube toolchain (`gamecube-dev`)    |
+| `development_devkitpro_wii_dev_enabled`      | `false` | Wii toolchain (`wii-dev`)              |
+| `development_devkitpro_switch_dev_enabled`   | `false` | Switch toolchain (`switch-dev`)        |
+
+Platform support:
+
+| Feature              | Arch | Debian Trixie | EL 9 | EL 10 |
+|----------------------|------|---------------|------|-------|
+| devkitPro toolchains | yes  | no            | no   | no    |
+
+The `dkp-libs` / `dkp-linux` repos are **registered by
+`marcstraube.common.package_management`**, which owns `/etc/pacman.conf`.
+The role ships the ready-made repo definitions in
+`development_devkitpro_repositories` (including the signing key); wire
+them into your inventory once:
+
+```yaml
+# group_vars/workstations/vars.yml
+pacman_custom_repositories: "{{ development_devkitpro_repositories }}"
+# ...or append to an existing list:
+#   pacman_custom_repositories: "{{ my_repos + development_devkitpro_repositories }}"
+```
+
+`package_management` then imports and locally signs the devkitPro master
+key; this role installs `devkitpro-keyring`, the `devkit-env` package
+(which provides `DEVKITPRO`, `DEVKITARM`, `DEVKITPPC`, `DEVKITA64` and
+`PATH` system-wide via `/etc/profile.d/devkit-env.sh`), and the selected
+platform groups. Debian/RedHat are a no-op (a notice is logged) until
+the cross-collection alternative-installs strategy lands.
+
 ### Build Tools
 
 | Variable                    | Default | Description                      |
@@ -394,6 +437,8 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - [bear](https://github.com/rizsotto/Bear) — compile_commands.json generator for non-CMake builds
 - [GBDK-2020](https://github.com/gbdk-2020/gbdk-2020) — Game Boy Development Kit (SDCC-based cross-compile toolchain)
 - [GB Studio](https://www.gbstudio.dev/) — Visual Game Boy game maker
+- [devkitPro](https://devkitpro.org/) — Nintendo console homebrew toolchains (devkitARM/devkitPPC/devkitA64)
+- [devkitPro pacman](https://github.com/devkitPro/pacman) — Package manager and repositories for the toolchains
 - [shfmt](https://github.com/mvdan/sh) — Shell formatter
 - [shellcheck](https://github.com/koalaman/shellcheck) — Shell script static analysis
 - [bats-core](https://github.com/bats-core/bats-core) — Bash automated testing system

--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -160,8 +160,10 @@ pacman_custom_repositories: "{{ development_devkitpro_repositories }}"
 key; this role installs `devkitpro-keyring`, the `devkit-env` package
 (which provides `DEVKITPRO`, `DEVKITARM`, `DEVKITPPC`, `DEVKITA64` and
 `PATH` system-wide via `/etc/profile.d/devkit-env.sh`), and the selected
-platform groups. Debian/RedHat are a no-op (a notice is logged) until
-the cross-collection alternative-installs strategy lands.
+platform groups. The groups share common members (compilers, tools), so
+they are install-only — disabling a platform toggle after install does
+not uninstall the toolchain. Debian/RedHat are a no-op (a notice is
+logged) until the cross-collection alternative-installs strategy lands.
 
 ### Build Tools
 

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -106,6 +106,43 @@ development_gb_gbdk_enabled: false
 # Enable the GB Studio visual game maker
 development_gb_gbstudio_enabled: false
 
+# devkitPro — Nintendo console homebrew toolchains
+#
+# devkitARM / devkitPPC / devkitA64 cross-compilers distributed via
+# devkitPro's own pacman repositories (dkp-libs, dkp-linux). Registering
+# those repos is package_management's job (it owns /etc/pacman.conf); to
+# enable them, merge development_devkitpro_repositories into
+# `pacman_custom_repositories` in your inventory — this role then
+# installs the signing keyring, the system-wide environment, and the
+# requested platform groups. Arch only — a no-op on Debian/RedHat until
+# the cross-collection alternative-installs strategy lands.
+
+# Enable the devkitPro toolchain block (master toggle — gates all
+# per-platform toggles below; installs devkitpro-keyring + devkit-env)
+development_devkitpro_enabled: false
+
+# devkitPro pacman repositories, provided ready-made so you do not have
+# to hand-type the signing key and server URLs. Registration itself
+# happens in marcstraube.common.package_management — wire it up once in
+# inventory group_vars:
+#   pacman_custom_repositories: "{{ development_devkitpro_repositories }}"
+development_devkitpro_repositories:
+  - name: 'dkp-libs'
+    server: 'https://pkg.devkitpro.org/packages'
+    key_id: 'BC26F752D25B92CE272E0F44F7FD5492264BB9D0'
+    keyserver: 'keyserver.ubuntu.com'
+  - name: 'dkp-linux'
+    server: 'https://pkg.devkitpro.org/packages/linux/$arch'
+
+# Per-platform toolchain groups (each pulls its devkit* compiler plus
+# libraries and tools). All require development_devkitpro_enabled.
+development_devkitpro_gba_dev_enabled: false        # Game Boy Advance (devkitARM)
+development_devkitpro_nds_dev_enabled: false        # Nintendo DS (devkitARM)
+development_devkitpro_3ds_dev_enabled: false        # Nintendo 3DS (devkitARM)
+development_devkitpro_gamecube_dev_enabled: false   # GameCube (devkitPPC)
+development_devkitpro_wii_dev_enabled: false        # Wii (devkitPPC)
+development_devkitpro_switch_dev_enabled: false     # Switch (devkitA64)
+
 #
 # Language Tooling
 #

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -136,6 +136,8 @@ development_devkitpro_repositories:
 
 # Per-platform toolchain groups (each pulls its devkit* compiler plus
 # libraries and tools). All require development_devkitpro_enabled.
+# Install-only: the groups share common members, so disabling a toggle
+# after install does not uninstall the toolchain.
 development_devkitpro_gba_dev_enabled: false        # Game Boy Advance (devkitARM)
 development_devkitpro_nds_dev_enabled: false        # Nintendo DS (devkitARM)
 development_devkitpro_3ds_dev_enabled: false        # Nintendo 3DS (devkitARM)

--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -4,6 +4,11 @@
 # packages when their toggle flips to false, which would otherwise make
 # play 1 reinstall on every converge). Only development_user_config_mode and
 # development_users differ between the plays.
+#
+# The devkitPro dkp-libs / dkp-linux repositories the toolchain toggles
+# depend on are registered in prepare.yml (via the real
+# marcstraube.common.package_management pacman tasks), so package_management's
+# own idempotence is not coupled to this scenario's idempotence gate.
 - name: Converge | Managed mode
   hosts: all
   gather_facts: true
@@ -20,6 +25,8 @@
     development_c_enabled: true
     development_gb_gbdk_enabled: true
     development_gb_gbstudio_enabled: true
+    development_devkitpro_enabled: true
+    development_devkitpro_gba_dev_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
@@ -79,6 +86,8 @@
     development_c_enabled: true
     development_gb_gbdk_enabled: true
     development_gb_gbstudio_enabled: true
+    development_devkitpro_enabled: true
+    development_devkitpro_gba_dev_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false
@@ -153,6 +162,8 @@
     development_c_enabled: true
     development_gb_gbdk_enabled: true
     development_gb_gbstudio_enabled: true
+    development_devkitpro_enabled: true
+    development_devkitpro_gba_dev_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
     development_zed_enabled: false

--- a/roles/development/molecule/default/prepare.yml
+++ b/roles/development/molecule/default/prepare.yml
@@ -165,3 +165,28 @@
         - dev_global_disabled
       loop_control:
         label: '{{ item }}'
+
+    #
+    # devkitPro repositories (Arch) — registered exactly as
+    # marcstraube.common.package_management does in production (it owns
+    # /etc/pacman.conf), so the development role's devkitPro tasks have
+    # the dkp-libs / dkp-linux repos and a locally-signed master key to
+    # work against. Uses the role's own development_devkitpro_repositories
+    # default, proving the documented inventory wiring. Kept in prepare
+    # (runs once) so package_management's own idempotence is not coupled
+    # to this scenario's idempotence gate.
+    #
+    - name: Prepare | Register devkitPro pacman repositories (Arch)
+      when: ansible_facts['os_family'] == 'Archlinux'
+      block:
+        - name: Prepare | Load development role defaults for devkitPro repos
+          ansible.builtin.include_vars:
+            file: '{{ playbook_dir }}/../../defaults/main.yml'
+            name: __dev_defaults
+
+        - name: Prepare | Configure pacman with devkitPro custom repositories
+          ansible.builtin.include_role:
+            name: marcstraube.common.package_management
+            tasks_from: archlinux/pacman.yml
+          vars:
+            pacman_custom_repositories: '{{ __dev_defaults.development_devkitpro_repositories }}'

--- a/roles/development/molecule/default/prepare.yml
+++ b/roles/development/molecule/default/prepare.yml
@@ -179,6 +179,16 @@
     - name: Prepare | Register devkitPro pacman repositories (Arch)
       when: ansible_facts['os_family'] == 'Archlinux'
       block:
+        # The minimal CI container ships an uninitialised pacman keyring
+        # (no local signing key), so package_management's `pacman-key
+        # --lsign-key` for the devkitPro master key fails with "no secret
+        # key available to sign with". A real Arch install always has this
+        # initialised; generate it here as a container precondition.
+        - name: Prepare | Initialize the pacman keyring
+          ansible.builtin.command:
+            cmd: 'pacman-key --init'
+          changed_when: true
+
         - name: Prepare | Load development role defaults for devkitPro repos
           ansible.builtin.include_vars:
             file: '{{ playbook_dir }}/../../defaults/main.yml'

--- a/roles/development/molecule/default/verify.yml
+++ b/roles/development/molecule/default/verify.yml
@@ -311,6 +311,56 @@
       when: ansible_facts['os_family'] != 'Archlinux'
 
     #
+    # devkitPro (Arch only — master + gba-dev enabled, switch-dev absent).
+    # No-op on non-Arch, so nothing to verify there.
+    #
+
+    - name: Verify | devkitpro-keyring installed (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q devkitpro-keyring'
+      register: _dev_dkp_keyring
+      changed_when: false
+      failed_when: _dev_dkp_keyring.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | devkit-env installed (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q devkit-env'
+      register: _dev_dkp_env
+      changed_when: false
+      failed_when: _dev_dkp_env.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | Stat devkit-env profile script (Arch)
+      ansible.builtin.stat:
+        path: /etc/profile.d/devkit-env.sh
+      register: _dev_dkp_profile
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | Assert devkit-env profile script exists (Arch)
+      ansible.builtin.assert:
+        that:
+          - _dev_dkp_profile.stat.exists
+        fail_msg: '/etc/profile.d/devkit-env.sh not shipped by devkit-env'
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | devkitARM compiler runs (Arch)
+      ansible.builtin.command:
+        cmd: '/opt/devkitpro/devkitARM/bin/arm-none-eabi-gcc --version'
+      register: _dev_dkp_gcc
+      changed_when: false
+      failed_when: _dev_dkp_gcc.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | switch-dev toolchain absent (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q devkitA64'
+      register: _dev_dkp_switch
+      changed_when: false
+      failed_when: _dev_dkp_switch.rc == 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    #
     # user_config_mode coverage — per-user git config (~/.gitconfig)
     #
 

--- a/roles/development/tasks/devkitpro.yml
+++ b/roles/development/tasks/devkitpro.yml
@@ -1,0 +1,77 @@
+---
+#
+# devkitPro — Nintendo console homebrew toolchains
+#
+# devkitARM / devkitPPC / devkitA64 cross-compilers and libraries,
+# distributed via devkitPro's own pacman repositories (dkp-libs,
+# dkp-linux). Registering those repos is package_management's job — it
+# owns /etc/pacman.conf; merge development_devkitpro_repositories into
+# `pacman_custom_repositories` to enable them (and thereby import and
+# locally sign the devkitPro master key). This file installs the signing
+# keyring, the system-wide environment (devkit-env), and the requested
+# platform groups.
+#
+# Arch only: the upstream dkp-pacman deb installer and the generic
+# tarball both reuse Arch-style pacman semantics under /opt/devkitpro and
+# need their own multi-distro story, so this is a no-op (a notice is
+# logged) on Debian/RedHat until the alternative-installs strategy lands.
+
+- name: DevkitPro | Report unsupported platform (non-Arch)
+  ansible.builtin.debug:
+    msg: >-
+      devkitPro toolchains are not packaged for
+      {{ ansible_facts["os_family"] }} (upstream reuses Arch pacman
+      semantics under /opt/devkitpro); skipping.
+  when: ansible_facts['os_family'] != 'Archlinux'
+
+- name: DevkitPro | Configure toolchains (Arch)
+  when: ansible_facts['os_family'] == 'Archlinux'
+  block:
+    # Preflight: the dkp-libs / dkp-linux repos are registered by
+    # marcstraube.common.package_management (which also imports and
+    # locally signs the devkitPro master key). Without that wiring the
+    # keyring below cannot be validated, so fail early with a clear
+    # pointer instead of a cryptic signature error.
+    - name: DevkitPro | Gather configured pacman repositories
+      ansible.builtin.command:
+        cmd: 'pacman-conf --repo-list'
+      register: __development_devkitpro_repo_list
+      changed_when: false
+
+    - name: DevkitPro | Assert the devkitPro repositories are registered
+      ansible.builtin.assert:
+        that:
+          - "'dkp-libs' in __development_devkitpro_repo_list.stdout_lines"
+        fail_msg: >-
+          devkitPro is enabled but the dkp-libs repository is not
+          registered. Merge development_devkitpro_repositories into
+          pacman_custom_repositories (marcstraube.common.package_management)
+          — see the development role README.
+
+    # The keyring package is served from dkp-libs and signed by the
+    # devkitPro master key (locally signed by package_management), so
+    # pacman trusts it. Its install hook populates the per-package signing
+    # keys needed for devkit-env and the platform groups below.
+    - name: DevkitPro | Install the signing keyring
+      community.general.pacman:
+        name: '{{ __development_devkitpro_keyring_package }}'
+        state: present
+      retries: 3
+      delay: 5
+
+    - name: DevkitPro | Install the system-wide environment (devkit-env)
+      community.general.pacman:
+        name: '{{ __development_devkitpro_env_package }}'
+        state: present
+      retries: 3
+      delay: 5
+
+    - name: DevkitPro | Manage platform toolchain groups
+      community.general.pacman:
+        name: '{{ item.group }}'
+        state: "{{ 'present' if item.enabled | bool else 'absent' }}"
+      loop: '{{ __development_devkitpro_groups }}'
+      loop_control:
+        label: '{{ item.group }}'
+      retries: 3
+      delay: 5

--- a/roles/development/tasks/devkitpro.yml
+++ b/roles/development/tasks/devkitpro.yml
@@ -66,12 +66,19 @@
       retries: 3
       delay: 5
 
-    - name: DevkitPro | Manage platform toolchain groups
+    # Install only the enabled groups. The dkp groups share common
+    # members (general-tools, devkit-env, catnip, the devkit* compilers),
+    # so removing a disabled group would drag out packages an enabled
+    # group still depends on and break the transaction. Toolchains are
+    # therefore install-only: disabling a platform toggle afterwards does
+    # not uninstall the group.
+    - name: DevkitPro | Install enabled platform toolchain groups
       community.general.pacman:
-        name: '{{ item.group }}'
-        state: "{{ 'present' if item.enabled | bool else 'absent' }}"
-      loop: '{{ __development_devkitpro_groups }}'
-      loop_control:
-        label: '{{ item.group }}'
+        name: >-
+          {{ __development_devkitpro_groups
+             | selectattr('enabled')
+             | map(attribute='group') | list }}
+        state: present
+      when: __development_devkitpro_groups | selectattr('enabled') | list | length > 0
       retries: 3
       delay: 5

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -76,6 +76,15 @@
     - development
     - development:gb-dev
 
+- name: Main | Import devkitPro toolchain tasks
+  ansible.builtin.import_tasks: devkitpro.yml
+  when:
+    - development_enabled | bool
+    - development_devkitpro_enabled | bool
+  tags:
+    - development
+    - development:devkitpro
+
 - name: Main | Import misc tools tasks
   ansible.builtin.import_tasks: tools.yml
   when: development_enabled | bool

--- a/roles/development/vars/Archlinux.yml
+++ b/roles/development/vars/Archlinux.yml
@@ -115,3 +115,27 @@ __development_aur_packages:
     - 'gbdk-2020'
   gb_gbstudio:
     - 'gb-studio-bin'
+
+# devkitPro (Nintendo homebrew toolchains via the dkp-libs / dkp-linux
+# repos — registered through package_management, see defaults/main.yml).
+# The keyring and toolchains are served from the repos themselves.
+__development_devkitpro_keyring_package: 'devkitpro-keyring'
+
+# devkit-env ships /etc/profile.d/devkit-env.sh, exporting DEVKITPRO,
+# DEVKITARM, DEVKITPPC, DEVKITA64 and PATH system-wide
+__development_devkitpro_env_package: 'devkit-env'
+
+# Per-platform package groups, paired with their master-gated toggle
+__development_devkitpro_groups:
+  - group: 'gba-dev'
+    enabled: '{{ development_devkitpro_gba_dev_enabled | bool }}'
+  - group: 'nds-dev'
+    enabled: '{{ development_devkitpro_nds_dev_enabled | bool }}'
+  - group: '3ds-dev'
+    enabled: '{{ development_devkitpro_3ds_dev_enabled | bool }}'
+  - group: 'gamecube-dev'
+    enabled: '{{ development_devkitpro_gamecube_dev_enabled | bool }}'
+  - group: 'wii-dev'
+    enabled: '{{ development_devkitpro_wii_dev_enabled | bool }}'
+  - group: 'switch-dev'
+    enabled: '{{ development_devkitpro_switch_dev_enabled | bool }}'


### PR DESCRIPTION
## Summary

Adds a devkitPro subsection to the `development` role for Nintendo console homebrew toolchains (devkitARM/devkitPPC/devkitA64), distributed via devkitPro's own pacman repositories. A master toggle plus six per-platform package-group toggles.

Repository registration follows the project convention that `marcstraube.common.package_management` owns `/etc/pacman.conf`: the role ships the ready-made `dkp-libs` / `dkp-linux` definitions in `development_devkitpro_repositories` for merging into `pacman_custom_repositories`, and a preflight assert fails early with a clear pointer when that wiring is missing. The role then installs `devkitpro-keyring` and `devkit-env` from the repos and the requested platform groups.

## Changes

- Master toggle `development_devkitpro_enabled` (default `false`) gates six per-platform toggles (`gba`/`nds`/`3ds`/`gamecube`/`wii`/`switch` dev, all `false`).
- New `tasks/devkitpro.yml` imported from `tasks/main.yml`, master-gated (tag `development:devkitpro`).
- `devkit-env` provides `DEVKITPRO`, `DEVKITARM`, `DEVKITPPC`, `DEVKITA64` and `PATH` system-wide via `/etc/profile.d/devkit-env.sh`.
- Toolchain groups are install-only: the dkp groups share common members (compilers, tools), so a disabled platform toggle is not actively removed (removing it would break dependencies of an enabled group).
- Non-Arch logs a notice (upstream reuses Arch pacman semantics under `/opt/devkitpro`); no vars entries on Debian/RedHat.
- README: devkitPro subsection + per-OS coverage matrix + inventory wiring snippet + upstream links.
- Molecule: `prepare` registers the repos via the real `package_management` pacman tasks; `converge` enables master + `gba_dev` across all three plays; `verify` checks the keyring, `devkit-env`, `arm-none-eabi-gcc` and the `switch-dev` negative control.

## Test plan

- [x] `ansible-lint` (production profile) + `yamllint` + `markdownlint` — clean
- [x] CI Molecule Arch: `converge`, `idempotence`, `verify` — full flow incl. `arm-none-eabi-gcc`
- [x] CI: Debian Trixie / Rocky 9 / Rocky 10 — non-Arch no-op path

Closes #154
