### PR TITLE
ci: add drift-targets prune step to restore instructions

### DIFF
--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -182,7 +182,7 @@ jobs:
           BODY=$(cat <<EOF
           The drift-detection workflow successfully probed \`${{ matrix.package }}\` on \`${{ matrix.platform }}\` — the package is installable again.
 
-          To restore: revert the Layer-1 no-op in \`roles/${{ matrix.role }}/${{ matrix.vars_file }}\` (set the package back to its upstream name and drop the explanatory comment), then run the role's molecule to confirm.
+          To restore: revert the Layer-1 no-op in \`roles/${{ matrix.role }}/${{ matrix.vars_file }}\` (set the package back to its upstream name and drop the explanatory comment), remove this package's entry from \`.github/drift-targets.yml\`, then run the role's molecule to confirm.
 
           - Role: \`${{ matrix.role }}\`
           - Package: \`${{ matrix.package }}\`


### PR DESCRIPTION
The drift-detection issue template told restorers to revert the Layer-1 no-op and run molecule, but not to remove the package's `.github/drift-targets.yml` entry. Missing that step left stale targets after #152/#155 restored packages, so the workflow re-filed already-fixed packages as redundant issues (#160-#162). Add the prune step to the restore instructions so future drift issues cover it.
