### PR TITLE
fix: emit update_url for Chrome and Brave force-installed extensions

### DIFF
--- a/roles/browser/templates/brave-policies.json.j2
+++ b/roles/browser/templates/brave-policies.json.j2
@@ -9,8 +9,8 @@
 
 {% for ext_id, ext_config in (browser_brave_extensions | combine(browser_brave_extensions_optional | default({}))) | dictsort %}
     "{{ ext_id }}": {
-      "installation_mode": "{{ ext_config.mode | default('normal_installed') }}"{% if ext_config.url is defined %},
-      "update_url": "{{ ext_config.url }}"{% endif %}
+      "installation_mode": "{{ ext_config.mode | default('normal_installed') }}",
+      "update_url": "{{ ext_config.update_url | default('https://clients2.google.com/service/update2/crx') }}"
 
     }{% if not loop.last %},{% endif %}
 

--- a/roles/browser/templates/chrome-policies.json.j2
+++ b/roles/browser/templates/chrome-policies.json.j2
@@ -9,8 +9,8 @@
 
 {% for ext_id, ext_config in (browser_chrome_extensions | combine(browser_chrome_extensions_optional | default({}))) | dictsort %}
     "{{ ext_id }}": {
-      "installation_mode": "{{ ext_config.mode | default('normal_installed') }}"{% if ext_config.url is defined %},
-      "update_url": "{{ ext_config.url }}"{% endif %}
+      "installation_mode": "{{ ext_config.mode | default('normal_installed') }}",
+      "update_url": "{{ ext_config.update_url | default('https://clients2.google.com/service/update2/crx') }}"
 
     }{% if not loop.last %},{% endif %}
 


### PR DESCRIPTION
## Summary

Chrome requires `update_url` on every `ExtensionSettings` entry with `installation_mode: force_installed` or `normal_installed`. `chrome-policies.json.j2` and `brave-policies.json.j2` only emitted `update_url` when the extension config set `url`, so baseline extensions (uBlock Origin, ClearURLs, LocalCDN, KeePassXC — which set only `mode`) rendered without it and the browser installed none of them. `chromium-policies.json.j2` already had the correct handling.

## Changes

- `chrome-policies.json.j2`, `brave-policies.json.j2`: always emit `update_url`, defaulting to the Chrome Web Store update service (`https://clients2.google.com/service/update2/crx`) and read from `ext_config.update_url`, matching `chromium-policies.json.j2`.

## Test plan

- [x] `ansible-lint` passes
- [x] Rendered Chrome managed policy contains `update_url` for every extension
- [x] Chrome installs the force-installed extensions after a policy reload
- [ ] CI green

Closes #230
