### PR TITLE
fix(development): make the qml-tools toggle install-only

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -331,6 +331,10 @@ dash, ksh, mksh); `bats-core` is bash-specific.
 |---------------------------------|---------|------------------------------------------------------|
 | `development_qml_tools_enabled` | `false` | Enable Qt6 QML tools (qmllint + qmlformat, same pkg) |
 
+The QML tools are install-only — on Arch they ship in `qt6-declarative`
+itself, a core Qt6 library the desktop stack depends on, so disabling the
+toggle after install does not uninstall the package.
+
 ##### Platform support
 
 | Tool         | Arch | Debian Trixie | EL 9 | EL 10 |

--- a/roles/development/tasks/qml.yml
+++ b/roles/development/tasks/qml.yml
@@ -6,10 +6,16 @@
 # supported distros. A single toggle covers both binaries.
 #
 
-- name: QML | Manage qml-tools
+# Install-only: on Arch the tools ship in qt6-declarative itself, a core
+# Qt6 library the desktop stack depends on (qt6-wayland, KDE frameworks,
+# ...), so removal can never succeed there. Disabling the toggle therefore
+# does not uninstall the package on any platform.
+- name: QML | Install qml-tools
   ansible.builtin.package:
     name: '{{ __development_qml_tools_package }}'
-    state: "{{ 'present' if development_qml_tools_enabled | bool else 'absent' }}"
-  when: __development_qml_tools_package | default('') | length > 0
+    state: present
+  when:
+    - development_qml_tools_enabled | bool
+    - __development_qml_tools_package | default('') | length > 0
   retries: 3
   delay: 5


### PR DESCRIPTION
## Summary

Disabling `development_qml_tools_enabled` (the default) set the QML tools package to `state: absent`. On Arch the qmllint/qmlformat binaries ship in `qt6-declarative` itself, a core Qt6 library required by qt6-wayland, the KDE frameworks and most Qt desktop applications, so the removal transaction can never succeed and the role fails on any host with a Qt-based desktop.

The toggle is now install-only, following the devkitPro platform-group semantics: enabling it installs the package, disabling it afterwards leaves the package in place. The role README documents the behaviour.

## Test plan

- [x] `yamllint` and `ansible-lint` pass on the changed task file
- [x] `markdownlint` passes on the changed README
- [x] Full site playbook `--check` run on an Arch workstation with the toggle disabled: the development role no longer attempts the removal and completes without failure

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)