### PR TITLE
ci: prune restored packages from drift-detection targets

### DIFF
--- a/.github/drift-targets.yml
+++ b/.github/drift-targets.yml
@@ -32,17 +32,7 @@ targets:
 
   - role: system_apps
     platform: rocky-10
-    package: filelight
-    vars_file: vars/RedHat.yml
-
-  - role: system_apps
-    platform: rocky-10
     package: solaar
-    vars_file: vars/RedHat.yml
-
-  - role: system_apps
-    platform: rocky-10
-    package: plasma-systemmonitor
     vars_file: vars/RedHat.yml
 
   - role: system_apps
@@ -53,11 +43,6 @@ targets:
   - role: system_apps
     platform: rocky-10
     package: deja-dup
-    vars_file: vars/RedHat.yml
-
-  - role: display_manager
-    platform: rocky-10
-    package: sddm
     vars_file: vars/RedHat.yml
 
   # EL9 EPEL drift — wine-core depends on mesa-libOSMesa, dropped from


### PR DESCRIPTION
sddm (#155), filelight and plasma-systemmonitor (#152) were re-enabled on EL10 on 2026-06-27, but their `drift-targets.yml` entries were not removed, so the drift-detection workflow kept re-probing them and filed redundant issues (#160, #161, #162). Remove the three stale entries; gparted, solaar, timeshift, deja-dup, kmail and wine remain no-ops.

Closes #160
Closes #161
Closes #162
