### PR TITLE
ci: centralize pip dependencies into requirements files and enable caching

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,0 +1,3 @@
+ansible-core
+ansible-lint
+yamllint

--- a/.github/requirements-molecule.txt
+++ b/.github/requirements-molecule.txt
@@ -1,0 +1,3 @@
+molecule==26.6.0
+molecule-plugins[podman]==26.7.8
+passlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
       - name: Install dependencies
-        run: |
-          pip install ansible-core ansible-lint
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Install collection dependencies
         run: |
@@ -66,9 +67,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
-      - name: Install yamllint
-        run: pip install yamllint
+      - name: Install dependencies
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Run yamllint
         run: yamllint -c .yamllint .
@@ -99,13 +102,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-molecule.txt
 
       - name: Install dependencies
-        run: |
-          pip install "ansible-core~=2.21.0" \
-                      "molecule==26.6.0" \
-                      "molecule-plugins[podman]==26.7.8" \
-                      passlib
+        run: pip install "ansible-core~=2.21.0" -r .github/requirements-molecule.txt
 
       - name: Install collection dependencies
         run: |
@@ -278,13 +279,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-molecule.txt
 
       - name: Install dependencies
-        run: |
-          pip install "ansible-core~=2.19.0" \
-                      "molecule==26.6.0" \
-                      "molecule-plugins[podman]==26.7.8" \
-                      passlib
+        run: pip install "ansible-core~=2.19.0" -r .github/requirements-molecule.txt
 
       - name: Install collection dependencies
         run: |
@@ -325,9 +324,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
-      - name: Install Ansible
-        run: pip install ansible-core
+      - name: Install dependencies
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Build collection
         run: ansible-galaxy collection build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
-      - name: Install Ansible
-        run: pip install ansible-core
+      - name: Install dependencies
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Build and publish to Galaxy
         run: |


### PR DESCRIPTION
## Summary

Applies the CI requirements-file + pip-caching convention (design in marcstraube/ansible-collection-common#289) to this collection.

## Changes

- Add `.github/requirements-ci.txt` (unpinned `ansible-core` / `ansible-lint` / `yamllint`) and `.github/requirements-molecule.txt` (single source of truth for the molecule pins, previously duplicated inline across `molecule-compat` and `molecule-roles`).
- Wire every `setup-python` job (`lint`, `yaml-lint`, `build`, `publish`, `molecule-compat`, `molecule-roles`) to `cache: 'pip'` + `cache-dependency-path`, installing via `pip install -r`. Both molecule jobs keep their `ansible-core` matrix version (`~=2.21.0` / `~=2.19.0`) inline.
- `detect-changes` keeps its inline `pyyaml` install — it has no `setup-python` step, so pip caching does not apply.

The `.github` tree is in `build_ignore`, so the requirements files stay out of the Galaxy tarball.

## Acceptance criteria

- [x] Both requirements files added; molecule pins live only in `requirements-molecule.txt`
- [x] All Python jobs use `pip install -r …` + `cache: 'pip'` + `cache-dependency-path`
- [ ] CI green — `lint` / `build` / `molecule-compat` run on this PR and verify `requirements-molecule.txt`; `molecule-roles` shares that file and is gated by `detect-changes` (skipped for `.github`-only PRs).

Closes #219
