### PR TITLE
fix: run read-only lookup commands under --check

### DIFF
--- a/roles/development/tasks/devkitpro.yml
+++ b/roles/development/tasks/devkitpro.yml
@@ -32,11 +32,14 @@
     # locally signs the devkitPro master key). Without that wiring the
     # keyring below cannot be validated, so fail early with a clear
     # pointer instead of a cryptic signature error.
+    # check_mode: false — read-only lookup, must run under --check so the
+    # assert below sees the actual repo list instead of a skipped result.
     - name: DevkitPro | Gather configured pacman repositories
       ansible.builtin.command:
         cmd: 'pacman-conf --repo-list'
       register: __development_devkitpro_repo_list
       changed_when: false
+      check_mode: false
 
     - name: DevkitPro | Assert the devkitPro repositories are registered
       ansible.builtin.assert:

--- a/roles/plymouth/tasks/configure.yml
+++ b/roles/plymouth/tasks/configure.yml
@@ -4,11 +4,14 @@
 #
 
 # Theme
+# check_mode: false — read-only lookup, must run under --check so the
+# theme comparison below sees the actual current theme.
 - name: Configure | Get current default theme
   ansible.builtin.command:
     cmd: plymouth-set-default-theme
   register: __plymouth_current_theme
   changed_when: false
+  check_mode: false
 
 - name: Configure | Set Plymouth theme
   ansible.builtin.command:
@@ -22,11 +25,14 @@
 #
 # Debian/RedHat integrate plymouth automatically via initramfs-tools/dracut.
 
+# check_mode: false — read-only lookup, must run under --check so the
+# hook checks below operate on the actual HOOKS line.
 - name: Configure | Read current mkinitcpio hooks (Arch)
   ansible.builtin.command:
     cmd: grep '^HOOKS=' {{ __plymouth_mkinitcpio_conf }}
   register: __plymouth_current_hooks
   changed_when: false
+  check_mode: false
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __plymouth_mkinitcpio_conf | length > 0

--- a/roles/tuxedo/tasks/install.yml
+++ b/roles/tuxedo/tasks/install.yml
@@ -21,11 +21,15 @@
 # multi-kernel setups (e.g. linux-lts + linux) where DKMS needs headers
 # for every bootable kernel.
 
+# check_mode: false — read-only lookup, must run under --check so the
+# kernel headers list below is built from the actual package DB instead
+# of an empty skipped result.
 - name: Install | Detect installed kernel packages
   ansible.builtin.command:
     cmd: pacman -Qq
   register: __tuxedo_installed_packages
   changed_when: false
+  check_mode: false
   when: tuxedo_drivers_enabled | bool or tuxedo_yt6801_ethernet_enabled | bool
 
 - name: Install | Build kernel headers list

--- a/roles/tuxedo/tasks/validate.yml
+++ b/roles/tuxedo/tasks/validate.yml
@@ -18,11 +18,15 @@
       not 'TUXEDO'. Tuxedo packages may not work correctly on non-Tuxedo hardware.
   when: ansible_facts['sys_vendor'] | default('') != 'TUXEDO'
 
+# check_mode: false — read-only lookup, must run under --check so the
+# conflict warning below reflects the actual install state (the skipped
+# result carries rc=0, which would warn on every check run).
 - name: Validate | Check for auto-cpufreq conflict
   ansible.builtin.command:
     cmd: pacman -Qi auto-cpufreq
   register: __tuxedo_auto_cpufreq_check
   changed_when: false
+  check_mode: false
   # pacman -Qi exits 1 when package is not installed
   failed_when: false
   when: tuxedo_warn_conflicts_enabled | bool

--- a/roles/wine/tasks/install.yml
+++ b/roles/wine/tasks/install.yml
@@ -3,11 +3,14 @@
 # i386 Architecture (Debian)
 #
 
+# check_mode: false — read-only lookup, must run under --check so the
+# i386 enablement below sees the actual foreign-architecture list.
 - name: Install | Check i386 architecture (Debian)
   ansible.builtin.command:
     cmd: dpkg --print-foreign-architectures
   register: __wine_foreign_archs
   changed_when: false
+  check_mode: false
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install | Enable i386 architecture (Debian)
@@ -98,11 +101,14 @@
 # GPU Vulkan Driver Detection (Arch Linux)
 #
 
+# check_mode: false — read-only lookup, must run under --check so the
+# vendor resolution below is based on the actual GPU list.
 - name: Install | Detect GPU vendor
   ansible.builtin.command:
     cmd: lspci -nn
   register: __wine_lspci
   changed_when: false
+  check_mode: false
   failed_when: false
   when:
     - ansible_facts['os_family'] == 'Archlinux'


### PR DESCRIPTION
## Summary

In check mode, `ansible.builtin.command` (ansible-core 2.20) skips execution and returns a result with `rc=0` and no stdout. Read-only lookup commands whose registered result is consumed downstream therefore misbehave under `--check`: the devkitPro repo assert and the tuxedo kernel assert fail on empty `stdout_lines`, the tuxedo auto-cpufreq conflict warning fires on the skip result's `rc=0` even when the package is absent, and the plymouth theme/hooks and wine dpkg/lspci lookups produce spurious change reports or a wrong GPU vendor resolution.

This adds `check_mode: false` with the collection-standard "read-only lookup, must run under --check" comment to these preflight lookups (development/devkitpro, tuxedo install and validate, plymouth configure, wine install). Verify-after-install commands keep skipping under `--check`, since their subject only exists after a real run.

## Test plan

- [x] `yamllint` and `ansible-lint` pass on all changed task files
- [x] Full site playbook `--check` run on an Arch workstation: the devkitPro and kernel asserts pass against the real host state, the auto-cpufreq warning no longer fires spuriously, and no spurious change reports remain

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)