### PR TITLE
fix(desktop_environment): rely on the packaged uwsm session desktop entry

### DIFF
--- a/roles/desktop_environment/tasks/hyprland.yml
+++ b/roles/desktop_environment/tasks/hyprland.yml
@@ -88,24 +88,11 @@
   retries: 3
   delay: 5
 
-# uwsm Desktop Entry
-- name: Hyprland | Create wayland-sessions directory
-  ansible.builtin.file:
-    path: '/usr/share/wayland-sessions'
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-  when: desktop_environment_hyprland_uwsm_enabled | bool
-
-- name: Hyprland | Deploy uwsm desktop entry
-  ansible.builtin.template:
-    src: 'hyprland-uwsm.desktop.j2'
-    dest: '/usr/share/wayland-sessions/hyprland-uwsm.desktop'
-    owner: root
-    group: root
-    mode: '0644'
-  when: desktop_environment_hyprland_uwsm_enabled | bool
+# uwsm session desktop entry: shipped by the hyprland package itself
+# (Arch and Debian trixie-backports both install
+# /usr/share/wayland-sessions/hyprland-uwsm.desktop), so the role does
+# not deploy its own — overwriting the package file caused a ping-pong
+# with every hyprland update.
 
 # uwsm service automation (drop-ins + enable)
 - name: Hyprland | Create uwsm drop-in directories

--- a/roles/desktop_environment/templates/hyprland-uwsm.desktop.j2
+++ b/roles/desktop_environment/templates/hyprland-uwsm.desktop.j2
@@ -1,8 +1,0 @@
-{{ ansible_managed | comment }}
-
-[Desktop Entry]
-Name=Hyprland (UWSM)
-Comment=Hyprland Wayland compositor managed by Universal Wayland Session Manager
-Exec=uwsm start hyprland.desktop
-Type=Application
-DesktopNames=Hyprland


### PR DESCRIPTION
## Summary

The role deployed its own `hyprland-uwsm.desktop` to `/usr/share/wayland-sessions` whenever `desktop_environment_hyprland_uwsm_enabled` was set. Current hyprland packages ship this file themselves — the Arch package owns it, and the Debian trixie-backports package (the only Debian source for hyprland) ships it as well. The role therefore overwrote a package-managed file, and every hyprland update restored the package version — a permanent ping-pong reporting `changed` on each run.

This drops the deploy task, the wayland-sessions directory task that only existed for it, and the template. Hosts where the file was previously overwritten self-heal on the next hyprland update.

## Test plan

- [x] `yamllint` and `ansible-lint` pass on the changed task file
- [x] Package file lists confirmed: the Arch hyprland package owns `/usr/share/wayland-sessions/hyprland-uwsm.desktop`, and the Debian trixie-backports hyprland package ships it too (uwsm itself is not packaged in Debian)
- [x] Full site playbook `--check` run on an Arch workstation with the uwsm toggle enabled: no change reported for the session entry, uwsm drop-ins and service automation unaffected

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)