### PR TITLE
fix(development): make Arduino IDE override task idempotent

### DIFF
--- a/roles/development/tasks/ides.yml
+++ b/roles/development/tasks/ides.yml
@@ -136,7 +136,9 @@
 - name: IDEs | Generate Arduino IDE desktop override (Arch)
   ansible.builtin.command: '/usr/local/bin/arduino-ide-desktop-override'
   register: __development_arduino_override
-  changed_when: "'changed' in __development_arduino_override.stdout"
+  # The script prints 'changed: …' on a rewrite and 'unchanged' on a no-op;
+  # match the colon so the 'changed' substring in 'unchanged' is not caught.
+  changed_when: "'changed:' in __development_arduino_override.stdout"
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - development_arduino_ide_enabled | bool


### PR DESCRIPTION
Closes #222

## Summary

The `IDEs | Generate Arduino IDE desktop override (Arch)` task in the `development` role reported `changed` on every run, breaking idempotency.

## Root cause

The task's `changed_when` matched the bare substring `changed`:

```yaml
changed_when: "'changed' in __development_arduino_override.stdout"
```

The override script is itself idempotent — it prints `unchanged` on a no-op and `changed: …` only on a rewrite. But `unchanged` contains `changed` as a substring, so the condition was always true.

## Fix

Match `changed:` with the colon, which the `unchanged` marker does not contain, so the task only reports changed on an actual rewrite.

## Verification

- `yamllint` and `ansible-lint` (production profile) clean.
- Live run on an Arch host with `development_arduino_ide_enabled: true`: the `development` role now reports `changed=0` on an otherwise idempotent run; the Arduino override task reports `ok`.
