### PR TITLE
feat(browser): add Google Chrome support

### DIFF
--- a/roles/browser/README.md
+++ b/roles/browser/README.md
@@ -6,7 +6,8 @@ Install and configure web browsers with enterprise policies and hardening.
 
 Installs and configures web browsers with system-wide enterprise policies for
 extension management, privacy hardening, and telemetry control. Supports
-Firefox, LibreWolf, Chromium, Brave, Tor Browser, and Zen Browser.
+Firefox, LibreWolf, Chromium, Brave, Google Chrome, Tor Browser, and Zen
+Browser.
 
 Browser extensions are managed via policies (force-installed, user-installable,
 or blocked). Firefox/LibreWolf system-wide locked preferences go through the
@@ -18,6 +19,15 @@ LibreWolf, Brave, Tor Browser, and Zen Browser are installed from AUR on
 Arch Linux. Tor Browser is available via `torbrowser-launcher` on Debian.
 Chromium on Rocky Linux requires EPEL.
 
+Google Chrome is available on every platform: from AUR (`google-chrome`) on
+Arch Linux, and from Google's own vendor package on Debian/EL. On Debian/EL
+the vendor package's post-install script installs and owns Google's apt/yum
+repository and signing key, so Chrome updates through the normal system
+upgrade path (the role installs the package directly rather than adding a
+second, conflicting repository entry). Chrome is opt-in
+(`browser_chrome_enabled: false`) and shares the Chromium extension and
+policy mechanism.
+
 ## Requirements
 
 - ansible-core >= 2.17
@@ -28,12 +38,12 @@ Chromium on Rocky Linux requires EPEL.
 
 ## Supported Platforms
 
-| Platform       | Firefox | Chromium     | LibreWolf | Brave | Tor    | Zen  |
-| -------------- | ------- | ------------ | --------- | ----- | ------ | ---- |
-| Arch Linux     | yes     | yes          | AUR       | AUR   | AUR    | AUR  |
-| Debian Trixie  | ESR     | yes          | no        | no    | yes    | no   |
-| EL 9           | yes     | EPEL         | no        | no    | no     | no   |
-| EL 10          | yes     | EPEL         | no        | no    | no     | no   |
+| Platform       | Firefox | LibreWolf | Tor | Zen | Chromium | Brave | Chrome |
+| -------------- | ------- | --------- | --- | --- | -------- | ----- | ------ |
+| Arch Linux     | yes     | AUR       | AUR | AUR | yes      | AUR   | AUR    |
+| Debian Trixie  | ESR     | no        | yes | no  | yes      | no    | repo   |
+| EL 9           | yes     | no        | no  | no  | EPEL     | no    | repo   |
+| EL 10          | yes     | no        | no  | no  | EPEL     | no    | repo   |
 
 ## Role Variables
 
@@ -48,11 +58,12 @@ Chromium on Rocky Linux requires EPEL.
 | Variable                     | Default     | Description                   |
 | ---------------------------- | ----------- | ----------------------------- |
 | `browser_firefox_enabled`    | `true`      | Install Firefox               |
-| `browser_chromium_enabled`   | `true`      | Install Chromium              |
 | `browser_librewolf_enabled`  | `false`     | Install LibreWolf (Arch only) |
-| `browser_brave_enabled`      | `false`     | Install Brave (Arch only)     |
 | `browser_tor_enabled`        | `false`     | Install Tor Browser           |
 | `browser_zen_enabled`        | `false`     | Install Zen Browser (Arch)    |
+| `browser_chromium_enabled`   | `true`      | Install Chromium              |
+| `browser_brave_enabled`      | `false`     | Install Brave (Arch only)     |
+| `browser_chrome_enabled`     | `false`     | Install Google Chrome         |
 | `browser_default`            | `'firefox'` | Default http/https handler    |
 
 ### Firefox Options
@@ -110,6 +121,29 @@ Chromium on Rocky Linux requires EPEL.
 | `browser_brave_password_manager`      | `false`     | Built-in password manager         |
 | `browser_brave_autofill_address`      | `false`     | Autofill address forms            |
 | `browser_brave_autofill_credit_card`  | `false`     | Autofill credit card forms        |
+
+### Chrome Options
+
+| Variable                              | Default     | Description                       |
+| ------------------------------------- | ----------- | --------------------------------- |
+| `browser_chrome_policies_enabled`     | `true`      | Deploy policies                   |
+| `browser_chrome_flags_enabled`        | `false`     | Per-user chrome-flags.conf (Arch) |
+| `browser_chrome_flags`                | `[]`        | Launch switches (one per line)    |
+| `browser_chrome_extensions`           | `{...}`     | Extensions (defaults to Chromium) |
+| `browser_chrome_extensions_optional`  | `{}`        | Optional extensions (merged)      |
+| `browser_chrome_homepage`             | `''`        | Homepage URL (empty = default)    |
+| `browser_chrome_signin`               | `0`         | Sign-in: 0=off, 1=on, 2=required  |
+| `browser_chrome_sync_disabled`        | `true`      | Disable Chrome Sync               |
+| `browser_chrome_metrics`              | `false`     | Metrics reporting                 |
+| `browser_chrome_safe_browsing`        | `true`      | Safe Browsing                     |
+| `browser_chrome_password_manager`     | `false`     | Built-in password manager         |
+| `browser_chrome_autofill_address`     | `false`     | Autofill address forms            |
+| `browser_chrome_autofill_credit_card` | `false`     | Autofill credit card forms        |
+
+Google Chrome uses the Chromium extension and policy mechanism. The launch
+switches in `browser_chrome_flags` are only read by Arch's `google-chrome`
+AUR launcher (`~/.config/chrome-flags.conf`); Google's own launcher on
+Debian/EL ignores them.
 
 ### Extension Control
 
@@ -206,9 +240,10 @@ the random-prefix profile the browser creates on first launch.
 | `browser`            | All browser tasks           |
 | `browser:install`    | Package installation        |
 | `browser:firefox`    | Firefox policy deployment   |
-| `browser:chromium`   | Chromium policy deployment  |
 | `browser:librewolf`  | LibreWolf policy deployment |
+| `browser:chromium`   | Chromium policy deployment  |
 | `browser:brave`      | Brave policy deployment     |
+| `browser:chrome`     | Chrome policy deployment    |
 | `browser:configure`  | Per-user profile config     |
 | `browser:default`    | Default browser setting     |
 
@@ -242,13 +277,16 @@ molecule test
   Reference for `policies.json` keys deployed by this role
 - [arkenfox/user.js](https://github.com/arkenfox/user.js) —
   Hardened Firefox `user.js` template the role's defaults derive from
-- [Chromium](https://www.chromium.org/) — Open-source browser project
-- [Chromium Enterprise Policy List](https://chromeenterprise.google/policies/) —
-  Reference for Chromium/Brave policy keys
 - [LibreWolf](https://librewolf.net/) — Privacy-focused Firefox fork
-- [Brave](https://brave.com/) — Privacy-focused Chromium fork
 - [Tor Browser](https://www.torproject.org/) — Anonymity-focused Firefox fork
 - [Zen Browser](https://zen-browser.app/) — Productivity-focused Firefox fork
+- [Chromium](https://www.chromium.org/) — Open-source browser project
+- [Chromium Enterprise Policy List](https://chromeenterprise.google/policies/) —
+  Reference for Chromium/Brave/Chrome policy keys
+- [Brave](https://brave.com/) — Privacy-focused Chromium fork
+- [Google Chrome](https://www.google.com/chrome/) — Chromium-based browser
+- [Linux Software Repositories](https://www.google.com/linuxrepositories/) —
+  Google's apt/yum repository the vendor package configures for updates
 
 ## License
 

--- a/roles/browser/defaults/main.yml
+++ b/roles/browser/defaults/main.yml
@@ -22,6 +22,9 @@ browser_chromium_enabled: true
 # Install Brave
 browser_brave_enabled: false
 
+# Install Google Chrome
+browser_chrome_enabled: false
+
 # Install Tor Browser
 browser_tor_enabled: false
 
@@ -87,6 +90,26 @@ browser_chromium_flags: []
 
 # Deploy extension policies
 browser_brave_policies_enabled: true
+
+#
+# Chrome Options
+#
+
+# Deploy extension policies
+browser_chrome_policies_enabled: true
+
+# Deploy per-user launch switches (~/.config/chrome-flags.conf)
+# Confirmed only for Arch's google-chrome AUR launcher, which sources this
+# file like chromium-flags.conf. Google's own launcher on Debian/EL ignores
+# it. Deployed per user via browser_users (respects managed/initial/seed).
+browser_chrome_flags_enabled: false
+
+# Launch switches written one per line to ~/.config/chrome-flags.conf.
+# See browser_chromium_flags for the equivalent Chromium mechanism.
+# Example:
+#   browser_chrome_flags:
+#     - '--enable-experimental-web-platform-features'
+browser_chrome_flags: []
 
 #
 # Extensions - Firefox/LibreWolf
@@ -283,6 +306,21 @@ browser_brave_safe_browsing: true
 browser_brave_password_manager: false
 browser_brave_autofill_address: false
 browser_brave_autofill_credit_card: false
+
+#
+# Chrome Additional Settings
+#
+
+browser_chrome_extensions: '{{ browser_chromium_extensions }}'
+browser_chrome_extensions_optional: '{{ browser_chromium_extensions_optional }}'
+browser_chrome_homepage: ''
+browser_chrome_signin: 0                  # 0 = disabled, 1 = enabled, 2 = required
+browser_chrome_sync_disabled: true
+browser_chrome_metrics: false
+browser_chrome_safe_browsing: true
+browser_chrome_password_manager: false
+browser_chrome_autofill_address: false
+browser_chrome_autofill_credit_card: false
 
 #
 # User Configuration

--- a/roles/browser/molecule/default/converge.yml
+++ b/roles/browser/molecule/default/converge.yml
@@ -15,6 +15,13 @@
     browser_firefox_policies_enabled: true
     browser_chromium_policies_enabled: true
 
+    # Chrome: Google's vendor package (.deb/.rpm) install exercised on
+    # Debian/EL; the Arch AUR build is skipped in containers (like
+    # Brave/LibreWolf). Policies and the optional-extension merge are
+    # verified wherever Chrome is installed.
+    browser_chrome_enabled: "{{ ansible_facts['os_family'] != 'Archlinux' }}"
+    browser_chrome_policies_enabled: true
+
     # Exercise the per-user chromium-flags.conf path
     browser_chromium_flags_enabled: true
     browser_chromium_flags:

--- a/roles/browser/molecule/default/verify.yml
+++ b/roles/browser/molecule/default/verify.yml
@@ -124,6 +124,59 @@
               | b64decode | from_json).ExtensionSettings }}
 
     #
+    # Chrome Verification (Debian/EL only — Arch AUR build skipped)
+    #
+
+    - name: Verify | Google Chrome checks
+      when: ansible_facts['os_family'] != 'Archlinux'
+      block:
+        - name: Verify | Check Google Chrome package installed
+          ansible.builtin.package:
+            name: google-chrome-stable
+            state: present
+          check_mode: true
+          register: __browser_verify_chrome
+
+        - name: Verify | Assert Google Chrome installed
+          ansible.builtin.assert:
+            that:
+              - not __browser_verify_chrome.changed
+            fail_msg: 'Google Chrome is not installed'
+
+        - name: Verify | Check Chrome policies.json exists
+          ansible.builtin.stat:
+            path: /etc/opt/chrome/policies/managed/policies.json
+          register: __browser_verify_chrome_policies
+
+        - name: Verify | Assert Chrome policies.json exists
+          ansible.builtin.assert:
+            that:
+              - __browser_verify_chrome_policies.stat.exists
+            fail_msg: 'Chrome policies.json not found'
+
+        - name: Verify | Validate Chrome policies.json is valid JSON
+          ansible.builtin.command:
+            cmd: 'python3 -c "import json; json.load(open(''/etc/opt/chrome/policies/managed/policies.json''))"'
+          register: __browser_verify_chrome_policies_json
+          changed_when: false
+
+        - name: Verify | Read Chrome policies.json for extension merge check
+          ansible.builtin.slurp:
+            src: /etc/opt/chrome/policies/managed/policies.json
+          register: __browser_verify_chrome_policies_content
+
+        - name: Verify | Assert optional extension merged into Chrome policies
+          ansible.builtin.assert:
+            that:
+              - "'cjpalhdlnbpafiamejdnhcphjbkeiagm' in __ext_settings"
+              - "'kglkahinilanaaknphakkkaigkildipe' in __ext_settings"
+            fail_msg: 'browser_chrome_extensions_optional not merged into ExtensionSettings'
+          vars:
+            __ext_settings: >-
+              {{ (__browser_verify_chrome_policies_content.content
+                  | b64decode | from_json).ExtensionSettings }}
+
+    #
     # Chromium Launch Switches (per-user chromium-flags.conf)
     #
 

--- a/roles/browser/tasks/chrome.yml
+++ b/roles/browser/tasks/chrome.yml
@@ -1,0 +1,21 @@
+---
+- name: Chrome | Ensure policies directories exist
+  ansible.builtin.file:
+    path: '{{ item }}'
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  loop:
+    - '{{ __browser_chrome_policies_path }}/managed'
+    - '{{ __browser_chrome_policies_path }}/recommended'
+  when: __browser_chrome_policies_path | length > 0
+
+- name: Chrome | Deploy managed policies
+  ansible.builtin.template:
+    src: chrome-policies.json.j2
+    dest: '{{ __browser_chrome_policies_path }}/managed/policies.json'
+    owner: root
+    group: root
+    mode: '0644'
+  when: __browser_chrome_policies_path | length > 0

--- a/roles/browser/tasks/install.yml
+++ b/roles/browser/tasks/install.yml
@@ -84,6 +84,58 @@
     - browser_brave_enabled | bool
 
 #
+# Google Chrome (AUR on Arch, Google's own vendor package on Debian/EL).
+# On Debian/EL the google-chrome package's post-install script installs and
+# owns Google's apt/yum repository and signing key, so Chrome updates through
+# the normal system upgrade path. Installing the vendor package directly
+# avoids a second, conflicting Ansible-managed repository entry: Google's
+# post-install script recreates its own repo file (same name) on every
+# install, which would break idempotency.
+#
+
+- name: Install | Google Chrome from AUR (Arch)
+  become: true
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
+  kewlfft.aur.aur:
+    name: '{{ __browser_aur_packages.chrome }}'
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - browser_chrome_enabled | bool
+  retries: 3
+  delay: 5
+
+- name: Install | Google Chrome vendor package (Debian)
+  ansible.builtin.apt:
+    deb: '{{ __browser_chrome_deb_url }}'
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - browser_chrome_enabled | bool
+  retries: 3
+  delay: 5
+
+- name: Install | Import Google Chrome signing key (RedHat)
+  ansible.builtin.rpm_key:
+    key: '{{ __browser_chrome_gpg_url }}'
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - browser_chrome_enabled | bool
+  retries: 3
+  delay: 5
+
+- name: Install | Google Chrome vendor package (RedHat)
+  ansible.builtin.dnf:
+    name: '{{ __browser_chrome_rpm_url }}'
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - browser_chrome_enabled | bool
+  retries: 3
+  delay: 5
+
+#
 # Tor Browser
 #
 

--- a/roles/browser/tasks/main.yml
+++ b/roles/browser/tasks/main.yml
@@ -82,6 +82,21 @@
     - browser_brave_enabled | bool
     - browser_brave_policies_enabled | bool
 
+- name: Main | Include Chrome tasks
+  ansible.builtin.include_tasks:
+    file: chrome.yml
+    apply:
+      tags:
+        - browser
+        - browser:chrome
+  tags:
+    - browser
+    - browser:chrome
+  when:
+    - browser_enabled | bool
+    - browser_chrome_enabled | bool
+    - browser_chrome_policies_enabled | bool
+
 - name: Main | Include user profile tasks
   ansible.builtin.include_tasks:
     file: users.yml

--- a/roles/browser/tasks/users.yml
+++ b/roles/browser/tasks/users.yml
@@ -89,6 +89,30 @@
       or ((browser_user.mode | default(browser_user_config_mode)) == 'initial'
           and browser_user.username in (__users_newly_created | default([])))
 
+- name: Users | Deploy Chrome launch switches
+  ansible.builtin.include_tasks:
+    file: users_chrome.yml
+    apply:
+      tags:
+        - browser
+        - browser:configure
+  tags:
+    - browser
+    - browser:configure
+  loop: '{{ browser_users }}'
+  loop_control:
+    loop_var: browser_user
+    label: '{{ browser_user.username }}'
+  when:
+    - browser_chrome_enabled | bool
+    - browser_chrome_flags_enabled | bool
+    - browser_chrome_flags | length > 0
+    - (browser_user.mode | default(browser_user_config_mode)) != 'disabled'
+    - >-
+      (browser_user.mode | default(browser_user_config_mode)) in ['managed', 'seed']
+      or ((browser_user.mode | default(browser_user_config_mode)) == 'initial'
+          and browser_user.username in (__users_newly_created | default([])))
+
 - name: Users | Include default browser handler config
   ansible.builtin.include_tasks:
     file: users_default_handler.yml

--- a/roles/browser/tasks/users_chrome.yml
+++ b/roles/browser/tasks/users_chrome.yml
@@ -1,0 +1,34 @@
+---
+# Per-user Google Chrome launch switches. Arch's google-chrome AUR launcher
+# sources ~/.config/chrome-flags.conf (identical to chromium-flags.conf), so
+# switches without a policy equivalent (e.g. Web Bluetooth) are deployed here
+# instead of via policies.json.
+
+- name: Users Chrome | Get user info
+  ansible.builtin.getent:
+    database: passwd
+    key: '{{ browser_user.username }}'
+
+- name: Users Chrome | Set user home fact
+  ansible.builtin.set_fact:
+    __browser_user_home: "{{ ansible_facts['getent_passwd'][browser_user.username][4] }}"
+
+- name: Users Chrome | Ensure config directory exists
+  ansible.builtin.file:
+    path: '{{ __browser_user_home }}/.config'
+    state: directory
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0700'
+
+# seed mode deploys the file only when absent (force: false) and never
+# overwrites a copy the user has since edited; managed/initial reconcile
+# it (force: true).
+- name: Users Chrome | Deploy chrome-flags.conf
+  ansible.builtin.template:
+    src: chrome-flags.conf.j2
+    dest: '{{ __browser_user_home }}/.config/chrome-flags.conf'
+    owner: '{{ browser_user.username }}'
+    group: '{{ browser_user.username }}'
+    mode: '0644'
+    force: "{{ (browser_user.mode | default(browser_user_config_mode)) != 'seed' }}"

--- a/roles/browser/templates/chrome-flags.conf.j2
+++ b/roles/browser/templates/chrome-flags.conf.j2
@@ -1,0 +1,7 @@
+{{ ansible_managed | comment }}
+#
+# Google Chrome launch switches, one per line. Sourced by the Arch
+# google-chrome AUR launcher from $XDG_CONFIG_HOME (like chromium-flags.conf).
+{% for flag in browser_chrome_flags %}
+{{ flag }}
+{% endfor %}

--- a/roles/browser/templates/chrome-policies.json.j2
+++ b/roles/browser/templates/chrome-policies.json.j2
@@ -1,0 +1,36 @@
+{
+  "_comment": "{{ ansible_managed }}",
+{% if browser_chrome_extensions | length > 0 or browser_chrome_extensions_optional | default({}) | length > 0 %}
+  "ExtensionSettings": {
+    "*": {
+      "blocked_install_message": "Extension installation is managed by system policy.",
+      "installation_mode": "{{ browser_extension_default_mode }}"
+    }{% if browser_chrome_extensions | length > 0 or browser_chrome_extensions_optional | default({}) | length > 0 %},{% endif %}
+
+{% for ext_id, ext_config in (browser_chrome_extensions | combine(browser_chrome_extensions_optional | default({}))) | dictsort %}
+    "{{ ext_id }}": {
+      "installation_mode": "{{ ext_config.mode | default('normal_installed') }}"{% if ext_config.url is defined %},
+      "update_url": "{{ ext_config.url }}"{% endif %}
+
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  },
+{% endif %}
+{% if browser_chrome_homepage | length > 0 %}
+  "HomepageLocation": "{{ browser_chrome_homepage }}",
+  "HomepageIsNewTabPage": false,
+{% endif %}
+{% if browser_chrome_search_provider is defined %}
+  "DefaultSearchProviderEnabled": true,
+  "DefaultSearchProviderName": "{{ browser_chrome_search_provider.name | default('DuckDuckGo') }}",
+  "DefaultSearchProviderSearchURL": "{{ browser_chrome_search_provider.url | default('https://duckduckgo.com/?q={searchTerms}') }}",
+{% endif %}
+  "BrowserSignin": {{ browser_chrome_signin | default(0) }},
+  "SyncDisabled": {{ browser_chrome_sync_disabled | default(true) | lower }},
+  "MetricsReportingEnabled": {{ browser_chrome_metrics | default(false) | lower }},
+  "SafeBrowsingEnabled": {{ browser_chrome_safe_browsing | default(true) | lower }},
+  "PasswordManagerEnabled": {{ browser_chrome_password_manager | default(false) | lower }},
+  "AutofillAddressEnabled": {{ browser_chrome_autofill_address | default(false) | lower }},
+  "AutofillCreditCardEnabled": {{ browser_chrome_autofill_credit_card | default(false) | lower }}
+}

--- a/roles/browser/vars/Archlinux.yml
+++ b/roles/browser/vars/Archlinux.yml
@@ -8,6 +8,7 @@ __browser_chromium_package: 'chromium'
 __browser_aur_packages:
   librewolf: 'librewolf-bin'
   brave: 'brave-bin'
+  chrome: 'google-chrome'
   tor: 'tor-browser'
   zen: 'zen-browser-bin'
 
@@ -16,6 +17,7 @@ __browser_firefox_policies_path: '/usr/lib/firefox/distribution'
 __browser_librewolf_policies_path: '/usr/lib/librewolf/distribution'
 __browser_chromium_policies_path: '/etc/chromium/policies'
 __browser_brave_policies_path: '/etc/brave/policies'
+__browser_chrome_policies_path: '/etc/opt/chrome/policies'
 
 # Profile detection: pattern to discover any existing profile
 # (random-prefixed by Firefox itself, e.g. xyz123.default-release).

--- a/roles/browser/vars/Debian.yml
+++ b/roles/browser/vars/Debian.yml
@@ -5,11 +5,17 @@ __browser_firefox_i18n_package: 'firefox-esr-l10n-{{ browser_firefox_i18n }}'
 __browser_chromium_package: 'chromium'
 __browser_tor_package: 'torbrowser-launcher'
 
+# Google Chrome vendor package (Debian). Installing Google's own .deb lets
+# its post-install script configure and own Google's apt repository + signing
+# key, so Chrome updates via the normal apt upgrade path.
+__browser_chrome_deb_url: 'https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb'
+
 # Policy paths
 __browser_firefox_policies_path: '/etc/firefox-esr/policies'
 __browser_librewolf_policies_path: ''
 __browser_chromium_policies_path: '/etc/chromium/policies'
 __browser_brave_policies_path: ''
+__browser_chrome_policies_path: '/etc/opt/chrome/policies'
 
 # Profile detection: pattern to discover any existing profile
 # (random-prefixed by Firefox itself).

--- a/roles/browser/vars/RedHat.yml
+++ b/roles/browser/vars/RedHat.yml
@@ -5,11 +5,19 @@ __browser_firefox_i18n_package: 'firefox-langpack-{{ browser_firefox_i18n }}'
 __browser_chromium_package: 'chromium'
 __browser_tor_package: ''                 # Not available on Rocky
 
+# Google Chrome vendor package (EL). Installing Google's own .rpm lets its
+# post-install script configure and own Google's yum repository, so Chrome
+# updates via the normal dnf upgrade path. The signing key is imported
+# separately (rpm_key) so the package signature is verified on install.
+__browser_chrome_rpm_url: 'https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm'
+__browser_chrome_gpg_url: 'https://dl.google.com/linux/linux_signing_key.pub'
+
 # Policy paths
 __browser_firefox_policies_path: '/usr/lib64/firefox/distribution'
 __browser_librewolf_policies_path: ''
 __browser_chromium_policies_path: '/etc/chromium/policies'
 __browser_brave_policies_path: ''
+__browser_chrome_policies_path: '/etc/opt/chrome/policies'
 
 # Profile detection: pattern to discover any existing profile
 # (random-prefixed by Firefox itself).


### PR DESCRIPTION
Closes #220

## Summary

Adds Google Chrome as an opt-in chromium-family browser alongside the existing Chromium and Brave support. Chrome shares Chromium's extension and policy mechanism and applies the same privacy hardening through managed policies in `/etc/opt/chrome/policies`.

## Install per platform

- **Arch Linux:** `google-chrome` from the AUR.
- **Debian/EL:** Google's own vendor package (`.deb`/`.rpm`), whose post-install script configures and owns Google's apt/yum repository and signing key, so Chrome updates through the normal system upgrade path.

### Why the vendor package instead of a managed repository

The issue proposed adding Google's repository via `deb822_repository`/`yum_repository`. During implementation this proved fundamentally non-idempotent: the `google-chrome-stable` post-install script installs and owns its own repository file (`/etc/apt/sources.list.d/google-chrome.sources`, resp. `/etc/yum.repos.d/google-chrome.repo`) — the same filename as any Ansible-managed entry — and recreates it on every install (even with `repo_add_once="false"` and `repo_reenable_on_distupgrade="false"`). A parallel managed entry would therefore be reverted on every second run. Installing the vendor package directly lets Google own the repository as it insists on doing, and is fully idempotent.

## Toggles

- `browser_chrome_enabled` (default `false`)
- `browser_chrome_policies_enabled` (default `true`)

Optional extensions derive from `browser_chromium_extensions_optional`, so host-specific additions apply to Chrome automatically. A per-user `chrome-flags.conf` is deployed on Arch, where the AUR launcher sources it like `chromium-flags.conf`.

## Docs

The role README reference tables are also reordered by family (Mozilla, then Chromium; base engine first) for consistency.

## Test plan

- [x] `yamllint` and `ansible-lint` (production profile) clean
- [x] Molecule Debian Trixie — converge, idempotence (`changed=0`), verify green (vendor `.deb`)
- [x] Molecule Rocky 10 — converge, idempotence (`changed=0`), verify green (vendor `.rpm` + `rpm_key`)
- [x] Molecule Arch Linux — converge, idempotence, verify green (Chrome disabled, AUR build skipped like Brave)
- [x] Verify asserts the package is installed, managed policies deploy and are valid JSON, and the optional extension merges into Chrome policies