### PR TITLE
feat(gaming): make the Playback package variant selectable

### DIFF
--- a/roles/gaming/README.md
+++ b/roles/gaming/README.md
@@ -78,6 +78,13 @@ overrides if needed.
 \* PCSX2 is installed via AUR on Arch Linux.
 \*\* PCSX2 requires RPM Fusion on Rocky Linux (not managed by this role).
 
+| Variable                  | Default     | Description                                                 |
+| ------------------------- | ----------- | ----------------------------------------------------------- |
+| `gaming_playback_variant` | `'flatpak'` | Playback variant: `flatpak` (official bundle) or `appimage` |
+
+The Playback variants conflict with each other, so the role removes the
+unselected variant before installing the selected one.
+
 ### Game Streaming
 
 | Variable                   | Default | Arch | Debian | Rocky | Description                        |

--- a/roles/gaming/defaults/main.yml
+++ b/roles/gaming/defaults/main.yml
@@ -29,6 +29,12 @@ gaming_retroarch_enabled: true
 # Playback game recording/replay viewer
 gaming_playback_enabled: true
 
+# Playback package variant (Arch AUR): 'flatpak' installs the official
+# Flatpak bundle (playback-flatpak), 'appimage' the AppImage repack
+# (playback-appimage). The variants conflict; the unselected one is
+# removed.
+gaming_playback_variant: 'flatpak'
+
 # PCSX2 PlayStation 2 emulator
 gaming_pcsx2_enabled: false
 

--- a/roles/gaming/tasks/install.yml
+++ b/roles/gaming/tasks/install.yml
@@ -93,11 +93,26 @@
   retries: 3
   delay: 5
 
+# The Playback variants conflict with each other, which paru cannot
+# resolve under --noconfirm — remove the unselected variant before
+# installing the selected one (variant exclusive).
+- name: Install | Remove unselected Playback variant (Arch)
+  community.general.pacman:
+    name: >-
+      {{ __gaming_aur_packages.playback
+         | dict2items
+         | rejectattr('key', 'equalto', gaming_playback_variant)
+         | map(attribute='value') | flatten | list }}
+    state: absent
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - gaming_playback_enabled | bool
+
 - name: Install | Playback from AUR (Arch)
   become: true
   become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
-    name: '{{ __gaming_aur_packages.playback }}'
+    name: '{{ __gaming_aur_packages.playback[gaming_playback_variant] }}'
     state: present
   when:
     - ansible_facts['os_family'] == 'Archlinux'

--- a/roles/gaming/tasks/main.yml
+++ b/roles/gaming/tasks/main.yml
@@ -13,6 +13,19 @@
   tags:
     - gaming
 
+- name: Main | Validate gaming_playback_variant
+  ansible.builtin.assert:
+    that:
+      - gaming_playback_variant in ['flatpak', 'appimage']
+    fail_msg: >-
+      gaming_playback_variant must be 'flatpak' or 'appimage',
+      got '{{ gaming_playback_variant }}'
+  when:
+    - gaming_enabled | bool
+    - gaming_playback_enabled | bool
+  tags:
+    - gaming
+
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml
   when: gaming_enabled | bool

--- a/roles/gaming/vars/Archlinux.yml
+++ b/roles/gaming/vars/Archlinux.yml
@@ -16,6 +16,9 @@ __gaming_aur_packages:
   heroic:
     - heroic-games-launcher-bin
   playback:
-    - playback-appimage
+    flatpak:
+      - playback-flatpak
+    appimage:
+      - playback-appimage
   pcsx2:
     - pcsx2


### PR DESCRIPTION
## Summary

Playback is packaged in the AUR in two conflicting variants: the official Flatpak bundle (`playback-flatpak`) and the AppImage repack (`playback-appimage`). The role hardcoded the AppImage variant, and paru under `--noconfirm` aborts on hosts where the other variant is installed.

This adds `gaming_playback_variant` (`flatpak` default — the official upstream bundle — or `appimage`) following the `wine_variant` pattern, with an assert on valid values. The variants are exclusive: the role removes the unselected variant before installing the selected one. The variable is documented in the role README.

## Test plan

- [x] `yamllint`, `ansible-lint` and `markdownlint` pass on all changed files
- [x] Live run on an Arch workstation with `playback-flatpak` installed and the default variant: the removal task is a no-op for the absent AppImage variant and the install task confirms the present Flatpak variant, run completes without changes

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)