### PR TITLE
feat(browser): add optional-extension merge for Chromium and Brave

### DIFF
--- a/roles/browser/README.md
+++ b/roles/browser/README.md
@@ -90,6 +90,7 @@ Chromium on Rocky Linux requires EPEL.
 | `browser_chromium_policies_enabled`           | `true`      | Deploy policies                   |
 | `browser_chromium_wayland_gestures_enabled`   | `true`      | Wayland gesture hook (Arch only)  |
 | `browser_chromium_extensions`                 | `{...}`     | Extensions with install modes     |
+| `browser_chromium_extensions_optional`        | `{}`        | Optional extensions (merged)      |
 | `browser_chromium_policy_settings`            | `{...}`     | Additional policy settings        |
 
 ### Brave Options
@@ -98,6 +99,7 @@ Chromium on Rocky Linux requires EPEL.
 | ------------------------------------- | ----------- | --------------------------------- |
 | `browser_brave_policies_enabled`      | `true`      | Deploy policies                   |
 | `browser_brave_extensions`            | `{...}`     | Extensions (defaults to Chromium) |
+| `browser_brave_extensions_optional`   | `{}`        | Optional extensions (merged)      |
 | `browser_brave_homepage`              | `''`        | Homepage URL (empty = default)    |
 | `browser_brave_signin`                | `0`         | Sign-in: 0=off, 1=on, 2=required  |
 | `browser_brave_sync_disabled`         | `true`      | Disable Brave Sync                |

--- a/roles/browser/defaults/main.yml
+++ b/roles/browser/defaults/main.yml
@@ -147,6 +147,16 @@ browser_chromium_extensions:
   'oboonakemofpalcgghocfoadofidjkkk':
     mode: 'normal_installed'
 
+# Optional Chromium/Brave extensions (disabled by default), merged on top
+# of the baseline above. Use this for host-specific additions so the
+# shared baseline stays untouched.
+# Example:
+#   browser_chromium_extensions_optional:
+#     # Pixels Roll20 Integration
+#     'kglkahinilanaaknphakkkaigkildipe':
+#       mode: 'force_installed'
+browser_chromium_extensions_optional: {}
+
 #
 # Firefox Preferences (user.js — per-user, overridable in about:config)
 #
@@ -251,6 +261,7 @@ browser_librewolf_password_manager: false
 #
 
 browser_brave_extensions: '{{ browser_chromium_extensions }}'
+browser_brave_extensions_optional: '{{ browser_chromium_extensions_optional }}'
 browser_brave_homepage: ''
 browser_brave_signin: 0                   # 0 = disabled, 1 = enabled, 2 = required
 browser_brave_sync_disabled: true

--- a/roles/browser/molecule/default/converge.yml
+++ b/roles/browser/molecule/default/converge.yml
@@ -41,6 +41,11 @@
       'cjpalhdlnbpafiamejdnhcphjbkeiagm':
         mode: 'force_installed'
 
+    # Exercise the optional-extension merge path
+    browser_chromium_extensions_optional:
+      'kglkahinilanaaknphakkkaigkildipe':
+        mode: 'force_installed'
+
   tasks:
     - name: Converge | Include browser role  # noqa: role-name[path]
       ansible.builtin.include_role:

--- a/roles/browser/molecule/default/verify.yml
+++ b/roles/browser/molecule/default/verify.yml
@@ -107,6 +107,22 @@
       register: __browser_verify_chromium_policies_json
       changed_when: false
 
+    - name: Verify | Read Chromium policies.json for extension merge check
+      ansible.builtin.slurp:
+        src: /etc/chromium/policies/managed/policies.json
+      register: __browser_verify_chromium_policies_content
+
+    - name: Verify | Assert optional extension merged into Chromium policies
+      ansible.builtin.assert:
+        that:
+          - "'cjpalhdlnbpafiamejdnhcphjbkeiagm' in __ext_settings"
+          - "'kglkahinilanaaknphakkkaigkildipe' in __ext_settings"
+        fail_msg: 'browser_chromium_extensions_optional not merged into ExtensionSettings'
+      vars:
+        __ext_settings: >-
+          {{ (__browser_verify_chromium_policies_content.content
+              | b64decode | from_json).ExtensionSettings }}
+
     - name: Verify | Read Firefox policies.json for Preferences check
       ansible.builtin.slurp:
         src: '{{ __browser_verify_policies_path | trim }}/policies.json'

--- a/roles/browser/templates/brave-policies.json.j2
+++ b/roles/browser/templates/brave-policies.json.j2
@@ -1,13 +1,13 @@
 {
   "_comment": "{{ ansible_managed }}",
-{% if browser_brave_extensions | length > 0 %}
+{% if browser_brave_extensions | length > 0 or browser_brave_extensions_optional | default({}) | length > 0 %}
   "ExtensionSettings": {
     "*": {
       "blocked_install_message": "Extension installation is managed by system policy.",
       "installation_mode": "{{ browser_extension_default_mode }}"
-    }{% if browser_brave_extensions | length > 0 %},{% endif %}
+    }{% if browser_brave_extensions | length > 0 or browser_brave_extensions_optional | default({}) | length > 0 %},{% endif %}
 
-{% for ext_id, ext_config in browser_brave_extensions | dictsort %}
+{% for ext_id, ext_config in (browser_brave_extensions | combine(browser_brave_extensions_optional | default({}))) | dictsort %}
     "{{ ext_id }}": {
       "installation_mode": "{{ ext_config.mode | default('normal_installed') }}"{% if ext_config.url is defined %},
       "update_url": "{{ ext_config.url }}"{% endif %}

--- a/roles/browser/templates/chromium-policies.json.j2
+++ b/roles/browser/templates/chromium-policies.json.j2
@@ -1,13 +1,13 @@
 {
   "_comment": "{{ ansible_managed }}",
-{% if browser_chromium_extensions | length > 0 %}
+{% if browser_chromium_extensions | length > 0 or browser_chromium_extensions_optional | default({}) | length > 0 %}
   "ExtensionSettings": {
     "*": {
       "blocked_install_message": "Extension installation is managed by system policy.",
       "installation_mode": "{{ browser_extension_default_mode }}"
-    }{% if browser_chromium_extensions | length > 0 %},{% endif %}
+    }{% if browser_chromium_extensions | length > 0 or browser_chromium_extensions_optional | default({}) | length > 0 %},{% endif %}
 
-{% for ext_id, ext_config in browser_chromium_extensions | dictsort %}
+{% for ext_id, ext_config in (browser_chromium_extensions | combine(browser_chromium_extensions_optional | default({}))) | dictsort %}
     "{{ ext_id }}": {
       "installation_mode": "{{ ext_config.mode | default('force_installed') }}",
       "update_url": "{{ ext_config.update_url | default('https://clients2.google.com/service/update2/crx') }}"


### PR DESCRIPTION
Adds `browser_chromium_extensions_optional` and `browser_brave_extensions_optional` (default `{}`), merged on top of the baseline via `combine()` in the Chromium and Brave policy templates — parity with the existing Firefox/LibreWolf `_optional` pattern. Host-specific extensions can now be added without redefining the shared baseline dict.

Molecule covers the merge: the optional extension appears in the rendered `ExtensionSettings` alongside the baseline.

Closes #206