### PR TITLE
test(development): skip devkitPro coverage on GitHub-hosted runners

### DIFF
--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -9,6 +9,8 @@
 # depend on are registered in prepare.yml (via the real
 # marcstraube.common.package_management pacman tasks), so package_management's
 # own idempotence is not coupled to this scenario's idempotence gate.
+# devkitPro coverage is disabled in CI via __molecule_devkitpro_reachable
+# (molecule.yml) — pkg.devkitpro.org blocks GitHub-hosted runners.
 - name: Converge | Managed mode
   hosts: all
   gather_facts: true
@@ -25,7 +27,7 @@
     development_c_enabled: true
     development_gb_gbdk_enabled: true
     development_gb_gbstudio_enabled: true
-    development_devkitpro_enabled: true
+    development_devkitpro_enabled: '{{ __molecule_devkitpro_reachable | default(true) | bool }}'
     development_devkitpro_gba_dev_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
@@ -86,7 +88,7 @@
     development_c_enabled: true
     development_gb_gbdk_enabled: true
     development_gb_gbstudio_enabled: true
-    development_devkitpro_enabled: true
+    development_devkitpro_enabled: '{{ __molecule_devkitpro_reachable | default(true) | bool }}'
     development_devkitpro_gba_dev_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false
@@ -162,7 +164,7 @@
     development_c_enabled: true
     development_gb_gbdk_enabled: true
     development_gb_gbstudio_enabled: true
-    development_devkitpro_enabled: true
+    development_devkitpro_enabled: '{{ __molecule_devkitpro_reachable | default(true) | bool }}'
     development_devkitpro_gba_dev_enabled: true
     development_vscodium_enabled: false
     development_vscode_enabled: false

--- a/roles/development/molecule/default/molecule.yml
+++ b/roles/development/molecule/default/molecule.yml
@@ -49,6 +49,13 @@ provisioner:
     converge: converge.yml
     verify: verify.yml
   inventory:
+    group_vars:
+      all:
+        # pkg.devkitpro.org rejects requests from GitHub-hosted runners
+        # with HTTP 403 (IP-based blocking), so the devkitPro repo
+        # registration and toolchain coverage only run outside CI.
+        # Local molecule runs still exercise the full devkitPro path.
+        __molecule_devkitpro_reachable: "{{ lookup('env', 'CI') != 'true' }}"
     host_vars:
       development-archlinux:
         ansible_python_interpreter: /usr/bin/python

--- a/roles/development/molecule/default/prepare.yml
+++ b/roles/development/molecule/default/prepare.yml
@@ -174,10 +174,14 @@
     # work against. Uses the role's own development_devkitpro_repositories
     # default, proving the documented inventory wiring. Kept in prepare
     # (runs once) so package_management's own idempotence is not coupled
-    # to this scenario's idempotence gate.
+    # to this scenario's idempotence gate. Skipped in CI —
+    # pkg.devkitpro.org blocks GitHub-hosted runners with HTTP 403 (see
+    # __molecule_devkitpro_reachable in molecule.yml).
     #
     - name: Prepare | Register devkitPro pacman repositories (Arch)
-      when: ansible_facts['os_family'] == 'Archlinux'
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __molecule_devkitpro_reachable | default(true) | bool
       block:
         # The minimal CI container ships an uninitialised pacman keyring
         # (no local signing key), so package_management's `pacman-key

--- a/roles/development/molecule/default/verify.yml
+++ b/roles/development/molecule/default/verify.yml
@@ -312,7 +312,10 @@
 
     #
     # devkitPro (Arch only — master + gba-dev enabled, switch-dev absent).
-    # No-op on non-Arch, so nothing to verify there.
+    # No-op on non-Arch, so nothing to verify there. Skipped in CI —
+    # pkg.devkitpro.org blocks GitHub-hosted runners, so converge runs
+    # with the devkitPro master toggle disabled there (see
+    # __molecule_devkitpro_reachable in molecule.yml).
     #
 
     - name: Verify | devkitpro-keyring installed (Arch)
@@ -321,7 +324,9 @@
       register: _dev_dkp_keyring
       changed_when: false
       failed_when: _dev_dkp_keyring.rc != 0
-      when: ansible_facts['os_family'] == 'Archlinux'
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __molecule_devkitpro_reachable | default(true) | bool
 
     - name: Verify | devkit-env installed (Arch)
       ansible.builtin.command:
@@ -329,20 +334,26 @@
       register: _dev_dkp_env
       changed_when: false
       failed_when: _dev_dkp_env.rc != 0
-      when: ansible_facts['os_family'] == 'Archlinux'
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __molecule_devkitpro_reachable | default(true) | bool
 
     - name: Verify | Stat devkit-env profile script (Arch)
       ansible.builtin.stat:
         path: /etc/profile.d/devkit-env.sh
       register: _dev_dkp_profile
-      when: ansible_facts['os_family'] == 'Archlinux'
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __molecule_devkitpro_reachable | default(true) | bool
 
     - name: Verify | Assert devkit-env profile script exists (Arch)
       ansible.builtin.assert:
         that:
           - _dev_dkp_profile.stat.exists
         fail_msg: '/etc/profile.d/devkit-env.sh not shipped by devkit-env'
-      when: ansible_facts['os_family'] == 'Archlinux'
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __molecule_devkitpro_reachable | default(true) | bool
 
     - name: Verify | devkitARM compiler runs (Arch)
       ansible.builtin.command:
@@ -350,7 +361,9 @@
       register: _dev_dkp_gcc
       changed_when: false
       failed_when: _dev_dkp_gcc.rc != 0
-      when: ansible_facts['os_family'] == 'Archlinux'
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __molecule_devkitpro_reachable | default(true) | bool
 
     - name: Verify | switch-dev toolchain absent (Arch)
       ansible.builtin.command:


### PR DESCRIPTION
Closes #204

pkg.devkitpro.org answers requests from GitHub-hosted runners with HTTP 403 (IP-based blocking — the same requests succeed from other networks with a pacman user agent), so the prepare-phase pacman cache refresh fails after registering the dkp-libs/dkp-linux repositories and the development-archlinux molecule job is consistently red.

## Changes

- `molecule.yml`: new scenario inventory variable `__molecule_devkitpro_reachable`, false when the `CI` environment variable is set
- `prepare.yml`: the devkitPro repository registration block is additionally gated on the variable
- `converge.yml`: all three plays derive `development_devkitpro_enabled` from the variable
- `verify.yml`: the positive devkitPro checks are gated on the variable; the switch-dev absence check keeps running in both modes

Molecule runs outside CI keep exercising the full devkitPro path.

## Test plan

- [x] `yamllint` and `ansible-lint` pass on the scenario files
- [x] `CI=true molecule test -p development-archlinux` — full sequence green with the devkitPro coverage skipped
- [x] `molecule test -p development-archlinux` — full sequence green including the devkitPro toolchain install and verify checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)