### PR TITLE
feat(browser): add seed per-user config mode

### DIFF
--- a/roles/browser/README.md
+++ b/roles/browser/README.md
@@ -119,10 +119,10 @@ Chromium on Rocky Linux requires EPEL.
 
 ### User Configuration
 
-| Variable                   | Default     | Description                            |
-| -------------------------- | ----------- | -------------------------------------- |
-| `browser_users`            | `[]`        | Users for per-user profile settings    |
-| `browser_user_config_mode` | `'initial'` | Default mode: managed/initial/disabled |
+| Variable                   | Default     | Description                                  |
+| -------------------------- | ----------- | -------------------------------------------- |
+| `browser_users`            | `[]`        | Users for per-user profile settings          |
+| `browser_user_config_mode` | `'initial'` | Default mode: managed/initial/seed/disabled  |
 
 `browser_default` is applied per-user via `~/.config/mimeapps.list`
 (sections `[Default Applications]`, keys `x-scheme-handler/http`
@@ -132,10 +132,18 @@ match the `.desktop` basename of an installed browser, without the
 suffix (e.g. `firefox`, `librewolf`, `chromium`, `brave-browser`).
 Set to an empty string to skip handler management. Other entries
 in `mimeapps.list` are preserved on each run. The same
-`managed`/`initial`/`disabled` mode that governs per-user profile
+`managed`/`initial`/`seed`/`disabled` mode that governs per-user profile
 config applies here too — `initial` deploys only on newly created
-users, leaving subsequent manual changes intact. `browser_chromium_flags`
-(`~/.config/chromium-flags.conf`) follows the same per-user mode.
+users, leaving subsequent manual changes intact.
+
+`browser_chromium_flags` (`~/.config/chromium-flags.conf`) and the
+per-user `user.js` are whole-file deploys and additionally honour `seed`
+mode: the file is written only when absent (`force: false`) and never
+overwritten afterwards. Use `seed` to roll a new config out to an
+existing user once and then leave it under the user's control — unlike
+`initial`, which is gated on user creation and so never reaches existing
+users. `mimeapps.list` manages individual handler keys rather than a
+whole file, so it treats `seed` like `initial`.
 
 ### Firefox / LibreWolf preferences — locked vs. user-overridable
 

--- a/roles/browser/defaults/main.yml
+++ b/roles/browser/defaults/main.yml
@@ -293,6 +293,9 @@ browser_brave_autofill_credit_card: false
 # Modes:
 #   managed  — always deploy/overwrite user config (default)
 #   initial  — deploy only when user is newly created
+#   seed     — deploy whole-file configs (user.js, chromium-flags.conf)
+#              only when absent, never overwrite; rolls new files out to
+#              existing users once. mimeapps.list treats seed like initial.
 #   disabled — skip config deployment for this user
 
 browser_users: []
@@ -302,5 +305,6 @@ browser_users: []
 
 # Default mode when user entry has no 'mode' key
 # 'initial' preserves user customisations after first deploy.
-# Set to 'managed' for continuous reconciliation.
+# 'managed' reconciles continuously; 'seed' deploys missing files once
+# without ever overwriting them.
 browser_user_config_mode: 'initial'

--- a/roles/browser/molecule/default/converge.yml
+++ b/roles/browser/molecule/default/converge.yml
@@ -137,3 +137,48 @@
     - name: Converge | Include browser role  # noqa: role-name[path]
       ansible.builtin.include_role:
         name: '{{ playbook_dir }}/../..'
+
+
+# seed mode: both users are pre-existing (empty __users_newly_created), so
+# initial would skip them. seed must create chromium-flags.conf where it is
+# absent (browser_seed_new_file) and leave an already-present copy untouched
+# (browser_seed_keep_file).
+- name: Converge | Seed mode (existing users)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    browser_enabled: true
+    browser_firefox_enabled: false
+    browser_chromium_enabled: true
+    browser_chromium_policies_enabled: false
+    browser_chromium_flags_enabled: true
+    browser_chromium_flags:
+      - '--enable-experimental-web-platform-features'
+    browser_default: ''
+    browser_user_config_mode: 'seed'
+    browser_users:
+      - username: 'browser_seed_new_file'
+      - username: 'browser_seed_keep_file'
+
+  pre_tasks:
+    - name: Converge | Ensure seed-keep user config dir exists
+      ansible.builtin.file:
+        path: /home/browser_seed_keep_file/.config
+        state: directory
+        owner: browser_seed_keep_file
+        group: browser_seed_keep_file
+        mode: '0700'
+
+    - name: Converge | Pre-seed a user-edited chromium-flags.conf
+      ansible.builtin.copy:
+        content: "--user-edited-sentinel\n"
+        dest: /home/browser_seed_keep_file/.config/chromium-flags.conf
+        owner: browser_seed_keep_file
+        group: browser_seed_keep_file
+        mode: '0644'
+
+  tasks:
+    - name: Converge | Include browser role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'

--- a/roles/browser/molecule/default/prepare.yml
+++ b/roles/browser/molecule/default/prepare.yml
@@ -108,5 +108,9 @@
         - browser_initial_exist
         # Play 3 (disabled, global): never deployed
         - browser_global_disabled
+        # Play 4 (seed): existing users — file absent (created) and file
+        # already present (left untouched)
+        - browser_seed_new_file
+        - browser_seed_keep_file
       loop_control:
         label: '{{ item }}'

--- a/roles/browser/molecule/default/verify.yml
+++ b/roles/browser/molecule/default/verify.yml
@@ -368,3 +368,37 @@
           - not __browser_verify_globaldisabled_profile.stat.exists
           - not __browser_verify_globaldisabled_mimeapps.stat.exists
         fail_msg: 'browser config deployed despite global disabled mode'
+
+    #
+    # Seed Mode — Existing Users (browser_seed_new_file / _keep_file)
+    #
+    # browser_user_config_mode=seed on pre-existing users (NOT in
+    # __users_newly_created): initial would skip both. seed MUST create
+    # chromium-flags.conf where absent and MUST NOT overwrite an existing
+    # (user-edited) copy.
+    #
+
+    - name: Verify | Read seed-new-file user chromium-flags.conf
+      ansible.builtin.slurp:
+        src: /home/browser_seed_new_file/.config/chromium-flags.conf
+      register: __browser_verify_seed_new
+
+    - name: Verify | Assert seed created chromium-flags.conf for existing user
+      ansible.builtin.assert:
+        that:
+          - "'--enable-experimental-web-platform-features'
+            in (__browser_verify_seed_new.content | b64decode)"
+        fail_msg: 'seed did not create chromium-flags.conf for an existing user'
+
+    - name: Verify | Read seed-keep-file user chromium-flags.conf
+      ansible.builtin.slurp:
+        src: /home/browser_seed_keep_file/.config/chromium-flags.conf
+      register: __browser_verify_seed_keep
+
+    - name: Verify | Assert seed left the user-edited chromium-flags.conf intact
+      ansible.builtin.assert:
+        that:
+          - "'--user-edited-sentinel' in (__browser_verify_seed_keep.content | b64decode)"
+          - "'--enable-experimental-web-platform-features'
+            not in (__browser_verify_seed_keep.content | b64decode)"
+        fail_msg: 'seed overwrote a pre-existing user-edited chromium-flags.conf'

--- a/roles/browser/tasks/users.yml
+++ b/roles/browser/tasks/users.yml
@@ -1,5 +1,8 @@
 ---
-# Respects mode: managed | initial | disabled
+# Respects mode: managed | initial | seed | disabled. Whole-file deploys
+# (user.js, chromium-flags.conf) honour seed via force: false (deploy if
+# absent, never overwrite). mimeapps.list manages individual handler keys
+# rather than a whole file, so it treats seed like initial.
 
 - name: Users | Bootstrap Firefox profile
   ansible.builtin.include_tasks:
@@ -27,7 +30,7 @@
     - browser_firefox_user_js_enabled | bool
     - (browser_user.mode | default(browser_user_config_mode)) != 'disabled'
     - >-
-      (browser_user.mode | default(browser_user_config_mode)) == 'managed'
+      (browser_user.mode | default(browser_user_config_mode)) in ['managed', 'seed']
       or ((browser_user.mode | default(browser_user_config_mode)) == 'initial'
           and browser_user.username in (__users_newly_created | default([])))
 
@@ -58,7 +61,7 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - (browser_user.mode | default(browser_user_config_mode)) != 'disabled'
     - >-
-      (browser_user.mode | default(browser_user_config_mode)) == 'managed'
+      (browser_user.mode | default(browser_user_config_mode)) in ['managed', 'seed']
       or ((browser_user.mode | default(browser_user_config_mode)) == 'initial'
           and browser_user.username in (__users_newly_created | default([])))
 
@@ -82,7 +85,7 @@
     - browser_chromium_flags | length > 0
     - (browser_user.mode | default(browser_user_config_mode)) != 'disabled'
     - >-
-      (browser_user.mode | default(browser_user_config_mode)) == 'managed'
+      (browser_user.mode | default(browser_user_config_mode)) in ['managed', 'seed']
       or ((browser_user.mode | default(browser_user_config_mode)) == 'initial'
           and browser_user.username in (__users_newly_created | default([])))
 
@@ -107,5 +110,5 @@
     - (browser_user.mode | default(browser_user_config_mode)) != 'disabled'
     - >-
       (browser_user.mode | default(browser_user_config_mode)) == 'managed'
-      or ((browser_user.mode | default(browser_user_config_mode)) == 'initial'
+      or ((browser_user.mode | default(browser_user_config_mode)) in ['initial', 'seed']
           and browser_user.username in (__users_newly_created | default([])))

--- a/roles/browser/tasks/users_chromium.yml
+++ b/roles/browser/tasks/users_chromium.yml
@@ -21,6 +21,9 @@
     group: '{{ browser_user.username }}'
     mode: '0700'
 
+# seed mode deploys the file only when absent (force: false) and never
+# overwrites a copy the user has since edited; managed/initial reconcile
+# it (force: true).
 - name: Users Chromium | Deploy chromium-flags.conf
   ansible.builtin.template:
     src: chromium-flags.conf.j2
@@ -28,3 +31,4 @@
     owner: '{{ browser_user.username }}'
     group: '{{ browser_user.username }}'
     mode: '0644'
+    force: "{{ (browser_user.mode | default(browser_user_config_mode)) != 'seed' }}"

--- a/roles/browser/tasks/users_firefox_family.yml
+++ b/roles/browser/tasks/users_firefox_family.yml
@@ -125,6 +125,8 @@
     label: 'Install.{{ item.option }}'
   when: __ff_install_hash | length > 0
 
+# seed mode deploys user.js only when absent (force: false), preserving a
+# copy the user has since edited; managed/initial reconcile it.
 - name: Users Profile | Deploy user.js
   ansible.builtin.template:
     src: user.js.j2
@@ -132,6 +134,7 @@
     owner: '{{ browser_user.username }}'
     group: '{{ browser_user.username }}'
     mode: '0644'
+    force: "{{ (browser_user.mode | default(browser_user_config_mode)) != 'seed' }}"
   vars:
     __browser_template_prefs: '{{ __ff_preferences }}'
   when: __ff_preferences | length > 0


### PR DESCRIPTION
Adds a fourth `browser_user_config_mode` value, `seed`: whole-file per-user configs (`user.js`, `chromium-flags.conf`) are deployed only when absent (`force: false`) and never overwritten, so a newly added file reaches an already-provisioned user once and then stays under the user's control.

Unlike `initial` (gated on user creation), `seed` is gated on file existence, which is what lets it roll a new file out to existing users. `mimeapps.list` manages individual handler keys rather than a whole file, so it treats `seed` like `initial`.

Molecule adds a seed-mode play with two pre-existing users: the file is created where absent and left untouched where the user has edited it.

Closes #208