### PR TITLE
feat(browser): add per-user Chromium launch switches (chromium-flags.conf)

### DIFF
--- a/roles/browser/README.md
+++ b/roles/browser/README.md
@@ -89,6 +89,8 @@ Chromium on Rocky Linux requires EPEL.
 | --------------------------------------------- | ----------- | --------------------------------- |
 | `browser_chromium_policies_enabled`           | `true`      | Deploy policies                   |
 | `browser_chromium_wayland_gestures_enabled`   | `true`      | Wayland gesture hook (Arch only)  |
+| `browser_chromium_flags_enabled`              | `false`     | Per-user chromium-flags.conf      |
+| `browser_chromium_flags`                      | `[]`        | Launch switches (one per line)    |
 | `browser_chromium_extensions`                 | `{...}`     | Extensions with install modes     |
 | `browser_chromium_extensions_optional`        | `{}`        | Optional extensions (merged)      |
 | `browser_chromium_policy_settings`            | `{...}`     | Additional policy settings        |
@@ -132,7 +134,8 @@ Set to an empty string to skip handler management. Other entries
 in `mimeapps.list` are preserved on each run. The same
 `managed`/`initial`/`disabled` mode that governs per-user profile
 config applies here too — `initial` deploys only on newly created
-users, leaving subsequent manual changes intact.
+users, leaving subsequent manual changes intact. `browser_chromium_flags`
+(`~/.config/chromium-flags.conf`) follows the same per-user mode.
 
 ### Firefox / LibreWolf preferences — locked vs. user-overridable
 

--- a/roles/browser/defaults/main.yml
+++ b/roles/browser/defaults/main.yml
@@ -68,6 +68,19 @@ browser_chromium_policies_enabled: true
 # Wayland touchpad gesture support (pacman hook, Arch only)
 browser_chromium_wayland_gestures_enabled: true
 
+# Deploy per-user launch switches (~/.config/chromium-flags.conf)
+browser_chromium_flags_enabled: false
+
+# Launch switches written one per line to ~/.config/chromium-flags.conf.
+# Arch's Chromium binary reads this file directly (downstream patch), so
+# switches without a policy equivalent go here. Deployed per user via
+# browser_users (respects managed/initial/disabled).
+# Example:
+#   browser_chromium_flags:
+#     # Web Bluetooth (navigator.bluetooth) — not enabled by default on Linux
+#     - '--enable-experimental-web-platform-features'
+browser_chromium_flags: []
+
 #
 # Brave Options
 #

--- a/roles/browser/molecule/default/converge.yml
+++ b/roles/browser/molecule/default/converge.yml
@@ -15,6 +15,11 @@
     browser_firefox_policies_enabled: true
     browser_chromium_policies_enabled: true
 
+    # Exercise the per-user chromium-flags.conf path
+    browser_chromium_flags_enabled: true
+    browser_chromium_flags:
+      - '--enable-experimental-web-platform-features'
+
     # Per-user paths now bootstrap profiles via filesystem writes,
     # no DISPLAY/D-Bus needed — keep enabled in container tests.
     browser_firefox_user_js_enabled: true
@@ -63,7 +68,14 @@
   vars:
     browser_enabled: true
     browser_firefox_enabled: true
-    browser_chromium_enabled: false
+    # Chromium policies stay off; the flags path is exercised under initial
+    # mode — deployed for the newly-created user, skipped for the existing
+    # one (same gating as user.js).
+    browser_chromium_enabled: true
+    browser_chromium_policies_enabled: false
+    browser_chromium_flags_enabled: true
+    browser_chromium_flags:
+      - '--enable-experimental-web-platform-features'
     browser_firefox_policies_enabled: false
     browser_firefox_user_js_enabled: true
     browser_firefox_preferences:

--- a/roles/browser/molecule/default/verify.yml
+++ b/roles/browser/molecule/default/verify.yml
@@ -123,6 +123,29 @@
           {{ (__browser_verify_chromium_policies_content.content
               | b64decode | from_json).ExtensionSettings }}
 
+    #
+    # Chromium Launch Switches (per-user chromium-flags.conf)
+    #
+
+    - name: Verify | Check chromium-flags.conf exists for test user
+      ansible.builtin.stat:
+        path: /home/browser_test_user/.config/chromium-flags.conf
+      register: __browser_verify_chromium_flags
+
+    - name: Verify | Read chromium-flags.conf content
+      ansible.builtin.slurp:
+        src: /home/browser_test_user/.config/chromium-flags.conf
+      register: __browser_verify_chromium_flags_content
+
+    - name: Verify | Assert chromium-flags.conf deployed with expected switch
+      ansible.builtin.assert:
+        that:
+          - __browser_verify_chromium_flags.stat.exists
+          - __browser_verify_chromium_flags.stat.pw_name == 'browser_test_user'
+          - "'--enable-experimental-web-platform-features'
+            in (__browser_verify_chromium_flags_content.content | b64decode)"
+        fail_msg: 'chromium-flags.conf not deployed correctly for browser_test_user'
+
     - name: Verify | Read Firefox policies.json for Preferences check
       ansible.builtin.slurp:
         src: '{{ __browser_verify_policies_path | trim }}/policies.json'
@@ -245,11 +268,17 @@
         path: /home/browser_disabled_user/.config/mimeapps.list
       register: __browser_verify_disabled_mimeapps
 
+    - name: Verify | Check per-user-disabled user has no chromium-flags.conf
+      ansible.builtin.stat:
+        path: /home/browser_disabled_user/.config/chromium-flags.conf
+      register: __browser_verify_disabled_chromium_flags
+
     - name: Verify | Assert per-user-disabled user has no config
       ansible.builtin.assert:
         that:
           - not __browser_verify_disabled_profile.stat.exists
           - not __browser_verify_disabled_mimeapps.stat.exists
+          - not __browser_verify_disabled_chromium_flags.stat.exists
         fail_msg: 'browser config deployed for a per-user-disabled entry'
 
     #
@@ -269,12 +298,18 @@
         path: /home/browser_initial_new/.config/mimeapps.list
       register: __browser_verify_initialnew_mimeapps
 
+    - name: Verify | Check initial-new user chromium-flags.conf exists
+      ansible.builtin.stat:
+        path: /home/browser_initial_new/.config/chromium-flags.conf
+      register: __browser_verify_initialnew_chromium_flags
+
     - name: Verify | Assert initial-new user config is deployed
       ansible.builtin.assert:
         that:
           - __browser_verify_initialnew_userjs.stat.exists
           - __browser_verify_initialnew_userjs.stat.pw_name == 'browser_initial_new'
           - __browser_verify_initialnew_mimeapps.stat.exists
+          - __browser_verify_initialnew_chromium_flags.stat.exists
         fail_msg: 'browser config not deployed for newly-created initial-mode user'
 
     #
@@ -295,6 +330,11 @@
         path: /home/browser_initial_exist/.mozilla/firefox/{{ __browser_firefox_profile_dirname }}
       register: __browser_verify_initialexist_profile
 
+    - name: Verify | Check initial-exist user has no chromium-flags.conf
+      ansible.builtin.stat:
+        path: /home/browser_initial_exist/.config/chromium-flags.conf
+      register: __browser_verify_initialexist_chromium_flags
+
     - name: Verify | Assert initial-exist user config is unchanged
       ansible.builtin.assert:
         that:
@@ -302,6 +342,7 @@
             in (__browser_verify_initialexist_mimeapps.content | b64decode)"
           - "'firefox.desktop' not in (__browser_verify_initialexist_mimeapps.content | b64decode)"
           - not __browser_verify_initialexist_profile.stat.exists
+          - not __browser_verify_initialexist_chromium_flags.stat.exists
         fail_msg: 'pre-existing config was modified for existing initial-mode user'
 
     #

--- a/roles/browser/tasks/users.yml
+++ b/roles/browser/tasks/users.yml
@@ -62,6 +62,30 @@
       or ((browser_user.mode | default(browser_user_config_mode)) == 'initial'
           and browser_user.username in (__users_newly_created | default([])))
 
+- name: Users | Deploy Chromium launch switches
+  ansible.builtin.include_tasks:
+    file: users_chromium.yml
+    apply:
+      tags:
+        - browser
+        - browser:configure
+  tags:
+    - browser
+    - browser:configure
+  loop: '{{ browser_users }}'
+  loop_control:
+    loop_var: browser_user
+    label: '{{ browser_user.username }}'
+  when:
+    - browser_chromium_enabled | bool
+    - browser_chromium_flags_enabled | bool
+    - browser_chromium_flags | length > 0
+    - (browser_user.mode | default(browser_user_config_mode)) != 'disabled'
+    - >-
+      (browser_user.mode | default(browser_user_config_mode)) == 'managed'
+      or ((browser_user.mode | default(browser_user_config_mode)) == 'initial'
+          and browser_user.username in (__users_newly_created | default([])))
+
 - name: Users | Include default browser handler config
   ansible.builtin.include_tasks:
     file: users_default_handler.yml

--- a/roles/browser/tasks/users_chromium.yml
+++ b/roles/browser/tasks/users_chromium.yml
@@ -1,0 +1,30 @@
+---
+# Per-user Chromium launch switches. Arch's Chromium binary reads
+# ~/.config/chromium-flags.conf directly (downstream flags-file patch),
+# so switches without a policy equivalent (e.g. Web Bluetooth) are
+# deployed here instead of via policies.json.
+
+- name: Users Chromium | Get user info
+  ansible.builtin.getent:
+    database: passwd
+    key: '{{ browser_user.username }}'
+
+- name: Users Chromium | Set user home fact
+  ansible.builtin.set_fact:
+    __browser_user_home: "{{ ansible_facts['getent_passwd'][browser_user.username][4] }}"
+
+- name: Users Chromium | Ensure config directory exists
+  ansible.builtin.file:
+    path: '{{ __browser_user_home }}/.config'
+    state: directory
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0700'
+
+- name: Users Chromium | Deploy chromium-flags.conf
+  ansible.builtin.template:
+    src: chromium-flags.conf.j2
+    dest: '{{ __browser_user_home }}/.config/chromium-flags.conf'
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0644'

--- a/roles/browser/templates/chromium-flags.conf.j2
+++ b/roles/browser/templates/chromium-flags.conf.j2
@@ -1,0 +1,7 @@
+{{ ansible_managed | comment }}
+#
+# Chromium launch switches, one per line. Read directly by the Arch
+# Chromium binary (downstream flags-file patch) from $XDG_CONFIG_HOME.
+{% for flag in browser_chromium_flags %}
+{{ flag }}
+{% endfor %}


### PR DESCRIPTION
Adds `browser_chromium_flags` (list) and `browser_chromium_flags_enabled` (default `false`), deploying `~/.config/chromium-flags.conf` per `browser_users`. Arch's Chromium binary reads this file directly (downstream flags-file patch), so switches with no `policies.json` equivalent — such as Web Bluetooth's `--enable-experimental-web-platform-features` — can be managed declaratively.

Molecule covers the managed/initial/disabled gating: the flags file is deployed for managed and newly-created initial users, and skipped for existing initial users and disabled entries.

Closes #207