### PR TITLE
ci: pin molecule and molecule-plugins to the last schema-compatible release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install "ansible-core~=2.21.0" \
-                      molecule \
-                      molecule-plugins[podman] \
+                      "molecule==26.6.0" \
+                      "molecule-plugins[podman]==26.7.8" \
                       passlib
 
       - name: Install collection dependencies
@@ -270,8 +270,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install "ansible-core~=2.19.0" \
-                      molecule \
-                      molecule-plugins[podman] \
+                      "molecule==26.6.0" \
+                      "molecule-plugins[podman]==26.7.8" \
                       passlib
 
       - name: Install collection dependencies


### PR DESCRIPTION
## Summary

molecule-plugins 26.7.15 changed the podman driver tmpfs schema to require an array, which is incompatible with `containers.podman.podman_container.tmpfs` (type dict) and fails validation for every `molecule.yml` (`is not of type 'array'`). Every molecule-compat and molecule-roles job fails during scenario validation, blocking all pull requests.

This pins both CI install steps to the last known-good molecule 26.6.0 / molecule-plugins 26.7.8, matching the pin applied in the common collection, until upstream resolves the schema/runtime mismatch.

## Test plan

- [x] `yamllint` passes on the changed workflow file
- [x] CI on this PR runs the molecule jobs with the pinned versions — green molecule jobs on this PR are the verification

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)