### PR TITLE
feat(graphics_apps): add Inkscape extension install list

### DIFF
--- a/roles/graphics_apps/README.md
+++ b/roles/graphics_apps/README.md
@@ -11,7 +11,10 @@ XnConvert and XnView are Arch Linux-only (installed from AUR). EL requires
 EPEL for GIMP and Inkscape. Krita is not available on EL 9 (not in EPEL 9)
 — it requires EL 10 with EPEL 10.
 
-Optional GIMP plugins can be installed via `graphics_apps_gimp_plugins`.
+Optional GIMP plugins can be installed via `graphics_apps_gimp_plugins`, and
+Inkscape extensions via `graphics_apps_inkscape_plugins`. On Arch the latter are
+installed from the AUR (e.g. `inkscape-silhouette-git`); on Debian/EL they must be
+available as distribution packages.
 
 ## Requirements
 
@@ -52,6 +55,7 @@ overrides if needed.
 | `graphics_apps_xnconvert_enabled` | `true`  | Install XnConvert (Arch only, AUR)         |
 | `graphics_apps_xnview_enabled`    | `false` | Install XnView (Arch only, AUR)            |
 | `graphics_apps_gimp_plugins`      | `[]`    | Additional GIMP plugin packages to install |
+| `graphics_apps_inkscape_plugins`  | `[]`    | Additional Inkscape extension packages     |
 
 ## Tags
 

--- a/roles/graphics_apps/defaults/main.yml
+++ b/roles/graphics_apps/defaults/main.yml
@@ -26,6 +26,11 @@ graphics_apps_gimp_plugins: []
 # Enable Inkscape (vector graphics editor)
 graphics_apps_inkscape_enabled: true
 
+# Additional Inkscape extension packages to install.
+# On Arch these are installed from the AUR (e.g. inkscape-silhouette-git);
+# on Debian/EL they must be available as distribution packages.
+graphics_apps_inkscape_plugins: []
+
 #
 # Image Conversion/Viewing
 #

--- a/roles/graphics_apps/molecule/default/converge.yml
+++ b/roles/graphics_apps/molecule/default/converge.yml
@@ -12,6 +12,7 @@
     graphics_apps_xnconvert_enabled: false
     graphics_apps_xnview_enabled: false
     graphics_apps_gimp_plugins: []
+    graphics_apps_inkscape_plugins: []
 
   tasks:
     - name: Converge | Include graphics_apps role  # noqa: role-name[path]

--- a/roles/graphics_apps/molecule/default/verify.yml
+++ b/roles/graphics_apps/molecule/default/verify.yml
@@ -185,3 +185,45 @@
       when:
         - ansible_facts['os_family'] == 'RedHat'
         - graphics_apps_gimp_plugins | default([]) | length > 0
+
+    #
+    # Inkscape Plugins
+    #
+    # Skipped when graphics_apps_inkscape_plugins is empty (default).
+    # On Arch these are AUR packages (not built in molecule containers).
+
+    - name: Verify | Check Inkscape plugins installed (Arch)
+      ansible.builtin.command:
+        cmd: >-
+          pacman -Q {{ item }}
+      register: _gfx_inkscape_plugin_arch
+      changed_when: false
+      failed_when: _gfx_inkscape_plugin_arch.rc != 0
+      loop: "{{ graphics_apps_inkscape_plugins | default([]) }}"
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - graphics_apps_inkscape_plugins | default([]) | length > 0
+
+    - name: Verify | Check Inkscape plugins installed (Debian)
+      ansible.builtin.command:
+        cmd: >-
+          dpkg -l {{ item }}
+      register: _gfx_inkscape_plugin_deb
+      changed_when: false
+      failed_when: _gfx_inkscape_plugin_deb.rc != 0
+      loop: "{{ graphics_apps_inkscape_plugins | default([]) }}"
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - graphics_apps_inkscape_plugins | default([]) | length > 0
+
+    - name: Verify | Check Inkscape plugins installed (RedHat)
+      ansible.builtin.command:  # noqa: command-instead-of-module
+        cmd: >-
+          rpm -q {{ item }}
+      register: _gfx_inkscape_plugin_rpm
+      changed_when: false
+      failed_when: _gfx_inkscape_plugin_rpm.rc != 0
+      loop: "{{ graphics_apps_inkscape_plugins | default([]) }}"
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - graphics_apps_inkscape_plugins | default([]) | length > 0

--- a/roles/graphics_apps/tasks/install.yml
+++ b/roles/graphics_apps/tasks/install.yml
@@ -39,6 +39,30 @@
   retries: 3
   delay: 5
 
+- name: Install | Inkscape plugins from AUR (Arch)
+  become: true
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
+  kewlfft.aur.aur:
+    name: '{{ graphics_apps_inkscape_plugins }}'
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - graphics_apps_inkscape_enabled | bool
+    - graphics_apps_inkscape_plugins | length > 0
+  retries: 3
+  delay: 5
+
+- name: Install | Inkscape plugins
+  ansible.builtin.package:
+    name: '{{ graphics_apps_inkscape_plugins }}'
+    state: present
+  when:
+    - ansible_facts['os_family'] != 'Archlinux'
+    - graphics_apps_inkscape_enabled | bool
+    - graphics_apps_inkscape_plugins | length > 0
+  retries: 3
+  delay: 5
+
 - name: Install | XnConvert from AUR (Arch)
   become: true
   become_user: "{{ aur_builder_user | default('aur_builder') }}"


### PR DESCRIPTION
## Summary

Adds `graphics_apps_inkscape_plugins` (empty by default), mirroring `graphics_apps_gimp_plugins`, so Inkscape extensions install the same way GIMP plugins already do.

- On Arch the list is installed from the AUR (e.g. `inkscape-silhouette-git`).
- On Debian/EL the list is installed as distribution packages.
- Gated on `graphics_apps_inkscape_enabled` and a non-empty list, so it is a no-op by default.

## Context

`inkscape-silhouette` (the driver named in the issue) is only packaged for Arch, as the AUR VCS package `inkscape-silhouette-git`. Upstream documents Debian/RHEL install only via git-clone + build, which is out of scope here and deferred to the cross-distro missing-packages audit.

## Test plan

- [x] yamllint
- [x] ansible-lint (production profile)
- [x] markdownlint
- [x] molecule test (Arch) — converge + idempotence + verify green; the new install/verify tasks skip with the empty default list, matching the existing GIMP-plugin and AUR (XnConvert/XnView) coverage
- [ ] CI runs the full molecule matrix (Arch, Debian Trixie, Rocky 9, Rocky 10)

Note: the actual AUR build of `inkscape-silhouette-git` is not exercised in containers, identical to the existing XnConvert/XnView tasks.

Closes #209