### PR TITLE
feat: make role sub-tags selectable from the entry playbook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -74,6 +74,31 @@ All `include_tasks` in roles use `apply: tags:` for proper `--tags` filtering:
     - mytag
 ```
 
+#### Sub-tags must be self-contained
+
+A role exposes sub-tags (`<role>:<phase>`, e.g. `browser:configure`) so a single
+stage can be run in isolation. For that to work, two rules apply:
+
+1. **Entry playbooks import roles statically.** `playbooks/tasks/desktop_workstation.yml`
+   uses `import_role` (not `include_role`) for every role. A dynamic `include_role`
+   hides the role's inner sub-tags behind the include statement, so
+   `--tags browser:configure` would skip the whole role. Static `import_role`
+   exposes inner tags to `--tags` and `--list-tags`.
+
+2. **Bootstrap tasks are tagged `always`.** Any task a sub-tag path depends on —
+   OS-var loaders (`include_vars`), capability detection, derived-fact `set_fact`s —
+   must carry `tags: [always]`, not the bare role tag. Otherwise an isolated
+   sub-tag run skips the loader and fails on undefined `__<role>_*` vars.
+   Feature work keeps `role` + sub-tag; only genuine setup is `always`.
+
+```yaml
+- name: Main | Load OS-specific variables
+  ansible.builtin.include_vars: '{{ item }}'
+  with_first_found: ...
+  tags:
+    - always        # bootstrap — needed by every sub-tag path
+```
+
 ## Security
 
 - Vault files (`vault.yml`) are never accessed — only `vault.yml.example` templates

--- a/playbooks/tasks/desktop_workstation.yml
+++ b/playbooks/tasks/desktop_workstation.yml
@@ -9,32 +9,29 @@
 # See each role's defaults/main.yml for available variables.
 #
 # Tag scheme:
-#   desktop       All roles in this file
-#   <role-name>   Individual role (e.g., browser, terminal)
+#   desktop         All roles in this file
+#   <role-name>     Individual role (e.g., browser, terminal)
+#   <role>:<phase>  Role sub-stage (e.g., browser:configure, browser:install)
+#
+# Roles are imported statically (import_role) so their internal sub-tags are
+# exposed to --tags / --list-tags. Run `ansible-playbook … --list-tags` to see
+# the full set. Dynamic include_role would hide sub-tags behind the include.
 # =============================================================================
 
 #
 # Desktop Environment
 #
-- name: Desktop | Include desktop_environment role
-  ansible.builtin.include_role:
+- name: Desktop | Import desktop_environment role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.desktop_environment
-    apply:
-      tags:
-        - desktop
-        - desktop-environment
   tags:
     - desktop
     - desktop-environment
   when: desktop_environment_enabled | default(true) | bool
 
-- name: Desktop | Include display_manager role
-  ansible.builtin.include_role:
+- name: Desktop | Import display_manager role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.display_manager
-    apply:
-      tags:
-        - desktop
-        - display-manager
   tags:
     - desktop
     - display-manager
@@ -43,61 +40,41 @@
 #
 # Core Desktop
 #
-- name: Desktop | Include terminal role
-  ansible.builtin.include_role:
+- name: Desktop | Import terminal role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.terminal
-    apply:
-      tags:
-        - desktop
-        - terminal
   tags:
     - desktop
     - terminal
   when: terminal_enabled | default(true) | bool
 
-- name: Desktop | Include pipewire role
-  ansible.builtin.include_role:
+- name: Desktop | Import pipewire role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.pipewire
-    apply:
-      tags:
-        - desktop
-        - pipewire
   tags:
     - desktop
     - pipewire
   when: pipewire_enabled | default(true) | bool
 
-- name: Desktop | Include bluetooth role
-  ansible.builtin.include_role:
+- name: Desktop | Import bluetooth role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.bluetooth
-    apply:
-      tags:
-        - desktop
-        - bluetooth
   tags:
     - desktop
     - bluetooth
   when: bluetooth_enabled | default(true) | bool
 
-- name: Desktop | Include xdg_user_dirs role
-  ansible.builtin.include_role:
+- name: Desktop | Import xdg_user_dirs role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.xdg_user_dirs
-    apply:
-      tags:
-        - desktop
-        - xdg_user_dirs
   tags:
     - desktop
     - xdg_user_dirs
   when: xdg_user_dirs_enabled | default(true) | bool
 
-- name: Desktop | Include filemanagers role
-  ansible.builtin.include_role:
+- name: Desktop | Import filemanagers role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.filemanagers
-    apply:
-      tags:
-        - desktop
-        - filemanagers
   tags:
     - desktop
     - filemanagers
@@ -106,37 +83,25 @@
 #
 # Productivity
 #
-- name: Desktop | Include browser role
-  ansible.builtin.include_role:
+- name: Desktop | Import browser role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.browser
-    apply:
-      tags:
-        - desktop
-        - browser
   tags:
     - desktop
     - browser
   when: browser_enabled | default(true) | bool
 
-- name: Desktop | Include keepassxc role
-  ansible.builtin.include_role:
+- name: Desktop | Import keepassxc role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.keepassxc
-    apply:
-      tags:
-        - desktop
-        - keepassxc
   tags:
     - desktop
     - keepassxc
   when: keepassxc_enabled | default(true) | bool
 
-- name: Desktop | Include office role
-  ansible.builtin.include_role:
+- name: Desktop | Import office role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.office
-    apply:
-      tags:
-        - desktop
-        - office
   tags:
     - desktop
     - office
@@ -145,13 +110,9 @@
 #
 # Development
 #
-- name: Desktop | Include development role
-  ansible.builtin.include_role:
+- name: Desktop | Import development role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.development
-    apply:
-      tags:
-        - desktop
-        - development
   tags:
     - desktop
     - development
@@ -160,13 +121,9 @@
 #
 # AI Tools
 #
-- name: Desktop | Include ai role
-  ansible.builtin.include_role:
+- name: Desktop | Import ai role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.ai
-    apply:
-      tags:
-        - desktop
-        - ai
   tags:
     - desktop
     - ai
@@ -175,172 +132,108 @@
 #
 # Applications
 #
-- name: Desktop | Include multimedia role
-  ansible.builtin.include_role:
+- name: Desktop | Import multimedia role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.multimedia
-    apply:
-      tags:
-        - desktop
-        - multimedia
   tags:
     - desktop
     - multimedia
   when: multimedia_enabled | default(false) | bool
 
-- name: Desktop | Include graphics_apps role
-  ansible.builtin.include_role:
+- name: Desktop | Import graphics_apps role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.graphics_apps
-    apply:
-      tags:
-        - desktop
-        - graphics-apps
   tags:
     - desktop
     - graphics-apps
   when: graphics_apps_enabled | default(false) | bool
 
-- name: Desktop | Include cad role
-  ansible.builtin.include_role:
+- name: Desktop | Import cad role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.cad
-    apply:
-      tags:
-        - desktop
-        - cad
   tags:
     - desktop
     - cad
   when: cad_enabled | default(false) | bool
 
-- name: Desktop | Include imaging role
-  ansible.builtin.include_role:
+- name: Desktop | Import imaging role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.imaging
-    apply:
-      tags:
-        - desktop
-        - imaging
   tags:
     - desktop
     - imaging
   when: imaging_enabled | default(false) | bool
 
-- name: Desktop | Include downloads role
-  ansible.builtin.include_role:
+- name: Desktop | Import downloads role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.downloads
-    apply:
-      tags:
-        - desktop
-        - downloads
   tags:
     - desktop
     - downloads
   when: downloads_enabled | default(false) | bool
 
-- name: Desktop | Include gaming role
-  ansible.builtin.include_role:
+- name: Desktop | Import gaming role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.gaming
-    apply:
-      tags:
-        - desktop
-        - gaming
   tags:
     - desktop
     - gaming
   when: gaming_enabled | default(false) | bool
 
-- name: Desktop | Include wine role
-  ansible.builtin.include_role:
+- name: Desktop | Import wine role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.wine
-    apply:
-      tags:
-        - desktop
-        - wine
   tags:
     - desktop
     - wine
   when: wine_enabled | default(false) | bool
 
-- name: Desktop | Include communication role
-  ansible.builtin.include_role:
+- name: Desktop | Import communication role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.communication
-    apply:
-      tags:
-        - desktop
-        - communication
   tags:
     - desktop
     - communication
   when: communication_enabled | default(false) | bool
 
-- name: Desktop | Include remote_access role
-  ansible.builtin.include_role:
+- name: Desktop | Import remote_access role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.remote_access
-    apply:
-      tags:
-        - desktop
-        - remote-access
   tags:
     - desktop
     - remote-access
   when: remote_access_enabled | default(false) | bool
 
-- name: Desktop | Include security_apps role
-  ansible.builtin.include_role:
+- name: Desktop | Import security_apps role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.security_apps
-    apply:
-      tags:
-        - desktop
-        - security-apps
   tags:
     - desktop
     - security-apps
   when: security_apps_enabled | default(false) | bool
 
-- name: Desktop | Include system_apps role
-  ansible.builtin.include_role:
+- name: Desktop | Import system_apps role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.system_apps
-    apply:
-      tags:
-        - desktop
-        - system-apps
   tags:
     - desktop
     - system-apps
   when: system_apps_enabled | default(false) | bool
 
-- name: Desktop | Include tabletop role
-  ansible.builtin.include_role:
-    name: marcstraube.desktop.tabletop
-    apply:
-      tags:
-        - desktop
-        - tabletop
-  tags:
-    - desktop
-    - tabletop
-  when: tabletop_enabled | default(false) | bool
-
 #
 # Peripherals
 #
-- name: Desktop | Include elgato role
-  ansible.builtin.include_role:
+- name: Desktop | Import elgato role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.elgato
-    apply:
-      tags:
-        - desktop
-        - elgato
   tags:
     - desktop
     - elgato
   when: elgato_enabled | default(false) | bool
 
-- name: Desktop | Include tuxedo role
-  ansible.builtin.include_role:
+- name: Desktop | Import tuxedo role
+  ansible.builtin.import_role:
     name: marcstraube.desktop.tuxedo
-    apply:
-      tags:
-        - desktop
-        - tuxedo
   tags:
     - desktop
     - tuxedo

--- a/roles/ai/tasks/main.yml
+++ b/roles/ai/tasks/main.yml
@@ -15,7 +15,7 @@
       paths:
         - 'vars'
   tags:
-    - ai
+    - always
 
 - name: Main | Include CLI tools
   ansible.builtin.include_tasks:

--- a/roles/bluetooth/tasks/main.yml
+++ b/roles/bluetooth/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - bluetooth
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/browser/tasks/main.yml
+++ b/roles/browser/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - browser
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks:

--- a/roles/cad/tasks/main.yml
+++ b/roles/cad/tasks/main.yml
@@ -10,6 +10,8 @@
         - '{{ ansible_facts["os_family"] }}.yml'
       paths:
         - 'vars'
+  tags:
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks:

--- a/roles/communication/tasks/main.yml
+++ b/roles/communication/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - communication
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/desktop_environment/tasks/main.yml
+++ b/roles/desktop_environment/tasks/main.yml
@@ -15,7 +15,7 @@
       paths:
         - 'vars'
   tags:
-    - desktop-environment
+    - always
 
 - name: Main | Validate LXQt variant
   ansible.builtin.assert:
@@ -28,7 +28,7 @@
     - desktop_environment_enabled | bool
     - "'lxqt' in desktop_environment_list"
   tags:
-    - desktop-environment
+    - always
 
 - name: Main | Derive desktop users from users_list (exclude root and system users)
   ansible.builtin.set_fact:
@@ -47,7 +47,7 @@
     - users_list is defined
     - users_list | length > 0
   tags:
-    - desktop-environment
+    - always
 
 - name: Main | Check if any Wayland DE selected
   ansible.builtin.set_fact:
@@ -55,7 +55,7 @@
       {{ desktop_environment_list | intersect(__desktop_environment_wayland_des) | length > 0 }}
   when: desktop_environment_enabled | bool
   tags:
-    - desktop-environment
+    - always
 
 - name: Main | Build wayland_utils config for Hyprland
   ansible.builtin.set_fact:

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -23,7 +23,7 @@
     - users_list is defined
     - users_list | length > 0
   tags:
-    - development
+    - always
 
 - name: Main | Load OS-specific variables
   ansible.builtin.include_vars: '{{ item }}'
@@ -37,7 +37,7 @@
       paths:
         - 'vars'
   tags:
-    - development
+    - always
 
 - name: Main | Import version control tasks
   ansible.builtin.import_tasks: git.yml

--- a/roles/display_manager/tasks/main.yml
+++ b/roles/display_manager/tasks/main.yml
@@ -15,7 +15,7 @@
       paths:
         - 'vars'
   tags:
-    - display-manager
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/downloads/tasks/main.yml
+++ b/roles/downloads/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - downloads
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/elgato/tasks/main.yml
+++ b/roles/elgato/tasks/main.yml
@@ -16,7 +16,7 @@
         - 'vars'
       skip: true
   tags:
-    - elgato
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/filemanagers/tasks/main.yml
+++ b/roles/filemanagers/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - filemanagers
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/gaming/tasks/main.yml
+++ b/roles/gaming/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - gaming
+    - always
 
 - name: Main | Validate gaming_playback_variant
   ansible.builtin.assert:
@@ -24,7 +24,7 @@
     - gaming_enabled | bool
     - gaming_playback_enabled | bool
   tags:
-    - gaming
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/graphics_apps/tasks/main.yml
+++ b/roles/graphics_apps/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - graphics-apps
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/imaging/tasks/main.yml
+++ b/roles/imaging/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - imaging
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/multimedia/tasks/main.yml
+++ b/roles/multimedia/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - multimedia
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/office/tasks/main.yml
+++ b/roles/office/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - office
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/pipewire/tasks/main.yml
+++ b/roles/pipewire/tasks/main.yml
@@ -15,7 +15,7 @@
       paths:
         - 'vars'
   tags:
-    - pipewire
+    - always
 
 - name: Main | Import cleanup tasks
   ansible.builtin.import_tasks: cleanup.yml

--- a/roles/plymouth/tasks/main.yml
+++ b/roles/plymouth/tasks/main.yml
@@ -15,7 +15,7 @@
       paths:
         - 'vars'
   tags:
-    - plymouth
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/remote_access/tasks/main.yml
+++ b/roles/remote_access/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - remote-access
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/security_apps/tasks/main.yml
+++ b/roles/security_apps/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - security-apps
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/system_apps/tasks/main.yml
+++ b/roles/system_apps/tasks/main.yml
@@ -12,8 +12,7 @@
         - 'vars'
       skip: true
   tags:
-    - system-apps
-    - system-apps:install
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/terminal/tasks/main.yml
+++ b/roles/terminal/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - terminal
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/tuxedo/tasks/main.yml
+++ b/roles/tuxedo/tasks/main.yml
@@ -16,7 +16,7 @@
         - 'vars'
       skip: true
   tags:
-    - tuxedo
+    - always
 
 - name: Main | Import validation tasks
   ansible.builtin.import_tasks: validate.yml

--- a/roles/wayland_utils/tasks/main.yml
+++ b/roles/wayland_utils/tasks/main.yml
@@ -11,7 +11,7 @@
       paths:
         - 'vars'
   tags:
-    - wayland
+    - always
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml

--- a/roles/wine/tasks/main.yml
+++ b/roles/wine/tasks/main.yml
@@ -12,7 +12,7 @@
         - 'vars'
       skip: true
   tags:
-    - wine
+    - always
 
 - name: Main | Warn about unsupported EL version
   ansible.builtin.debug:


### PR DESCRIPTION
## Summary

Role sub-tags (e.g. `browser:configure`) were not selectable when running roles through `playbooks/tasks/desktop_workstation.yml`: the dynamic `include_role` is gated by its own `[desktop, <role>]` tags, so `--tags <role>:<subtag>` skipped the whole role. This switches the entry task file to static `import_role` (exposing inner tags to `--tags`/`--list-tags`) and tags each role's bootstrap tasks `always` so a sub-tag path resolves its `__<role>_*` vars.

## Changes

- `playbooks/tasks/desktop_workstation.yml`: `include_role` → `import_role` for all roles; drop the now-redundant `apply: tags:` blocks.
- 25 roles: OS-var loader tagged `always` (was the bare role tag); normalises `cad` (loader had no tags) and `system_apps` (loader carried a feature sub-tag).
- Bootstrap `set_fact`s / asserts tagged `always` in `desktop_environment`, `development`, `gaming`.
- `.claude/CLAUDE.md`: document the `import_role` + `always`-bootstrap convention.

## Test plan

- [x] `ansible-playbook … --syntax-check` passes
- [x] `ansible-lint roles/ playbooks/` — 0 failures / 0 warnings (production profile)
- [x] `--list-tags` now shows role sub-tags (e.g. `browser:configure`, `browser:install`)
- [x] `--tags browser:configure` runs the config path in isolation (previously failed on undefined vars)
- [x] `--tags browser:chrome` deploys Chrome policies as a `changed` task — confirms an isolated sub-tag does real work with `always` loaders providing vars
- [ ] CI green

Closes #227
