### PR TITLE
feat(development): add pytest toggle

### DIFF
--- a/roles/development/README.md
+++ b/roles/development/README.md
@@ -312,10 +312,11 @@ dash, ksh, mksh); `bats-core` is bash-specific.
 
 #### Python Tooling
 
-| Variable                          | Default | Description                                     |
-|-----------------------------------|---------|-------------------------------------------------|
-| `development_python_ruff_enabled` | `false` | Enable ruff Python linter and formatter         |
-| `development_python_uv_enabled`   | `false` | Enable uv Python package installer and resolver |
+| Variable                            | Default | Description                                     |
+|-------------------------------------|---------|-------------------------------------------------|
+| `development_python_ruff_enabled`   | `false` | Enable ruff Python linter and formatter         |
+| `development_python_uv_enabled`     | `false` | Enable uv Python package installer and resolver |
+| `development_python_pytest_enabled` | `false` | Enable pytest Python test framework             |
 
 #### Lua
 
@@ -344,6 +345,7 @@ toggle after install does not uninstall the package.
 | bats         | yes  | yes           | yes  | yes   |
 | ruff         | yes  | no            | no   | yes   |
 | uv           | yes  | no            | no   | yes   |
+| pytest       | yes  | yes           | yes  | yes   |
 | stylua       | yes  | no            | no   | no    |
 | luacheck     | yes  | yes           | no   | no    |
 | busted       | yes  | yes           | no   | no    |
@@ -457,6 +459,7 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - [bats-core](https://github.com/bats-core/bats-core) — Bash automated testing system
 - [ruff](https://github.com/astral-sh/ruff) — Python linter and formatter
 - [uv](https://github.com/astral-sh/uv) — Python package installer and resolver
+- [pytest](https://github.com/pytest-dev/pytest) — Python test framework
 - [stylua](https://github.com/JohnnyMorganz/StyLua) — Lua formatter
 - [luacheck](https://github.com/mpeterv/luacheck) — Lua linter
 - [busted](https://github.com/lunarmodules/busted) — Lua test framework

--- a/roles/development/defaults/main.yml
+++ b/roles/development/defaults/main.yml
@@ -172,6 +172,9 @@ development_python_ruff_enabled: false
 # Enable uv Python package installer and resolver
 development_python_uv_enabled: false
 
+# Enable pytest Python test framework
+development_python_pytest_enabled: false
+
 # Lua
 
 # Enable stylua Lua formatter

--- a/roles/development/molecule/default/converge.yml
+++ b/roles/development/molecule/default/converge.yml
@@ -46,6 +46,7 @@
     development_shell_bats_enabled: true
     development_python_ruff_enabled: true
     development_python_uv_enabled: true
+    development_python_pytest_enabled: true
     development_lua_stylua_enabled: true
     development_lua_luacheck_enabled: true
     development_lua_busted_enabled: true
@@ -107,6 +108,7 @@
     development_shell_bats_enabled: true
     development_python_ruff_enabled: true
     development_python_uv_enabled: true
+    development_python_pytest_enabled: true
     development_lua_stylua_enabled: true
     development_lua_luacheck_enabled: true
     development_lua_busted_enabled: true
@@ -183,6 +185,7 @@
     development_shell_bats_enabled: true
     development_python_ruff_enabled: true
     development_python_uv_enabled: true
+    development_python_pytest_enabled: true
     development_lua_stylua_enabled: true
     development_lua_luacheck_enabled: true
     development_lua_busted_enabled: true

--- a/roles/development/molecule/default/prepare.yml
+++ b/roles/development/molecule/default/prepare.yml
@@ -81,6 +81,15 @@
         allowerasing: true
       when: ansible_facts['os_family'] == 'RedHat'
 
+    # pytest lives in CRB on EL 10 (AppStream on EL 9). EPEL is already
+    # enabled in the geerlingguy base images. In production both repos are
+    # managed by marcstraube.common.package_management.
+    - name: Prepare | Enable CRB repository (RedHat)
+      ansible.builtin.command:
+        cmd: dnf config-manager --set-enabled crb
+      changed_when: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'

--- a/roles/development/molecule/default/verify.yml
+++ b/roles/development/molecule/default/verify.yml
@@ -197,6 +197,15 @@
       failed_when: _dev_uv_check.changed
       when: __development_python_uv_package | default('') | length > 0
 
+    - name: Verify | pytest — package installed
+      ansible.builtin.package:
+        name: '{{ __development_python_pytest_package }}'
+        state: present
+      check_mode: true
+      register: _dev_pytest_check
+      failed_when: _dev_pytest_check.changed
+      when: __development_python_pytest_package | default('') | length > 0
+
     - name: Verify | stylua — package installed
       ansible.builtin.package:
         name: '{{ __development_lua_stylua_package }}'

--- a/roles/development/tasks/python_tooling.yml
+++ b/roles/development/tasks/python_tooling.yml
@@ -19,6 +19,14 @@
   retries: 3
   delay: 5
 
+- name: Python Tooling | Manage pytest
+  ansible.builtin.package:
+    name: '{{ __development_python_pytest_package }}'
+    state: "{{ 'present' if development_python_pytest_enabled | bool else 'absent' }}"
+  when: __development_python_pytest_package | default('') | length > 0
+  retries: 3
+  delay: 5
+
 - name: Python Tooling | uv not available (unpackaged platform)
   ansible.builtin.debug:
     msg: >

--- a/roles/development/vars/Archlinux.yml
+++ b/roles/development/vars/Archlinux.yml
@@ -70,6 +70,7 @@ __development_shell_bats_package: 'bats'
 # Python tooling
 __development_python_ruff_package: 'ruff'
 __development_python_uv_package: 'uv'
+__development_python_pytest_package: 'python-pytest'
 
 # Lua tooling
 __development_lua_stylua_package: 'stylua'

--- a/roles/development/vars/Debian.yml
+++ b/roles/development/vars/Debian.yml
@@ -86,9 +86,10 @@ __development_shell_shfmt_package: 'shfmt'
 __development_shell_shellcheck_package: 'shellcheck'
 __development_shell_bats_package: 'bats'
 
-# Python tooling (ruff and uv not packaged in Debian Trixie)
+# Python tooling (ruff and uv not packaged in Debian Trixie; pytest is)
 __development_python_ruff_package: ''
 __development_python_uv_package: ''
+__development_python_pytest_package: 'python3-pytest'
 
 # Lua tooling (stylua not packaged in Debian)
 __development_lua_stylua_package: ''

--- a/roles/development/vars/RedHat-9.yml
+++ b/roles/development/vars/RedHat-9.yml
@@ -96,9 +96,10 @@ __development_shell_shfmt_package: ''
 __development_shell_shellcheck_package: 'ShellCheck'
 __development_shell_bats_package: 'bats'
 
-# Python tooling (ruff and uv not packaged on EL9)
+# Python tooling (ruff and uv not packaged on EL9; pytest is, in AppStream)
 __development_python_ruff_package: ''
 __development_python_uv_package: ''
+__development_python_pytest_package: 'python3-pytest'
 
 # Lua tooling (none packaged on EL)
 __development_lua_stylua_package: ''

--- a/roles/development/vars/RedHat.yml
+++ b/roles/development/vars/RedHat.yml
@@ -92,6 +92,8 @@ __development_shell_bats_package: 'bats'
 # Python tooling (ruff and uv are EL10-only, see vars/RedHat-9.yml)
 __development_python_ruff_package: 'ruff'
 __development_python_uv_package: 'uv'
+# pytest: CRB on EL10, AppStream on EL9 (CRB enabled by package_management)
+__development_python_pytest_package: 'python3-pytest'
 
 # Lua tooling (none packaged on EL)
 __development_lua_stylua_package: ''


### PR DESCRIPTION
## Summary

Adds `development_python_pytest_enabled`, a per-tool toggle for the pytest Python test framework — consistent with the role's existing language tooling toggles. It fills the gap on the Python side: bats and busted already cover the Bash and Lua test frameworks.

pytest is packaged on every supported platform (verified via `dnf repoquery` / `apt-cache`):

| Platform | Package | Source |
|----------|---------|--------|
| Arch | `python-pytest` | extra |
| Debian Trixie | `python3-pytest` | main |
| EL 9 | `python3-pytest` | AppStream |
| EL 10 | `python3-pytest` | CRB |

## Changes

- New toggle `development_python_pytest_enabled` (default `false`), with `__development_python_pytest_package` per OS and a length-guarded install task in `python_tooling.yml`.
- Molecule `prepare.yml` enables CRB on RedHat so EL 10's CRB-only pytest resolves, mirroring `marcstraube.common.package_management` in production (same pattern as other roles).
- README: variable table, platform support row, and references entry.

## Test plan

- [x] yamllint
- [x] ansible-lint (production profile)
- [x] markdownlint
- [x] molecule Rocky 10 — pytest installs via CRB, idempotent, verify green
- [x] molecule Rocky 9 — pytest installs via AppStream, idempotent, verify green
- [ ] CI runs the full molecule matrix (Arch, Debian Trixie, Rocky 9, Rocky 10)

Closes #214
