### PR TITLE
fix(graphics_apps): correct EL 10 package availability

### DIFF
--- a/roles/graphics_apps/README.md
+++ b/roles/graphics_apps/README.md
@@ -7,9 +7,9 @@ Install graphics and image editing applications.
 Installs graphics, digital painting, vector graphics, and image conversion
 applications. Supports GIMP, Krita, Inkscape, XnConvert, and XnView.
 
-XnConvert and XnView are Arch Linux-only (installed from AUR). EL requires
-EPEL for GIMP and Inkscape. Krita is not available on EL 9 (not in EPEL 9)
-— it requires EL 10 with EPEL 10.
+XnConvert and XnView are Arch Linux-only (installed from AUR). On EL, GIMP and
+Inkscape come from AppStream on EL 9 but are not packaged for EL 10. Krita is
+the opposite: absent on EL 9 (not in EPEL 9), available on EL 10 via EPEL 10.
 
 Optional GIMP plugins can be installed via `graphics_apps_gimp_plugins`, and
 Inkscape extensions via `graphics_apps_inkscape_plugins`. On Arch the latter are
@@ -21,8 +21,10 @@ available as distribution packages.
 - ansible-core >= 2.17
 - `community.general` collection (pacman module)
 - `kewlfft.aur` collection (Arch Linux AUR packages)
-- EL requires EPEL to be enabled for GIMP, Inkscape, and Krita (EL 10+).
-  EPEL is managed by the `marcstraube.common.package_management` role.
+- On EL 10, Krita requires EPEL and CRB enabled (its turbojpeg dependency lives
+  in CRB); GIMP and Inkscape are not packaged for EL 10, and on EL 9 both come
+  from AppStream. EPEL and CRB are managed by the
+  `marcstraube.common.package_management` role.
 
 ## Supported Platforms
 
@@ -31,7 +33,7 @@ available as distribution packages.
 | Arch Linux                 | yes  | yes     | yes      | AUR       | AUR    |
 | Debian Trixie              | yes  | yes     | yes      | no        | no     |
 | EL 9 (Rocky, Alma, RHEL)   | yes  | no      | yes      | no        | no     |
-| EL 10 (Rocky, Alma, RHEL)  | yes  | EPEL 10 | yes      | no        | no     |
+| EL 10 (Rocky, Alma, RHEL)  | no   | EPEL 10 | no       | no        | no     |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/graphics_apps/molecule/default/prepare.yml
+++ b/roles/graphics_apps/molecule/default/prepare.yml
@@ -53,6 +53,15 @@
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
 
+    # Krita (EPEL 10) pulls turbojpeg, which lives in CRB. EPEL itself is
+    # already enabled in the geerlingguy base images. In production both
+    # repos are managed by marcstraube.common.package_management.
+    - name: Prepare | Enable CRB repository (RedHat)
+      ansible.builtin.command:
+        cmd: dnf config-manager --set-enabled crb
+      changed_when: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
     - name: Prepare | Install container dependencies (RedHat)
       ansible.builtin.package:
         name: '{{ __prepare_packages["RedHat"] }}'

--- a/roles/graphics_apps/vars/RedHat-10.yml
+++ b/roles/graphics_apps/vars/RedHat-10.yml
@@ -1,9 +1,0 @@
----
-#
-# RedHat 10 Packages (Rocky 10 / EPEL 10)
-#
-
-# None of these are in EPEL 10
-__graphics_apps_gimp_package: ''
-__graphics_apps_krita_package: ''
-__graphics_apps_inkscape_package: ''

--- a/roles/graphics_apps/vars/RedHat.yml
+++ b/roles/graphics_apps/vars/RedHat.yml
@@ -2,7 +2,9 @@
 #
 # RedHat Packages (EL 10 / EPEL 10)
 #
+# GIMP and Inkscape are not packaged for EL 10 (absent from BaseOS,
+# AppStream, CRB and EPEL 10). Krita is available in EPEL 10.
 
-__graphics_apps_gimp_package: 'gimp'
+__graphics_apps_gimp_package: ''
 __graphics_apps_krita_package: 'krita'
-__graphics_apps_inkscape_package: 'inkscape'
+__graphics_apps_inkscape_package: ''


### PR DESCRIPTION
## Summary

Fixes inverted EL package availability in the `graphics_apps` RedHat vars files.

Verified via `dnf repoquery` (base + AppStream + CRB + EPEL):

| Package | EL 9 | EL 10 |
|---------|------|-------|
| gimp | AppStream | not available |
| inkscape | AppStream | not available |
| krita | not available | EPEL 10 (needs CRB for turbojpeg) |

Previously `RedHat-10.yml` set all three empty (silently dropping Krita, which is in EPEL 10), while `RedHat.yml` claimed GIMP/Inkscape were present for EL 10.

## Changes

- `vars/RedHat.yml` now holds the EL 10 truth (newest EL major per convention): `gimp: ''`, `inkscape: ''`, `krita: 'krita'`.
- Deleted `vars/RedHat-10.yml` (the `RedHat.yml` fallback already matches EL 10; the numbered file also violated the naming convention).
- `vars/RedHat-9.yml` unchanged (already correct: GIMP/Inkscape from AppStream, Krita absent).
- Enabled CRB in molecule `prepare.yml` so Krita's `turbojpeg` dependency resolves on Rocky 10, mirroring `marcstraube.common.package_management` in production (same pattern as system_apps/cad/communication/downloads/wine).
- Corrected the README platform table (EL 10: GIMP/Inkscape `no`) and the EPEL/CRB requirement notes.

## Test plan

- [x] yamllint
- [x] ansible-lint (production profile)
- [x] markdownlint
- [x] molecule Rocky 10 — Krita installs via EPEL + CRB, idempotent, verify green
- [x] molecule Rocky 9 — no regression (GIMP/Inkscape from AppStream, Krita skipped)
- [ ] CI runs the full molecule matrix (Arch, Debian Trixie, Rocky 9, Rocky 10)

Closes #216
